### PR TITLE
Add Curl package

### DIFF
--- a/projects/curl/brioche.lock
+++ b/projects/curl/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/projects/curl/project.bri
+++ b/projects/curl/project.bri
@@ -1,0 +1,35 @@
+import * as std from "std";
+
+export const project = {
+  name: "curl",
+  version: "8.8.0",
+};
+
+const source = std
+  .download({
+    url: `https://curl.se/download/curl-${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "77c0e1cd35ab5b45b659645a93b46d660224d0024f1185e8a95cdb27ae3d787d",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel()
+  .cast("directory");
+
+export default (): std.Recipe<std.Directory> => {
+  const curl = std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-openssl \\
+      --without-ca-bundle \\
+      --without-ca-path \\
+      --with-ca-fallback
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .cast("directory");
+
+  return std.withRunnableLink(curl, "bin/curl");
+};


### PR DESCRIPTION
This PR adds a new package for Curl, pretty self-explanatory!

Note that Curl does **not** provide CA certificates out of the box! Since the build sandbox doesn't (currently?) include CA certs from the host, you need to bring your own when using Curl in a build. The easiest way to do that is to use the `ca_certificates` package as a dependency as well:

```ts
import * as std from "std";
import curl from "curl";
import caCertificates from "ca_certificates";

export default () => {
  return std.runBash`
    curl -L 'https://example.com' -o "$BRIOCHE_OUTPUT"
  `
    .dependencies(curl(), caCertificates())
    .unsafe({ networking: true });
};

```