### PR TITLE
Add `dependencies` option to `std.process`

### DIFF
--- a/projects/std/core/recipes/process.bri
+++ b/projects/std/core/recipes/process.bri
@@ -7,6 +7,7 @@ export type ProcessOptions = {
   command: ProcessTemplateLike;
   args?: ProcessTemplateLike[];
   env?: Record<string, ProcessTemplateLike>;
+  dependencies?: AsyncRecipe<Directory>[];
   workDir?: AsyncRecipe<Directory>;
   outputScaffold?: AsyncRecipe | null;
 } & ({ unsafe?: false } | { unsafe: true; networking?: boolean });
@@ -48,6 +49,11 @@ export function process(options: ProcessOptions): Process {
               k,
               await processTemplate(v).briocheSerialize(),
             ]),
+          ),
+        ),
+        dependencies: await Promise.all(
+          (options.dependencies ?? []).map(
+            async (dep) => await (await dep).briocheSerialize(),
           ),
         ),
         platform: "x86_64-linux",

--- a/projects/std/core/runtime.bri
+++ b/projects/std/core/runtime.bri
@@ -118,6 +118,7 @@ export type ProcessRecipe = WithMeta & {
   command: ProcessTemplate;
   args: ProcessTemplate[];
   env: Record<BString, ProcessTemplate>;
+  dependencies?: Recipe[];
   workDir: Recipe;
   outputScaffold?: Recipe | null;
   platform: Platform;


### PR DESCRIPTION
This PR adds the new `dependencies` option to the function `std.process()`, to match the changes upstream. See brioche-dev/brioche#38