### PR TITLE
Update for upstream changes in Brioche

### DIFF
--- a/std/core/artifacts/file.bri
+++ b/std/core/artifacts/file.bri
@@ -30,7 +30,7 @@ export interface FileCtor {
   source?: runtime.Source;
   contentBlob: runtime.BlobId;
   executable: boolean;
-  resources: runtime.CompleteDirectoryContents;
+  resources: runtime.CompleteDirectory;
 }
 
 export class File implements Lazy<File> {
@@ -38,7 +38,7 @@ export class File implements Lazy<File> {
   source?: runtime.Source;
   contentBlob: runtime.BlobId;
   executable: boolean;
-  resources: runtime.CompleteDirectoryContents;
+  resources: runtime.CompleteDirectory;
 
   constructor(options: FileCtor) {
     this.source = options.source;

--- a/std/core/index.bri
+++ b/std/core/index.bri
@@ -4,8 +4,8 @@ export { assert, unreachable, indoc, type Awaitable } from "./utils.bri";
 export {
   utf8Encode,
   utf8Decode,
-  urlEncode,
-  urlDecode,
+  tickEncode,
+  tickDecode,
   bstring,
   bstringToBytes,
   bstringToString,

--- a/std/core/runtime.bri
+++ b/std/core/runtime.bri
@@ -77,7 +77,7 @@ export type CompleteFile = WithMeta & {
   type: "file";
   contentBlob: BlobId;
   executable: boolean;
-  resources: CompleteDirectoryContents;
+  resources: CompleteDirectory;
 };
 
 export type CompleteSymlink = WithMeta & {
@@ -87,9 +87,6 @@ export type CompleteSymlink = WithMeta & {
 
 export type CompleteDirectory = WithMeta & {
   type: "directory";
-} & CompleteDirectoryContents;
-
-export type CompleteDirectoryContents = {
   listingBlob?: BlobId;
 };
 

--- a/std/core/runtime.bri
+++ b/std/core/runtime.bri
@@ -52,15 +52,19 @@ export function utf8Decode(bytes: Uint8Array): string {
   return result;
 }
 
-export function urlEncode(value: Uint8Array | string): string {
+export function tickEncode(value: Uint8Array | string): string {
   const bytes = typeof value === "string" ? utf8Encode(value) : value;
-  const result = (globalThis as any).Deno.core.ops.op_brioche_url_encode(bytes);
+  const result = (globalThis as any).Deno.core.ops.op_brioche_tick_encode(
+    bytes,
+  );
   return result;
 }
 
-export function urlDecode(value: Uint8Array | string): Uint8Array {
+export function tickDecode(value: Uint8Array | string): Uint8Array {
   const bytes = typeof value === "string" ? utf8Encode(value) : value;
-  const result = (globalThis as any).Deno.core.ops.op_brioche_url_decode(bytes);
+  const result = (globalThis as any).Deno.core.ops.op_brioche_tick_decode(
+    bytes,
+  );
   return result;
 }
 
@@ -229,11 +233,11 @@ export function isHex(s: string): s is HexString {
 }
 
 export function bstring(value: string | Uint8Array): BString {
-  return urlEncode(value) as BString;
+  return tickEncode(value) as BString;
 }
 
 export function bstringToBytes(value: BString): Uint8Array {
-  return urlDecode(value);
+  return tickDecode(value);
 }
 
 export function bstringToString(value: BString): string {

--- a/std/toolchain/native/acl.bri
+++ b/std/toolchain/native/acl.bri
@@ -15,17 +15,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/attr.bri
+++ b/std/toolchain/native/attr.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          -prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            -prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/autoconf.bri
+++ b/std/toolchain/native/autoconf.bri
@@ -15,23 +15,23 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed -e 's/SECONDS|/&SHLVL|/' \
-          -e '/BASH_ARGV=/a\\        /^SHLVL=/ d' \
-          -i.orig tests/local.at
+          sed -e 's/SECONDS|/&SHLVL|/' \
+            -e '/BASH_ARGV=/a\\        /^SHLVL=/ d' \
+            -i.orig tests/local.at
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        # Replace absolute paths to perl with plain program name, and fix shebangs
-        sed -i 's|^#![[:space:]]*.*/bin/\\([^[:space:]]*\\)|#! /usr/bin/env \\1|' "$BRIOCHE_OUTPUT"/bin/*
-        sed -i 's|[^[:space:]]*/bin/perl|perl|g' "$BRIOCHE_OUTPUT"/bin/*
-      `,
+          # Replace absolute paths to perl with plain program name, and fix shebangs
+          sed -i 's|^#![[:space:]]*.*/bin/\\([^[:space:]]*\\)|#! /usr/bin/env \\1|' "$BRIOCHE_OUTPUT"/bin/*
+          sed -i 's|[^[:space:]]*/bin/perl|perl|g' "$BRIOCHE_OUTPUT"/bin/*
+        `,
       ],
       env: {
         source: sourceArchive,
@@ -45,11 +45,11 @@ export default std.memo((): std.Lazy<std.Directory> => {
     renameSuffix: "-orig",
     script: std
       .file(std.indoc`
-      #!/usr/bin/env sh
-      script_dir=$(cd "$(dirname -- "$0")" && pwd -P)
-      top_dir=$(cd "$script_dir/.." && pwd -P)
-      "$0-orig" --prepend-include="$top_dir/share/autoconf" "$@"
-    `)
+        #!/usr/bin/env sh
+        script_dir=$(cd "$(dirname -- "$0")" && pwd -P)
+        top_dir=$(cd "$script_dir/.." && pwd -P)
+        "$0-orig" --prepend-include="$top_dir/share/autoconf" "$@"
+      `)
       .withPermissions({ executable: true }),
   });
 

--- a/std/toolchain/native/automake.bri
+++ b/std/toolchain/native/automake.bri
@@ -16,18 +16,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        # Fix shebangs
-        sed -i 's|^#![[:space:]]*.*/bin/\\([^[:space:]]*\\)|#! /usr/bin/env \\1|' "$BRIOCHE_OUTPUT"/bin/*
-      `,
+          # Fix shebangs
+          sed -i 's|^#![[:space:]]*.*/bin/\\([^[:space:]]*\\)|#! /usr/bin/env \\1|' "$BRIOCHE_OUTPUT"/bin/*
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/bash.bri
+++ b/std/toolchain/native/bash.bri
@@ -14,18 +14,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --without-bash-malloc \
-          --with-installed-readline
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --without-bash-malloc \
+            --with-installed-readline
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/bc.bri
+++ b/std/toolchain/native/bc.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        CC=gcc ./configure --prefix=/ -G -O3 -r
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          CC=gcc ./configure --prefix=/ -G -O3 -r
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/binutils.bri
+++ b/std/toolchain/native/binutils.bri
@@ -17,27 +17,27 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        mkdir build
-        cd build
+          mkdir build
+          cd build
 
-        ../configure \
-          --prefix="$BRIOCHE_OUTPUT" \
-          --enable-gold \
-          --enable-ld=default \
-          --enable-plugins \
-          --enable-shared \
-          --disable-werror \
-          --enable-64-bit-bfd \
-          --with-system-zlib
+          ../configure \
+            --prefix="$BRIOCHE_OUTPUT" \
+            --enable-gold \
+            --enable-ld=default \
+            --enable-plugins \
+            --enable-shared \
+            --disable-werror \
+            --enable-64-bit-bfd \
+            --with-system-zlib
 
-        make tooldir="$BRIOCHE_OUTPUT"
-        make install tooldir="$BRIOCHE_OUTPUT"
-      `,
+          make tooldir="$BRIOCHE_OUTPUT"
+          make install tooldir="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/bison.bri
+++ b/std/toolchain/native/bison.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/bzip2.bri
+++ b/std/toolchain/native/bzip2.bri
@@ -20,25 +20,25 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        patch -Np1 -i "$sourcePatch"
-        sed -i 's@\\(ln -s -f \\)$(PREFIX)/bin/@\\1@' Makefile
-        sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
+          patch -Np1 -i "$sourcePatch"
+          sed -i 's@\\(ln -s -f \\)$(PREFIX)/bin/@\\1@' Makefile
+          sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
 
-        make -f Makefile-libbz2_so
-        make clean
+          make -f Makefile-libbz2_so
+          make clean
 
-        make
-        make PREFIX="$BRIOCHE_OUTPUT" install
+          make
+          make PREFIX="$BRIOCHE_OUTPUT" install
 
-        mkdir -p "$BRIOCHE_OUTPUT/lib"
-        cp -a libbz2.so.* "$BRIOCHE_OUTPUT/lib"
-        ln -s libbz2.so.1.0.8 "$BRIOCHE_OUTPUT/lib/libbz2.so"
-      `,
+          mkdir -p "$BRIOCHE_OUTPUT/lib"
+          cp -a libbz2.so.* "$BRIOCHE_OUTPUT/lib"
+          ln -s libbz2.so.1.0.8 "$BRIOCHE_OUTPUT/lib/libbz2.so"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/coreutils.bri
+++ b/std/toolchain/native/coreutils.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --enable-no-install-program=kill,uptime
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --enable-no-install-program=kill,uptime
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/diffutils.bri
+++ b/std/toolchain/native/diffutils.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/expat.bri
+++ b/std/toolchain/native/expat.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/file.bri
+++ b/std/toolchain/native/file.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/findutils.bri
+++ b/std/toolchain/native/findutils.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --localstatedir=/var/lib/locate
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --localstatedir=/var/lib/locate
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/flex.bri
+++ b/std/toolchain/native/flex.bri
@@ -14,18 +14,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        ln -s flex "$BRIOCHE_OUTPUT/bin/lex"
-        ln -s flex.1 "$BRIOCHE_OUTPUT/share/man/man1/lex.1"
-      `,
+          ln -s flex "$BRIOCHE_OUTPUT/bin/lex"
+          ln -s flex.1 "$BRIOCHE_OUTPUT/share/man/man1/lex.1"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gawk.bri
+++ b/std/toolchain/native/gawk.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed -i 's/extras//' Makefile.in
+          sed -i 's/extras//' Makefile.in
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gcc.bri
+++ b/std/toolchain/native/gcc.bri
@@ -38,45 +38,45 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        case "$(uname -m)" in
-          x86_64 )
-            sed -e '/m64=/s/lib64/lib/' -i gcc/config/i386/t-linux64
-          ;;
-        esac
+          case "$(uname -m)" in
+            x86_64 )
+              sed -e '/m64=/s/lib64/lib/' -i gcc/config/i386/t-linux64
+            ;;
+          esac
 
-        mkdir build
-        cd build
+          mkdir build
+          cd build
 
-        ../configure \
-          --prefix=/ \
-          --enable-languages=c,c++ \
-          --enable-default-pie \
-          --enable-default-ssp \
-          --disable-nls \
-          --disable-multilib \
-          --disable-bootstrap \
-          --disable-fixincludes \
-          --with-system-zlib \
-          --with-gmp="$gmp" \
-          --with-mpfr="$mpfr" \
-          --with-mpc="$mpc" \
-          --with-build-sysroot="$buildSysroot" \
-          CFLAGS_FOR_TARGET="-g -O2 $CPPFLAGS" \
-          CXXFLAGS_FOR_TARGET="-g -O2 $CPPFLAGS" \
-          LDFLAGS_FOR_TARGET="$LDFLAGS" \
-          CFLAGS_FOR_BUILD="$CPPFLAGS" \
-          CXXFLAGS_FOR_BUILD="$CPPFLAGS" \
-          CFLAGS="$CPPFLAGS" \
-          CXXFLAGS="$CPPFLAGS" \
-          LD="ld"
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ../configure \
+            --prefix=/ \
+            --enable-languages=c,c++ \
+            --enable-default-pie \
+            --enable-default-ssp \
+            --disable-nls \
+            --disable-multilib \
+            --disable-bootstrap \
+            --disable-fixincludes \
+            --with-system-zlib \
+            --with-gmp="$gmp" \
+            --with-mpfr="$mpfr" \
+            --with-mpc="$mpc" \
+            --with-build-sysroot="$buildSysroot" \
+            CFLAGS_FOR_TARGET="-g -O2 $CPPFLAGS" \
+            CXXFLAGS_FOR_TARGET="-g -O2 $CPPFLAGS" \
+            LDFLAGS_FOR_TARGET="$LDFLAGS" \
+            CFLAGS_FOR_BUILD="$CPPFLAGS" \
+            CXXFLAGS_FOR_BUILD="$CPPFLAGS" \
+            CFLAGS="$CPPFLAGS" \
+            CXXFLAGS="$CPPFLAGS" \
+            LD="ld"
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gdbm.bri
+++ b/std/toolchain/native/gdbm.bri
@@ -14,18 +14,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static \
-          --enable-libgdbm-compat
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static \
+            --enable-libgdbm-compat
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gettext.bri
+++ b/std/toolchain/native/gettext.bri
@@ -14,18 +14,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-        chmod +x "$BRIOCHE_OUTPUT"/lib/preloadable_libintl.so
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+          chmod +x "$BRIOCHE_OUTPUT"/lib/preloadable_libintl.so
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/glibc.bri
+++ b/std/toolchain/native/glibc.bri
@@ -26,34 +26,34 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
-        patch -Np1 -i "$sourcePatchFhs"
-        patch -Np1 -i "$sourcePatchMemalign"
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          patch -Np1 -i "$sourcePatchFhs"
+          patch -Np1 -i "$sourcePatchMemalign"
 
-        mkdir build
-        cd build
+          mkdir build
+          cd build
 
-        echo "rootsbindir=/sbin" > configparms
+          echo "rootsbindir=/sbin" > configparms
 
-        export PYTHONHOME="$stage2/usr"
-        export M4=m4
-        export MAGIC="$stage2/usr/share/misc/magic"
+          export PYTHONHOME="$stage2/usr"
+          export M4=m4
+          export MAGIC="$stage2/usr/share/misc/magic"
 
-        ../configure \
-          --prefix=/ \
-          --enable-kernel=4.14 \
-          --enable-stack-protector=strong \
-          --with-headers="$stage2/usr/include" \
-          libc_cv_slibdir=/lib
+          ../configure \
+            --prefix=/ \
+            --enable-kernel=4.14 \
+            --enable-stack-protector=strong \
+            --with-headers="$stage2/usr/include" \
+            libc_cv_slibdir=/lib
 
-        export BRIOCHE_LD_AUTOWRAP=false
-        make
-        sed '/test-installation/s@$(PERL)@echo not running@' -i ../Makefile
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          export BRIOCHE_LD_AUTOWRAP=false
+          make
+          sed '/test-installation/s@$(PERL)@echo not running@' -i ../Makefile
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gmp.bri
+++ b/std/toolchain/native/gmp.bri
@@ -14,19 +14,19 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --host=none-linux-gnu \
-          --enable-cxx \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --host=none-linux-gnu \
+            --enable-cxx \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gperf.bri
+++ b/std/toolchain/native/gperf.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/grep.bri
+++ b/std/toolchain/native/grep.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed -i "s/echo/#echo/" src/egrep.sh
+          sed -i "s/echo/#echo/" src/egrep.sh
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/groff.bri
+++ b/std/toolchain/native/groff.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/gzip.bri
+++ b/std/toolchain/native/gzip.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/inetutils.bri
+++ b/std/toolchain/native/inetutils.bri
@@ -14,28 +14,28 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --bindir=/bin \
-          --localstatedir=/var \
-          --disable-logger \
-          --disable-whois \
-          --disable-rcp \
-          --disable-rexec \
-          --disable-rlogin \
-          --disable-rsh \
-          --disable-servers
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure \
+            --prefix=/ \
+            --bindir=/bin \
+            --localstatedir=/var \
+            --disable-logger \
+            --disable-whois \
+            --disable-rcp \
+            --disable-rexec \
+            --disable-rlogin \
+            --disable-rsh \
+            --disable-servers
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        mkdir -p "$BRIOCHE_OUTPUT/sbin"
-        ln -s "../bin/ifconfig" "$BRIOCHE_OUTPUT/sbin/ifconfig"
-      `,
+          mkdir -p "$BRIOCHE_OUTPUT/sbin"
+          ln -s "../bin/ifconfig" "$BRIOCHE_OUTPUT/sbin/ifconfig"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/intltool.bri
+++ b/std/toolchain/native/intltool.bri
@@ -19,19 +19,19 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed -i 's:\\\\\\\${:\\\\\\\$\\\\{:' intltool-update.in
+          sed -i 's:\\\\\\\${:\\\\\\\$\\\\{:' intltool-update.in
 
-        perl -e "use XML::Parser; XML::Parser->new()->parse('<test/>'); print 'XML::Parser is available and working\\n';"
+          perl -e "use XML::Parser; XML::Parser->new()->parse('<test/>'); print 'XML::Parser is available and working\\n';"
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/less.bri
+++ b/std/toolchain/native/less.bri
@@ -14,17 +14,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --sysconfdir=/etc
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --sysconfdir=/etc
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/libelf.bri
+++ b/std/toolchain/native/libelf.bri
@@ -22,22 +22,22 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-debuginfod \
-          --enable-libdebuginfod=dummy
-        make
-        make -C libelf install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure \
+            --prefix=/ \
+            --disable-debuginfod \
+            --enable-libdebuginfod=dummy
+          make
+          make -C libelf install DESTDIR="$BRIOCHE_OUTPUT"
 
-        mkdir -p "$BRIOCHE_OUTPUT"/lib/pkgconfig
-        install -vm644 config/libelf.pc "$BRIOCHE_OUTPUT"/lib/pkgconfig/
-        rm "$BRIOCHE_OUTPUT"/lib/libelf.a
-      `,
+          mkdir -p "$BRIOCHE_OUTPUT"/lib/pkgconfig
+          install -vm644 config/libelf.pc "$BRIOCHE_OUTPUT"/lib/pkgconfig/
+          rm "$BRIOCHE_OUTPUT"/lib/libelf.a
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/libffi.bri
+++ b/std/toolchain/native/libffi.bri
@@ -14,18 +14,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static \
-          --with-gcc-arch=x86-64
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static \
+            --with-gcc-arch=x86-64
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/libpipeline.bri
+++ b/std/toolchain/native/libpipeline.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/libtool.bri
+++ b/std/toolchain/native/libtool.bri
@@ -14,16 +14,16 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-        rm -f "$BRIOCHE_OUTPUT"/lib/libltdl.a
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+          rm -f "$BRIOCHE_OUTPUT"/lib/libltdl.a
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/libxcrypt.bri
+++ b/std/toolchain/native/libxcrypt.bri
@@ -14,20 +14,20 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --enable-hashes=strong,glibc \
-          --enable-obsolete-api=no \
-          --disable-static \
-          --disable-failure-tokens
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --enable-hashes=strong,glibc \
+            --enable-obsolete-api=no \
+            --disable-static \
+            --disable-failure-tokens
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/linux_headers.bri
+++ b/std/toolchain/native/linux_headers.bri
@@ -14,19 +14,19 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        make mrproper
+          make mrproper
 
-        mkdir -p "$BRIOCHE_OUTPUT"
+          mkdir -p "$BRIOCHE_OUTPUT"
 
-        make headers
-        find usr/include -type f ! -name '*.h' -delete
-        cp -r usr/include "$BRIOCHE_OUTPUT/include"
-      `,
+          make headers
+          find usr/include -type f ! -name '*.h' -delete
+          cp -r usr/include "$BRIOCHE_OUTPUT/include"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/m4.bri
+++ b/std/toolchain/native/m4.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/make.bri
+++ b/std/toolchain/native/make.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/man_db.bri
+++ b/std/toolchain/native/man_db.bri
@@ -17,20 +17,20 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --sysconfdir=/etc \
-          --disable-setuid \
-          --with-systemdtmpfilesdir= \
-          --with-systemdsystemunitdir=
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --sysconfdir=/etc \
+            --disable-setuid \
+            --with-systemdtmpfilesdir= \
+            --with-systemdsystemunitdir=
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/mpc.bri
+++ b/std/toolchain/native/mpc.bri
@@ -16,17 +16,17 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/mpfr.bri
+++ b/std/toolchain/native/mpfr.bri
@@ -15,23 +15,23 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed \
-          -e 's/+01,234,567/+1,234,567 /' \
-          -e 's/13.10Pd/13Pd/' \
-          -i tests/tsprintf.c
+          sed \
+            -e 's/+01,234,567/+1,234,567 /' \
+            -e 's/13.10Pd/13Pd/' \
+            -i tests/tsprintf.c
 
-        ./configure \
-          --prefix=/ \
-          --disable-static \
-          --enable-thread-safe
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static \
+            --enable-thread-safe
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/ncurses.bri
+++ b/std/toolchain/native/ncurses.bri
@@ -14,33 +14,33 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --with-shared \
-          --without-debug \
-          --without-normal \
-          --with-cxx-shared \
-          --enable-pc-files \
-          --enable-widec \
-          --with-pkg-config-libdir=/lib/pkgconfig
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure \
+            --prefix=/ \
+            --with-shared \
+            --without-debug \
+            --without-normal \
+            --with-cxx-shared \
+            --enable-pc-files \
+            --enable-widec \
+            --with-pkg-config-libdir=/lib/pkgconfig
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        for lib in ncurses form panel menu ; do
-          rm -f "$BRIOCHE_OUTPUT"/lib/lib\${lib}.so
-          echo "INPUT(-l\${lib}w)" > "$BRIOCHE_OUTPUT"/lib/lib\${lib}.so
-          ln -sf \${lib}w.pc "$BRIOCHE_OUTPUT"/lib/pkgconfig/\${lib}.pc
-        done
+          for lib in ncurses form panel menu ; do
+            rm -f "$BRIOCHE_OUTPUT"/lib/lib\${lib}.so
+            echo "INPUT(-l\${lib}w)" > "$BRIOCHE_OUTPUT"/lib/lib\${lib}.so
+            ln -sf \${lib}w.pc "$BRIOCHE_OUTPUT"/lib/pkgconfig/\${lib}.pc
+          done
 
-        rm -f "$BRIOCHE_OUTPUT"/lib/libcursesw.so
-        echo "INPUT(-lncursesw)" > "$BRIOCHE_OUTPUT"/lib/libcursesw.so
-        ln -sf libncurses.so "$BRIOCHE_OUTPUT"/lib/libcurses.so
-      `,
+          rm -f "$BRIOCHE_OUTPUT"/lib/libcursesw.so
+          echo "INPUT(-lncursesw)" > "$BRIOCHE_OUTPUT"/lib/libcursesw.so
+          ln -sf libncurses.so "$BRIOCHE_OUTPUT"/lib/libcurses.so
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/ninja.bri
+++ b/std/toolchain/native/ninja.bri
@@ -37,16 +37,16 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        python3 configure.py --bootstrap
+          python3 configure.py --bootstrap
 
-        mkdir -p "$BRIOCHE_OUTPUT"/bin
-        install -vm755 ninja "$BRIOCHE_OUTPUT"/bin
-      `,
+          mkdir -p "$BRIOCHE_OUTPUT"/bin
+          install -vm755 ninja "$BRIOCHE_OUTPUT"/bin
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/openssl.bri
+++ b/std/toolchain/native/openssl.bri
@@ -16,25 +16,25 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./config \
-          --prefix=/ \
-          --openssldir=/etc/ssl \
-          --libdir=lib \
-          -L"$zlib/lib" \
-          -I"$zlib/include" \
-          shared \
-          zlib
+          ./config \
+            --prefix=/ \
+            --openssldir=/etc/ssl \
+            --libdir=lib \
+            -L"$zlib/lib" \
+            -I"$zlib/include" \
+            shared \
+            zlib
 
-        make
+          make
 
-        sed -i '/INSTALL_LIBS/s/libcrypto.a libssl.a//' Makefile
-        make install DESTDIR="$BRIOCHE_OUTPUT" MANSUFFIX=ssl
-      `,
+          sed -i '/INSTALL_LIBS/s/libcrypto.a libssl.a//' Makefile
+          make install DESTDIR="$BRIOCHE_OUTPUT" MANSUFFIX=ssl
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/patch.bri
+++ b/std/toolchain/native/patch.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/perl.bri
+++ b/std/toolchain/native/perl.bri
@@ -16,21 +16,21 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sh Configure \
-          -des \
-          -Dprefix=/ \
-          -Duserelocatableinc \
-          -Dusethreads \
-          -Dlocincpth="$zlib/include $bzip2/include" \
-          -Dloclibpth="$zlib/lib $bzip2/lib"
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          sh Configure \
+            -des \
+            -Dprefix=/ \
+            -Duserelocatableinc \
+            -Dusethreads \
+            -Dlocincpth="$zlib/include $bzip2/include" \
+            -Dloclibpth="$zlib/lib $bzip2/lib"
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/perl_xml_parser.bri
+++ b/std/toolchain/native/perl_xml_parser.bri
@@ -16,19 +16,19 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        perl Makefile.PL \
-          EXPATLIBPATH="$expat/lib" \
-          EXPATINCPATH="$expat/include" \
-          PREFIX="$BRIOCHE_OUTPUT"
-        make
-        make test
-        make install
-      `,
+          perl Makefile.PL \
+            EXPATLIBPATH="$expat/lib" \
+            EXPATINCPATH="$expat/include" \
+            PREFIX="$BRIOCHE_OUTPUT"
+          make
+          make test
+          make install
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/pkgconf.bri
+++ b/std/toolchain/native/pkgconf.bri
@@ -14,19 +14,19 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
+          ./configure \
+            --prefix=/ \
+            --disable-static
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
 
-        ln -sv pkgconf "$BRIOCHE_OUTPUT/bin/pkg-config"
-      `,
+          ln -sv pkgconf "$BRIOCHE_OUTPUT/bin/pkg-config"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/procps_ng.bri
+++ b/std/toolchain/native/procps_ng.bri
@@ -16,18 +16,18 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix=/ \
-          --disable-static \
-          --disable-kill
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --disable-static \
+            --disable-kill
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/psmisc.bri
+++ b/std/toolchain/native/psmisc.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/python.bri
+++ b/std/toolchain/native/python.bri
@@ -29,20 +29,20 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --prefix="$BRIOCHE_OUTPUT" \
-          --enable-shared \
-          --with-system-expat \
-          --with-system-ffi \
-          --enable-optimizations
-        make
-        make install
-      `,
+          ./configure \
+            --prefix="$BRIOCHE_OUTPUT" \
+            --enable-shared \
+            --with-system-expat \
+            --with-system-ffi \
+            --enable-optimizations
+          make
+          make install
+        `,
       ],
       env: {
         // TODO: Clean up these env vars

--- a/std/toolchain/native/python_flit_core.bri
+++ b/std/toolchain/native/python_flit_core.bri
@@ -31,23 +31,23 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        python3 -m venv "$BRIOCHE_OUTPUT"
+          python3 -m venv "$BRIOCHE_OUTPUT"
 
-        "$BRIOCHE_OUTPUT/bin/pip3" wheel \
-          -w dist \
-          --no-build-isolation \
-          --no-deps \
-          "$PWD"
-        "$BRIOCHE_OUTPUT/bin/pip3" install \
-          --no-index \
-          --find-links=dist \
-          flit_core
-      `,
+          "$BRIOCHE_OUTPUT/bin/pip3" wheel \
+            -w dist \
+            --no-build-isolation \
+            --no-deps \
+            "$PWD"
+          "$BRIOCHE_OUTPUT/bin/pip3" install \
+            --no-index \
+            --find-links=dist \
+            flit_core
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/python_wheel.bri
+++ b/std/toolchain/native/python_wheel.bri
@@ -32,23 +32,23 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        python3 -m venv "$BRIOCHE_OUTPUT"
+          python3 -m venv "$BRIOCHE_OUTPUT"
 
-        "$BRIOCHE_OUTPUT/bin/pip3" wheel \
-          -w dist \
-          --no-build-isolation \
-          --no-deps \
-          "$PWD"
-        "$BRIOCHE_OUTPUT/bin/pip3" install \
-          --no-index \
-          --find-links=dist \
-          wheel
-      `,
+          "$BRIOCHE_OUTPUT/bin/pip3" wheel \
+            -w dist \
+            --no-build-isolation \
+            --no-deps \
+            "$PWD"
+          "$BRIOCHE_OUTPUT/bin/pip3" install \
+            --no-index \
+            --find-links=dist \
+            wheel
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/readline.bri
+++ b/std/toolchain/native/readline.bri
@@ -20,22 +20,22 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        sed -i '/MV.*old/d' Makefile.in
-        sed -i '/{OLDSUFF}/c:' support/shlib-install
+          sed -i '/MV.*old/d' Makefile.in
+          sed -i '/{OLDSUFF}/c:' support/shlib-install
 
-        patch -Np1 -i "$sourcePatch"
+          patch -Np1 -i "$sourcePatch"
 
-        ./configure \
-          --prefix=/ \
-          --with-curses
-        make SHLIB_LIBS="-lncursesw"
-        make install SHLIB_LIBS="-lncursesw" DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --prefix=/ \
+            --with-curses
+          make SHLIB_LIBS="-lncursesw"
+          make install SHLIB_LIBS="-lncursesw" DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/sed.bri
+++ b/std/toolchain/native/sed.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/tar.bri
+++ b/std/toolchain/native/tar.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/texinfo.bri
+++ b/std/toolchain/native/texinfo.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/util_linux.bri
+++ b/std/toolchain/native/util_linux.bri
@@ -14,33 +14,33 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure \
-          --bindir=/bin \
-          --libdir=/lib \
-          --runstatedir=/run \
-          --sbindir=/bin \
-          --disable-chfn-chsh \
-          --disable-login \
-          --disable-nologin \
-          --disable-su \
-          --disable-setpriv \
-          --disable-runuser \
-          --disable-pylibmount \
-          --disable-static \
-          --without-python \
-          --without-systemd \
-          --without-systemdsystemunitdir \
-          --disable-makeinstall-chown \
-          --disable-makeinstall-setuid \
-          ADJTIME_PATH=/var/lib/hwclock/adjtime
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure \
+            --bindir=/bin \
+            --libdir=/lib \
+            --runstatedir=/run \
+            --sbindir=/bin \
+            --disable-chfn-chsh \
+            --disable-login \
+            --disable-nologin \
+            --disable-su \
+            --disable-setpriv \
+            --disable-runuser \
+            --disable-pylibmount \
+            --disable-static \
+            --without-python \
+            --without-systemd \
+            --without-systemdsystemunitdir \
+            --disable-makeinstall-chown \
+            --disable-makeinstall-setuid \
+            ADJTIME_PATH=/var/lib/hwclock/adjtime
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/xz.bri
+++ b/std/toolchain/native/xz.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/zlib.bri
+++ b/std/toolchain/native/zlib.bri
@@ -14,15 +14,15 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        ./configure --prefix=/
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          ./configure --prefix=/
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/native/zstd.bri
+++ b/std/toolchain/native/zstd.bri
@@ -14,14 +14,14 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${stage2()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
+          tar -xf "$source" --strip-components=1 --no-same-owner --no-same-permissions
 
-        make prefix=/
-        make install prefix="$BRIOCHE_OUTPUT"
-      `,
+          make prefix=/
+          make install prefix="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         source: sourceArchive,

--- a/std/toolchain/stage0/index.bri
+++ b/std/toolchain/stage0/index.bri
@@ -37,56 +37,56 @@ export function bootstrapRun(
       args: [
         "sh",
         "-c",
-        `
-        set -eu
+        std.indoc`
+          set -eu
 
-        "$BUSYBOX/bin/busybox" cp -r "$BOOTSTRAP_ROOTFS" ./rootfs
-        echo "$ENTER_BOOTSTRAP_SCRIPT" > enter.sh
-        "$BUSYBOX/bin/busybox" chmod +x enter.sh
-        echo "$RUN_BOOTSTRAP_SCRIPT" > rootfs/bootstrap.sh
-        "$BUSYBOX/bin/busybox" chmod +x rootfs/bootstrap.sh
-        "$BUSYBOX/bin/busybox" unshare -Umfr /usr/bin/env sh ./enter.sh
-      `,
+          "$BUSYBOX/bin/busybox" cp -r "$BOOTSTRAP_ROOTFS" ./rootfs
+          echo "$ENTER_BOOTSTRAP_SCRIPT" > enter.sh
+          "$BUSYBOX/bin/busybox" chmod +x enter.sh
+          echo "$RUN_BOOTSTRAP_SCRIPT" > rootfs/bootstrap.sh
+          "$BUSYBOX/bin/busybox" chmod +x rootfs/bootstrap.sh
+          "$BUSYBOX/bin/busybox" unshare -Umfr /usr/bin/env sh ./enter.sh
+        `,
       ],
       env: {
         BUSYBOX: busybox,
-        ENTER_BOOTSTRAP_SCRIPT: `
-        set -eu
+        ENTER_BOOTSTRAP_SCRIPT: std.indoc`
+          set -eu
 
-        "$BUSYBOX/bin/busybox" mkdir -p "$BRIOCHE_OUTPUT"
+          "$BUSYBOX/bin/busybox" mkdir -p "$BRIOCHE_OUTPUT"
 
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/hostfs"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/proc"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/sys"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/dev"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BUSYBOX"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$HOME"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
-        "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/hostfs"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/proc"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/sys"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/dev"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BUSYBOX"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$HOME"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
+          "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
 
-        "$BUSYBOX/bin/busybox" mount --rbind "$(pwd)/rootfs" "$(pwd)/rootfs"
-        "$BUSYBOX/bin/busybox" mount --rbind "/proc" "$(pwd)/rootfs/proc"
-        "$BUSYBOX/bin/busybox" mount --rbind "/sys" "$(pwd)/rootfs/sys"
-        "$BUSYBOX/bin/busybox" mount --rbind "/dev" "$(pwd)/rootfs/dev"
-        "$BUSYBOX/bin/busybox" mount --rbind "$BUSYBOX" "$(pwd)/rootfs/$BUSYBOX"
-        "$BUSYBOX/bin/busybox" mount --rbind "$HOME" "$(pwd)/rootfs/$HOME"
-        "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_OUTPUT" "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
-        "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_PACK_RESOURCES_DIR" "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
+          "$BUSYBOX/bin/busybox" mount --rbind "$(pwd)/rootfs" "$(pwd)/rootfs"
+          "$BUSYBOX/bin/busybox" mount --rbind "/proc" "$(pwd)/rootfs/proc"
+          "$BUSYBOX/bin/busybox" mount --rbind "/sys" "$(pwd)/rootfs/sys"
+          "$BUSYBOX/bin/busybox" mount --rbind "/dev" "$(pwd)/rootfs/dev"
+          "$BUSYBOX/bin/busybox" mount --rbind "$BUSYBOX" "$(pwd)/rootfs/$BUSYBOX"
+          "$BUSYBOX/bin/busybox" mount --rbind "$HOME" "$(pwd)/rootfs/$HOME"
+          "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_OUTPUT" "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
+          "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_PACK_RESOURCES_DIR" "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
 
-        "$BUSYBOX/bin/busybox" mkdir -p "$HOME/.local/libexec/brioche-toolchain/bin" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/lib64"
-        "$BUSYBOX/bin/busybox" cp "$BRIOCHE_LD" "$HOME/.local/libexec/brioche-toolchain/bin/brioche-ld"
-        "$BUSYBOX/bin/busybox" cp "$BRIOCHE_PACKED" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/brioche-packed"
-        "$BUSYBOX/bin/busybox" chmod +x "$HOME/.local/libexec/brioche-toolchain/bin/brioche-ld" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/brioche-packed"
-        "$BUSYBOX/bin/busybox" ln -s "/usr/bin/ld" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/ld"
-        "$BUSYBOX/bin/busybox" ln -s "/lib64/ld-linux-x86-64.so.2" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/lib64/"
-        "$BUSYBOX/bin/busybox" ln -s "brioche-ld" "$HOME/.local/libexec/brioche-toolchain/bin/ld"
-        "$BUSYBOX/bin/busybox" ln -s "brioche-ld" "$HOME/.local/libexec/brioche-toolchain/bin/x86_64-linux-gnu-ld"
+          "$BUSYBOX/bin/busybox" mkdir -p "$HOME/.local/libexec/brioche-toolchain/bin" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/lib64"
+          "$BUSYBOX/bin/busybox" cp "$BRIOCHE_LD" "$HOME/.local/libexec/brioche-toolchain/bin/brioche-ld"
+          "$BUSYBOX/bin/busybox" cp "$BRIOCHE_PACKED" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/brioche-packed"
+          "$BUSYBOX/bin/busybox" chmod +x "$HOME/.local/libexec/brioche-toolchain/bin/brioche-ld" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/brioche-packed"
+          "$BUSYBOX/bin/busybox" ln -s "/usr/bin/ld" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/ld"
+          "$BUSYBOX/bin/busybox" ln -s "/lib64/ld-linux-x86-64.so.2" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/lib64/"
+          "$BUSYBOX/bin/busybox" ln -s "brioche-ld" "$HOME/.local/libexec/brioche-toolchain/bin/ld"
+          "$BUSYBOX/bin/busybox" ln -s "brioche-ld" "$HOME/.local/libexec/brioche-toolchain/bin/x86_64-linux-gnu-ld"
 
-        export PATH="$HOME/.local/libexec/brioche-toolchain/bin\${PATH:+:$PATH}"
+          export PATH="$HOME/.local/libexec/brioche-toolchain/bin\${PATH:+:$PATH}"
 
-        "$BUSYBOX/bin/busybox" pivot_root "$(pwd)/rootfs" "$(pwd)/rootfs/hostfs"
-        /bin/bash /bootstrap.sh
-      `,
+          "$BUSYBOX/bin/busybox" pivot_root "$(pwd)/rootfs" "$(pwd)/rootfs/hostfs"
+          /bin/bash /bootstrap.sh
+        `,
         RUN_BOOTSTRAP_SCRIPT: options.script,
         BOOTSTRAP_ROOTFS: bootstrapRootfs,
         BRIOCHE_LD: briocheLd,

--- a/std/toolchain/stage1/1_01_binutils.bri
+++ b/std/toolchain/stage1/1_01_binutils.bri
@@ -10,7 +10,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage1/1_02_gcc.bri
+++ b/std/toolchain/stage1/1_02_gcc.bri
@@ -31,7 +31,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   const stage1 = binutils();
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage1/1_03_linux_headers.bri
+++ b/std/toolchain/stage1/1_03_linux_headers.bri
@@ -10,7 +10,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage1/1_04_glibc.bri
+++ b/std/toolchain/stage1/1_04_glibc.bri
@@ -25,7 +25,7 @@ export default std.memo((): std.Lazy<std.Directory> => {
   const stage1 = std.merge(binutils(), gcc(), linuxHeaders());
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage1/1_05_libstdcpp.bri
+++ b/std/toolchain/stage1/1_05_libstdcpp.bri
@@ -21,10 +21,10 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
     renameSuffix: "-orig",
     script: std
       .file(std.indoc`
-      #!/usr/bin/env sh
-      sysroot=$(cd "$(dirname -- "$0")/../.." && pwd)
-      "$0-orig" --sysroot="$sysroot" -isystem "$sysroot/usr/include" "$@"
-    `)
+        #!/usr/bin/env sh
+        sysroot=$(cd "$(dirname -- "$0")/../.." && pwd)
+        "$0-orig" --sysroot="$sysroot" -isystem "$sysroot/usr/include" "$@"
+      `)
       .withPermissions({ executable: true }),
   });
 
@@ -41,7 +41,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage1/index.bri
+++ b/std/toolchain/stage1/index.bri
@@ -41,11 +41,11 @@ export default std.memo(() => {
     renameSuffix: "-orig",
     script: std
       .file(std.indoc`
-      #!/usr/bin/env sh
-      script_dir=$(cd "$(dirname -- "$0")" && pwd -P)
-      sysroot=$(cd "$script_dir/../.." && pwd -P)
-      "$0-orig" --sysroot="$sysroot" -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0/x86_64-lfs-linux-gnu" -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0" -isystem "$sysroot/usr/include" "$@"
-    `)
+        #!/usr/bin/env sh
+        script_dir=$(cd "$(dirname -- "$0")" && pwd -P)
+        sysroot=$(cd "$script_dir/../.." && pwd -P)
+        "$0-orig" --sysroot="$sysroot" -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0/x86_64-lfs-linux-gnu" -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0" -isystem "$sysroot/usr/include" "$@"
+      `)
       .withPermissions({ executable: true }),
   });
 

--- a/std/toolchain/stage2/2_01_m4.bri
+++ b/std/toolchain/stage2/2_01_m4.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_02_ncurses.bri
+++ b/std/toolchain/stage2/2_02_ncurses.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_03_bash.bri
+++ b/std/toolchain/stage2/2_03_bash.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_04_coreutils.bri
+++ b/std/toolchain/stage2/2_04_coreutils.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_05_diffutils.bri
+++ b/std/toolchain/stage2/2_05_diffutils.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_06_file.bri
+++ b/std/toolchain/stage2/2_06_file.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_07_findutils.bri
+++ b/std/toolchain/stage2/2_07_findutils.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_08_gawk.bri
+++ b/std/toolchain/stage2/2_08_gawk.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_09_grep.bri
+++ b/std/toolchain/stage2/2_09_grep.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_10_gzip.bri
+++ b/std/toolchain/stage2/2_10_gzip.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_11_make.bri
+++ b/std/toolchain/stage2/2_11_make.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_12_patch.bri
+++ b/std/toolchain/stage2/2_12_patch.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_14_tar.bri
+++ b/std/toolchain/stage2/2_14_tar.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_15_xz.bri
+++ b/std/toolchain/stage2/2_15_xz.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_16_binutils.bri
+++ b/std/toolchain/stage2/2_16_binutils.bri
@@ -11,7 +11,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   });
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage1/usr/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_17_gcc.bri
+++ b/std/toolchain/stage2/2_17_gcc.bri
@@ -90,7 +90,7 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
   // stage2 = stage2.insert("usr/x86_64-lfs-linux-gnu/include", usrInclude);
 
   return bootstrapRun({
-    script: `
+    script: std.indoc`
       set -euo pipefail
 
       export PATH="$stage2/bin:/usr/lib/gcc/x86_64-linux-gnu/12\${PATH:+:$PATH}"

--- a/std/toolchain/stage2/2_18_toolchain.bri
+++ b/std/toolchain/stage2/2_18_toolchain.bri
@@ -70,76 +70,76 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
     renameSuffix: "-orig",
     script: std
       .file(std.indoc`
-      #!/usr/bin/env sh
-      # MIT license: https://stackoverflow.com/a/29835459
-      rreadlink() ( # Execute the function in a *subshell* to localize variables and the effect of 'cd'.
+        #!/usr/bin/env sh
+        # MIT license: https://stackoverflow.com/a/29835459
+        rreadlink() ( # Execute the function in a *subshell* to localize variables and the effect of 'cd'.
 
-        target=$1 fname= targetDir= CDPATH=
+          target=$1 fname= targetDir= CDPATH=
 
-        # Try to make the execution environment as predictable as possible:
-        # All commands below are invoked via 'command', so we must make sure that 'command'
-        # itself is not redefined as an alias or shell function.
-        # (Note that command is too inconsistent across shells, so we don't use it.)
-        # 'command' is a *builtin* in bash, dash, ksh, zsh, and some platforms do not even have
-        # an external utility version of it (e.g, Ubuntu).
-        # 'command' bypasses aliases and shell functions and also finds builtins
-        # in bash, dash, and ksh. In zsh, option POSIX_BUILTINS must be turned on for that
-        # to happen.
-        { \\unalias command; \\unset -f command; } >/dev/null 2>&1
-        [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on # make zsh find *builtins* with 'command' too.
+          # Try to make the execution environment as predictable as possible:
+          # All commands below are invoked via 'command', so we must make sure that 'command'
+          # itself is not redefined as an alias or shell function.
+          # (Note that command is too inconsistent across shells, so we don't use it.)
+          # 'command' is a *builtin* in bash, dash, ksh, zsh, and some platforms do not even have
+          # an external utility version of it (e.g, Ubuntu).
+          # 'command' bypasses aliases and shell functions and also finds builtins
+          # in bash, dash, and ksh. In zsh, option POSIX_BUILTINS must be turned on for that
+          # to happen.
+          { \\unalias command; \\unset -f command; } >/dev/null 2>&1
+          [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on # make zsh find *builtins* with 'command' too.
 
-        while :; do # Resolve potential symlinks until the ultimate target is found.
-            [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\\n' "ERROR: '$target' does not exist." >&2; return 1; }
-            command cd "$(command dirname -- "$target")" # Change to target dir; necessary for correct resolution of target path.
-            fname=$(command basename -- "$target") # Extract filename.
-            [ "$fname" = '/' ] && fname='' # !! curiously, 'basename /' returns '/'
-            if [ -L "$fname" ]; then
-              # Extract [next] target path, which may be defined
-              # *relative* to the symlink's own directory.
-              # Note: We parse 'ls -l' output to find the symlink target
-              #       which is the only POSIX-compliant, albeit somewhat fragile, way.
-              target=$(command ls -l "$fname")
-              target=\${target#* -> }
-              continue # Resolve [next] symlink target.
-            fi
-            break # Ultimate target reached.
+          while :; do # Resolve potential symlinks until the ultimate target is found.
+              [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\\n' "ERROR: '$target' does not exist." >&2; return 1; }
+              command cd "$(command dirname -- "$target")" # Change to target dir; necessary for correct resolution of target path.
+              fname=$(command basename -- "$target") # Extract filename.
+              [ "$fname" = '/' ] && fname='' # !! curiously, 'basename /' returns '/'
+              if [ -L "$fname" ]; then
+                # Extract [next] target path, which may be defined
+                # *relative* to the symlink's own directory.
+                # Note: We parse 'ls -l' output to find the symlink target
+                #       which is the only POSIX-compliant, albeit somewhat fragile, way.
+                target=$(command ls -l "$fname")
+                target=\${target#* -> }
+                continue # Resolve [next] symlink target.
+              fi
+              break # Ultimate target reached.
+          done
+          targetDir=$(command pwd -P) # Get canonical dir. path
+          # Output the ultimate target's canonical path.
+          # Note that we manually resolve paths ending in /. and /.. to make sure we have a normalized path.
+          if [ "$fname" = '.' ]; then
+            command printf '%s\\n' "\${targetDir%/}"
+          elif  [ "$fname" = '..' ]; then
+            # Caveat: something like /var/.. will resolve to /private (assuming /var@ -> /private/var), i.e. the '..' is applied
+            # AFTER canonicalization.
+            command printf '%s\\n' "$(command dirname -- "\${targetDir}")"
+          else
+            command printf '%s\\n' "\${targetDir%/}/$fname"
+          fi
+        )
+
+        script_dir=$(cd "$(dirname -- "$(rreadlink "$0")")" && pwd -P)
+        sysroot=$(cd "$script_dir/../.." && pwd -P)
+
+        include_system_headers=1
+        for arg in "$@"; do
+          if [ "$arg" = "-nostdinc" ]; then
+            include_system_headers=0
+            break
+          fi
         done
-        targetDir=$(command pwd -P) # Get canonical dir. path
-        # Output the ultimate target's canonical path.
-        # Note that we manually resolve paths ending in /. and /.. to make sure we have a normalized path.
-        if [ "$fname" = '.' ]; then
-          command printf '%s\\n' "\${targetDir%/}"
-        elif  [ "$fname" = '..' ]; then
-          # Caveat: something like /var/.. will resolve to /private (assuming /var@ -> /private/var), i.e. the '..' is applied
-          # AFTER canonicalization.
-          command printf '%s\\n' "$(command dirname -- "\${targetDir}")"
-        else
-          command printf '%s\\n' "\${targetDir%/}/$fname"
+
+        if [ "$include_system_headers" -eq 1 ]; then
+          set -- \
+            -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0/x86_64-lfs-linux-gnu" \
+            -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0" \
+            -isystem "$sysroot/usr/include" \
+            "$@"
         fi
-      )
+        set -- --sysroot="$sysroot" "$@"
 
-      script_dir=$(cd "$(dirname -- "$(rreadlink "$0")")" && pwd -P)
-      sysroot=$(cd "$script_dir/../.." && pwd -P)
-
-      include_system_headers=1
-      for arg in "$@"; do
-        if [ "$arg" = "-nostdinc" ]; then
-          include_system_headers=0
-          break
-        fi
-      done
-
-      if [ "$include_system_headers" -eq 1 ]; then
-        set -- \
-          -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0/x86_64-lfs-linux-gnu" \
-          -isystem "$sysroot/x86_64-lfs-linux-gnu/include/c++/13.2.0" \
-          -isystem "$sysroot/usr/include" \
-          "$@"
-      fi
-      set -- --sysroot="$sysroot" "$@"
-
-      "$(rreadlink "$0")-orig" "$@"
-    `)
+        "$(rreadlink "$0")-orig" "$@"
+      `)
       .withPermissions({ executable: true }),
   });
 

--- a/std/toolchain/stage2/2_19_gettext.bri
+++ b/std/toolchain/stage2/2_19_gettext.bri
@@ -15,15 +15,15 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar xf "$source" --strip-components=1
-        ./configure --disable-shared
-        make
-        mkdir -p "$BRIOCHE_OUTPUT/usr/bin"
-        cp gettext-tools/src/{msgfmt,msgmerge,xgettext} "$BRIOCHE_OUTPUT/usr/bin"
-      `,
+          tar xf "$source" --strip-components=1
+          ./configure --disable-shared
+          make
+          mkdir -p "$BRIOCHE_OUTPUT/usr/bin"
+          cp gettext-tools/src/{msgfmt,msgmerge,xgettext} "$BRIOCHE_OUTPUT/usr/bin"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin`,

--- a/std/toolchain/stage2/2_20_bison.bri
+++ b/std/toolchain/stage2/2_20_bison.bri
@@ -15,17 +15,17 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar xf "$source" --strip-components=1
-        ./configure \
-          --prefix=/usr \
-          --docdir=/usr/share/doc/bison-3.8.2 \
-          --enable-relocatable
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          tar xf "$source" --strip-components=1
+          ./configure \
+            --prefix=/usr \
+            --docdir=/usr/share/doc/bison-3.8.2 \
+            --enable-relocatable
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin`,

--- a/std/toolchain/stage2/2_21_perl.bri
+++ b/std/toolchain/stage2/2_21_perl.bri
@@ -15,17 +15,17 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar xf "$source" --strip-components=1
-        sh Configure \
-          -des \
-          -Dprefix="/usr" \
-          -Duserelocatableinc
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          tar xf "$source" --strip-components=1
+          sh Configure \
+            -des \
+            -Dprefix="/usr" \
+            -Duserelocatableinc
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin`,

--- a/std/toolchain/stage2/2_22_python.bri
+++ b/std/toolchain/stage2/2_22_python.bri
@@ -15,15 +15,15 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        tar xf "$source" --strip-components=1
-        ./configure \
-          --prefix=/usr \
-          --enable-shared \
-          --without-ensurepip
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+        std.indoc`
+          tar xf "$source" --strip-components=1
+          ./configure \
+            --prefix=/usr \
+            --enable-shared \
+            --without-ensurepip
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin`,

--- a/std/toolchain/stage2/2_23_texinfo.bri
+++ b/std/toolchain/stage2/2_23_texinfo.bri
@@ -16,14 +16,14 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        tar xf "$source" --strip-components=1
-        ./configure --prefix=/usr
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+          tar xf "$source" --strip-components=1
+          ./configure --prefix=/usr
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin:${perl()}/usr/bin`,

--- a/std/toolchain/stage2/2_24_util_linux.bri
+++ b/std/toolchain/stage2/2_24_util_linux.bri
@@ -15,28 +15,28 @@ export default std.memo(async (): Promise<std.Lazy<std.Directory>> => {
       args: [
         "sh",
         "-c",
-        `
-        tar xf "$source" --strip-components=1
-        ./configure \
-            --libdir=/usr/lib \
-            --runstatedir=/run \
-            --bindir=/usr/bin \
-            --sbindir=/usr/sbin \
-            --docdir=/usr/share/doc/util-linux-2.39.1 \
-            --disable-chfn-chsh \
-            --disable-login \
-            --disable-nologin \
-            --disable-su \
-            --disable-setpriv \
-            --disable-runuser \
-            --disable-pylibmount \
-            --disable-wall \
-            --disable-mount \
-            --disable-static \
-            --without-python
-        make
-        make install DESTDIR="$BRIOCHE_OUTPUT"
-      `,
+        std.indoc`
+          tar xf "$source" --strip-components=1
+          ./configure \
+              --libdir=/usr/lib \
+              --runstatedir=/run \
+              --bindir=/usr/bin \
+              --sbindir=/usr/sbin \
+              --docdir=/usr/share/doc/util-linux-2.39.1 \
+              --disable-chfn-chsh \
+              --disable-login \
+              --disable-nologin \
+              --disable-su \
+              --disable-setpriv \
+              --disable-runuser \
+              --disable-pylibmount \
+              --disable-wall \
+              --disable-mount \
+              --disable-static \
+              --without-python
+          make
+          make install DESTDIR="$BRIOCHE_OUTPUT"
+        `,
       ],
       env: {
         PATH: std.tpl`${toolchain()}/bin`,

--- a/std/toolchain/stage2/index.bri
+++ b/std/toolchain/stage2/index.bri
@@ -26,38 +26,38 @@ export default std.memo((): std.Lazy<std.Directory> => {
       command: std.tpl`${toolchain()}/bin/bash`,
       args: [
         "-c",
-        `
-        set -euo pipefail
+        std.indoc`
+          set -euo pipefail
 
-        cp -r "$stage2" "$BRIOCHE_OUTPUT"
-        find "$BRIOCHE_OUTPUT"/usr/bin -type f -executable -print0 \
-          | while IFS= read -r -d $'\\0' file; do
-            if [ "$(head -c 2 "$file")" == "#!" ]; then
-              awk '
-                {
-                  if (NR == 1 && $0 ~ /^#!/) {
-                    shebangInvocation = $0
-                    gsub(/^#! */, "", shebangInvocation)
-                    numShebangWords = split(shebangInvocation, shebangWords, / +/)
-                    if (numShebangWords == 1) {
-                      shebangCommand = shebangWords[1]
-                      numComponents = split(shebangCommand, shebangCommandComponents, "/")
-                      targetCommand = shebangCommandComponents[numComponents]
-                      gsub(" ", "", targetCommand)
-                      print "#!/usr/bin/env " targetCommand
+          cp -r "$stage2" "$BRIOCHE_OUTPUT"
+          find "$BRIOCHE_OUTPUT"/usr/bin -type f -executable -print0 \
+            | while IFS= read -r -d $'\\0' file; do
+              if [ "$(head -c 2 "$file")" == "#!" ]; then
+                awk '
+                  {
+                    if (NR == 1 && $0 ~ /^#!/) {
+                      shebangInvocation = $0
+                      gsub(/^#! */, "", shebangInvocation)
+                      numShebangWords = split(shebangInvocation, shebangWords, / +/)
+                      if (numShebangWords == 1) {
+                        shebangCommand = shebangWords[1]
+                        numComponents = split(shebangCommand, shebangCommandComponents, "/")
+                        targetCommand = shebangCommandComponents[numComponents]
+                        gsub(" ", "", targetCommand)
+                        print "#!/usr/bin/env " targetCommand
+                      } else {
+                        print $0
+                      }
                     } else {
                       print $0
                     }
-                  } else {
-                    print $0
                   }
-                }
-              ' "$file" > temp
-              chmod +x temp
-              mv temp "$file"
-            fi
-          done
-      `,
+                ' "$file" > temp
+                chmod +x temp
+                mv temp "$file"
+              fi
+            done
+        `,
       ],
       env: {
         PATH: std.tpl`${stage2}/bin`,


### PR DESCRIPTION
This PR updates `std` to cover a few upstream changes merged in Brioche:

- Use "tick encoding" instead of URL encoding when encoding binary data in JSON (brioche-dev/brioche#8)
- Add `type` field when serializing the `resources` field in `File` values (brioche-dev/brioche#9)
- Use `std.indoc` to clean up lots of packages built in the `std.native()` toolchain