### PR TITLE
Update `std.process` to expose new `networking` and `unsafe` fields

### DIFF
--- a/projects/std/core/recipes/process.bri
+++ b/projects/std/core/recipes/process.bri
@@ -3,13 +3,13 @@ import * as runtime from "../runtime.bri";
 import { type Directory, directory } from "./directory.bri";
 import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
 
-export interface ProcessOptions {
+export type ProcessOptions = {
   command: ProcessTemplateLike;
   args?: ProcessTemplateLike[];
   env?: Record<string, ProcessTemplateLike>;
   workDir?: AsyncRecipe<Directory>;
   outputScaffold?: AsyncRecipe | null;
-}
+} & ({ unsafe?: false } | { unsafe: true; networking?: boolean });
 
 export type Process = Recipe & ProcessUtils;
 
@@ -58,6 +58,8 @@ export function process(options: ProcessOptions): Process {
           options.outputScaffold != null
             ? await (await options.outputScaffold).briocheSerialize()
             : null,
+        unsafe: options.unsafe,
+        networking: options.unsafe === true ? options.networking : undefined,
         meta,
       };
     },

--- a/projects/std/core/runtime.bri
+++ b/projects/std/core/runtime.bri
@@ -121,6 +121,8 @@ export type ProcessRecipe = WithMeta & {
   workDir: Recipe;
   outputScaffold?: Recipe | null;
   platform: Platform;
+  unsafe?: boolean;
+  networking?: boolean;
 };
 
 export type CreateFileRecipe = WithMeta & {


### PR DESCRIPTION
This is a companion PR to brioche-dev/brioche#33, which just updates `std.process` to take the new process fields of `networking` and `unsafe`. The types were tweaked so that `networking` can only be set if `unsafe` is set to true.