### PR TITLE
Add `bzip2` decompression format

### DIFF
--- a/std/core/runtime.bri
+++ b/std/core/runtime.bri
@@ -211,7 +211,7 @@ export type Hash = { type: "sha256"; value: HexString };
 
 export type ArchiveFormat = "tar";
 
-export type CompressionFormat = "none" | "gzip" | "xz" | "zstd";
+export type CompressionFormat = "none" | "bzip2" | "gzip" | "xz" | "zstd";
 
 export type ProcessTemplate = {
   components: ProcessTemplateComponent[];


### PR DESCRIPTION
This PR updates the `std` package so that the `File.unpack()` method accepts a new compression type of `bzip2`. This corresponds with the upstream change from brioche-dev/brioche#15