### PR TITLE
Replace `Brioche.get` with `Brioche.includeFile` / `Brioche.includeDirectory`

### DIFF
--- a/projects/std/core/global.bri
+++ b/projects/std/core/global.bri
@@ -1,12 +1,18 @@
-import { Recipe, createRecipe } from "./recipes";
+import {
+  type Recipe,
+  type File,
+  type Directory,
+  createRecipe,
+} from "./recipes";
 import { source } from "./source.bri";
 
 export interface BriocheGlobal {
-  get(path: string): Recipe;
+  includeFile(path: string): Recipe<File>;
+  includeDirectory(path: string): Recipe<Directory>;
 }
 
 (globalThis as any).Brioche ??= {};
-(globalThis as any).Brioche.get ??= function get(path: string): Recipe {
+(globalThis as any).Brioche.includeFile ??= (path: string): Recipe<File> => {
   const sourceFrame = source({ depth: 1 }).at(0);
   if (sourceFrame === undefined) {
     throw new Error(`Could not find source file to retrieve ${path}`);
@@ -14,7 +20,31 @@ export interface BriocheGlobal {
 
   const sourceFile = sourceFrame.fileName;
 
-  return createRecipe(["file", "directory", "symlink"], {
+  return createRecipe(["file"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "include",
+          include: "file",
+          path,
+        },
+      );
+    },
+  });
+};
+(globalThis as any).Brioche.includeDirectory ??= (
+  path: string,
+): Recipe<Directory> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to retrieve ${path}`);
+  }
+
+  const sourceFile = sourceFrame.fileName;
+
+  return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async () => {
       return await (globalThis as any).Deno.core.ops.op_brioche_get_static(


### PR DESCRIPTION
Companion PR: brioche-dev/brioche#35

This PR is a follow-up to #7, replacing the function `Brioche.get(...)` with `Brioche.includeFile` and `Brioche.includeDirectory` instead to match the upstream change from brioche-dev/brioche#35