### PR TITLE
Add implementation for `Brioche.glob` global function

### DIFF
--- a/projects/std/core/global.bri
+++ b/projects/std/core/global.bri
@@ -9,6 +9,7 @@ import { source } from "./source.bri";
 export interface BriocheGlobal {
   includeFile(path: string): Recipe<File>;
   includeDirectory(path: string): Recipe<Directory>;
+  glob(...patterns: string[]): Recipe<Directory>;
 }
 
 (globalThis as any).Brioche ??= {};
@@ -53,6 +54,29 @@ export interface BriocheGlobal {
           type: "include",
           include: "directory",
           path,
+        },
+      );
+    },
+  });
+};
+(globalThis as any).Brioche.glob ??= (
+  ...patterns: string[]
+): Recipe<Directory> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to resolve glob`);
+  }
+
+  const sourceFile = sourceFrame.fileName;
+
+  return createRecipe(["directory"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "glob",
+          patterns,
         },
       );
     },


### PR DESCRIPTION
This PR provides an implementation for `Brioche.glob` from `std`. See brioche-dev/brioche#40