### PR TITLE
Add `Brioche.get` global in `std`

### DIFF
--- a/projects/std/core/global.bri
+++ b/projects/std/core/global.bri
@@ -1,0 +1,30 @@
+import { Recipe, createRecipe } from "./recipes";
+import { source } from "./source.bri";
+
+export interface BriocheGlobal {
+  get(path: string): Recipe;
+}
+
+(globalThis as any).Brioche = {
+  get(path: string): Recipe {
+    const sourceFrame = source({ depth: 1 }).at(0);
+    if (sourceFrame === undefined) {
+      throw new Error(`Could not find source file to retrieve ${path}`);
+    }
+
+    const sourceFile = sourceFrame.fileName;
+
+    return createRecipe(["file", "directory", "symlink"], {
+      sourceDepth: 1,
+      briocheSerialize: async () => {
+        return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+          sourceFile,
+          {
+            type: "get",
+            path,
+          },
+        );
+      },
+    });
+  },
+} satisfies BriocheGlobal;

--- a/projects/std/core/global.bri
+++ b/projects/std/core/global.bri
@@ -5,26 +5,25 @@ export interface BriocheGlobal {
   get(path: string): Recipe;
 }
 
-(globalThis as any).Brioche = {
-  get(path: string): Recipe {
-    const sourceFrame = source({ depth: 1 }).at(0);
-    if (sourceFrame === undefined) {
-      throw new Error(`Could not find source file to retrieve ${path}`);
-    }
+(globalThis as any).Brioche ??= {};
+(globalThis as any).Brioche.get ??= function get(path: string): Recipe {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to retrieve ${path}`);
+  }
 
-    const sourceFile = sourceFrame.fileName;
+  const sourceFile = sourceFrame.fileName;
 
-    return createRecipe(["file", "directory", "symlink"], {
-      sourceDepth: 1,
-      briocheSerialize: async () => {
-        return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
-          sourceFile,
-          {
-            type: "get",
-            path,
-          },
-        );
-      },
-    });
-  },
-} satisfies BriocheGlobal;
+  return createRecipe(["file", "directory", "symlink"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "get",
+          path,
+        },
+      );
+    },
+  });
+};

--- a/projects/std/core/index.bri
+++ b/projects/std/core/index.bri
@@ -13,3 +13,4 @@ export {
 } from "./runtime.bri";
 
 import "./console.bri";
+import "./global.bri";

--- a/projects/std/project.bri
+++ b/projects/std/project.bri
@@ -1,3 +1,4 @@
+import type { BriocheGlobal } from "./core/global.bri";
 import { toolchain } from "./toolchain";
 
 export * from "./core";
@@ -7,6 +8,10 @@ export const project = {
   name: "std",
   version: "0.0.0",
 };
+
+declare global {
+  const Brioche: BriocheGlobal;
+}
 
 // NOTE: This default export is a workaround so that `brioche build -p ./std`
 // will build the toolchain. This will be removed once we support building


### PR DESCRIPTION
Companion PR: brioche-dev/brioche#34

This PR updates the `std` package to define the new global constant `Brioche`, plus the function `Brioche.get(...)`. This is a special function that works with the Brioche runtime to allow loading an artifact from a local path relative to the current module. It's defined as a global because the runtime needs special awareness of this function.

I tried to make the implementation pretty defensive when setting `Brioche.get`-- it's only set if it's currently undefined. I figured this might save some headache in the future if we end up in a state where we have multiple versions of `std` loaded at once (which will probably cause mayhem with this feature). If we want to handle that case, future versions of `std` can set `Brioche.get` globally, which will take precedence over this implementation.