### PR TITLE
Update `std` to reflect changes to resource dirs

### DIFF
--- a/projects/std/core/recipes/process.bri
+++ b/projects/std/core/recipes/process.bri
@@ -29,7 +29,8 @@ export interface ProcessUtils {
 export function process(options: ProcessOptions): Process {
   const env: Record<string, ProcessTemplateLike> = {
     BRIOCHE_OUTPUT: outputPath,
-    BRIOCHE_PACK_RESOURCES_DIR: resourcesDir,
+    BRIOCHE_RESOURCE_DIR: resourceDir,
+    BRIOCHE_INPUT_RESOURCE_DIRS: inputResourceDirs,
     HOME: homeDir,
     TMPDIR: tempDir,
     ...options.env,
@@ -142,7 +143,8 @@ export function tpl(
 }
 
 export const outputPath: unique symbol = Symbol("outputPath");
-export const resourcesDir: unique symbol = Symbol("resourcesDir");
+export const resourceDir: unique symbol = Symbol("resourceDir");
+export const inputResourceDirs: unique symbol = Symbol("inputResourceDirs");
 export const homeDir: unique symbol = Symbol("homeDir");
 export const workDir: unique symbol = Symbol("workDir");
 export const tempDir: unique symbol = Symbol("tempDir");
@@ -154,7 +156,8 @@ export type ProcessTemplateComponent =
   | ProcessTemplate
   | Recipe
   | typeof outputPath
-  | typeof resourcesDir
+  | typeof resourceDir
+  | typeof inputResourceDirs
   | typeof homeDir
   | typeof workDir
   | typeof tempDir
@@ -179,8 +182,10 @@ export class ProcessTemplate {
             return [{ type: "literal", value: runtime.bstring(component) }];
           } else if (component === outputPath) {
             return [{ type: "output_path" }];
-          } else if (component === resourcesDir) {
-            return [{ type: "resources_dir" }];
+          } else if (component === resourceDir) {
+            return [{ type: "resource_dir" }];
+          } else if (component === inputResourceDirs) {
+            return [{ type: "input_resource_dirs" }];
           } else if (component === homeDir) {
             return [{ type: "home_dir" }];
           } else if (component === workDir) {

--- a/projects/std/core/runtime.bri
+++ b/projects/std/core/runtime.bri
@@ -219,7 +219,8 @@ export type ProcessTemplateComponent =
   | { type: "literal"; value: BString }
   | { type: "input"; recipe: Recipe }
   | { type: "output_path" }
-  | { type: "resources_dir" }
+  | { type: "resource_dir" }
+  | { type: "input_resource_dirs" }
   | { type: "home_dir" }
   | { type: "work_dir" }
   | { type: "temp_dir" };

--- a/projects/std/pack_tools.bri
+++ b/projects/std/pack_tools.bri
@@ -3,9 +3,9 @@ import * as std from "/core";
 export function packTools(): std.Recipe<std.Directory> {
   return std
     .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche/commits/2b2c62754247c7a5707faae1e664c1607765a548/x86_64-linux/brioche-pack.tar.zstd",
+      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche/commits/7995587bc9f8356780bcfb4d783eb545439ef949/x86_64-linux/brioche-pack.tar.zstd",
       hash: std.sha256Hash(
-        "191fde9807ee4d9a81d3db4c666f1a265d0cdcbde2c580eabaa37e0712f0a240",
+        "42225bcbb94b44687daa3a7b52f10cc82ce888b74df30b6a146f71edf427f729",
       ),
     })
     .unarchive("tar", "zstd");

--- a/projects/std/toolchain/stage0/index.bri
+++ b/projects/std/toolchain/stage0/index.bri
@@ -47,7 +47,7 @@ export function bootstrapRun(
       "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BUSYBOX"
       "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$HOME"
       "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
-      "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
+      "$BUSYBOX/bin/busybox" mkdir -p "$(pwd)/rootfs/$BRIOCHE_RESOURCE_DIR"
 
       "$BUSYBOX/bin/busybox" mount --rbind "$(pwd)/rootfs" "$(pwd)/rootfs"
       "$BUSYBOX/bin/busybox" mount --rbind "/proc" "$(pwd)/rootfs/proc"
@@ -56,7 +56,7 @@ export function bootstrapRun(
       "$BUSYBOX/bin/busybox" mount --rbind "$BUSYBOX" "$(pwd)/rootfs/$BUSYBOX"
       "$BUSYBOX/bin/busybox" mount --rbind "$HOME" "$(pwd)/rootfs/$HOME"
       "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_OUTPUT" "$(pwd)/rootfs/$BRIOCHE_OUTPUT"
-      "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_PACK_RESOURCES_DIR" "$(pwd)/rootfs/$BRIOCHE_PACK_RESOURCES_DIR"
+      "$BUSYBOX/bin/busybox" mount --rbind "$BRIOCHE_RESOURCE_DIR" "$(pwd)/rootfs/$BRIOCHE_RESOURCE_DIR"
 
       "$BUSYBOX/bin/busybox" mkdir -p "$HOME/.local/libexec/brioche-toolchain/bin" "$HOME/.local/libexec/brioche-toolchain/libexec/brioche-ld/lib64"
       "$BUSYBOX/bin/busybox" cp "$BRIOCHE_LD" "$HOME/.local/libexec/brioche-toolchain/bin/brioche-ld"


### PR DESCRIPTION
This PR updates `std` to match the changes from this upstream PR: brioche-dev/brioche#42

- Update template components
  - Remove `std.resourcesDir` symbol (plural)
  - Add `std.resourceDir` (singular) and `std.inputResourceDirs` symbol
- Update default env vars set by `std.process()`
  - Remove `$BRIOCHE_PACK_RESOURCES_DIR`
  - Add `$BRIOCHE_RESOURCE_DIR` and `$BRIOCHE_INPUT_RESOURCE_DIRS`
- Update pack tools to a version that handles these changes