### PR TITLE
Add `ca_certificates` package

### DIFF
--- a/projects/ca_certificates/brioche.lock
+++ b/projects/ca_certificates/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/projects/ca_certificates/project.bri
+++ b/projects/ca_certificates/project.bri
@@ -1,0 +1,30 @@
+import * as std from "std";
+
+export const project = {
+  name: "ca_certificates",
+  version: "2024-03-11",
+};
+
+export default (): std.Recipe<std.Directory> => {
+  const cacert = std.download({
+    url: `https://curl.se/ca/cacert-${project.version}.pem`,
+    hash: std.sha256Hash(
+      "1794c1d4f7055b7d02c2170337b61b48a2ef6c90d77e95444fd2596f4cac609f",
+    ),
+  });
+
+  return std.setEnv(
+    std.directory({
+      etc: std.directory({
+        ssl: std.directory({
+          certs: std.directory({
+            "ca-bundle.crt": cacert,
+          }),
+        }),
+      }),
+    }),
+    {
+      SSL_CERT_FILE: { path: "etc/ssl/certs/ca-bundle.crt" },
+    },
+  );
+};


### PR DESCRIPTION
This PR adds a new `ca_certificates` package. This provides a bundle of CA certificates from Mozilla (the same bundle endorsed by Curl and used by lots of other package managers, as far as I can tell).

When used as a dependency, it sets the `$SSL_CERT_FILE` env var, which OpenSSL (and others) can use to verify TLS / HTTPS certificates