### PR TITLE
Add Node.js package (binary-only)

### DIFF
--- a/projects/nodejs/brioche.lock
+++ b/projects/nodejs/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/projects/nodejs/project.bri
+++ b/projects/nodejs/project.bri
@@ -1,0 +1,25 @@
+import * as std from "std";
+
+export const project = {
+  name: "nodejs",
+  version: "20.14.0",
+};
+
+export default (): std.Recipe<std.Directory> => {
+  let node = std
+    .download({
+      url: "https://nodejs.org/dist/v20.14.0/node-v20.14.0-linux-x64.tar.xz",
+      hash: std.sha256Hash(
+        "fedf8fa73b6f51c4ffcc5da8f86cd1ed381bc9dceae0829832c7d683a78b8e36",
+      ),
+    })
+    .unarchive("tar", "xz")
+    .peel()
+    .cast("directory");
+
+  node = std.autowrap(node, {
+    executables: ["bin/node"],
+  });
+
+  return std.withRunnableLink(node, "bin/node");
+};

--- a/projects/nodejs/project.bri
+++ b/projects/nodejs/project.bri
@@ -5,7 +5,7 @@ export const project = {
   version: "20.14.0",
 };
 
-export default (): std.Recipe<std.Directory> => {
+function nodejs(): std.Recipe<std.Directory> {
   let node = std
     .download({
       url: "https://nodejs.org/dist/v20.14.0/node-v20.14.0-linux-x64.tar.xz",
@@ -22,4 +22,18 @@ export default (): std.Recipe<std.Directory> => {
   });
 
   return std.withRunnableLink(node, "bin/node");
-};
+}
+export default nodejs;
+
+export function npmInstall(
+  pkg: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    npm clean-install
+  `
+    .dependencies(nodejs())
+    .outputScaffold(pkg)
+    .unsafe({ networking: true })
+    .cast("directory");
+}


### PR DESCRIPTION
This PR adds a new `nodejs` package.

- The default export can be used as a dependency, giving the `node` and `npm` binaries
- `nodejs.npmInstall()` takes an NPM package and downloads the dependencies while verifying the lockfile is up-to-date, returning the same package with a `node_modules` directory. It's effectively equivalent to running `npm install`.

This package does not currently build from source-- instead, it downloads and wraps an official Node.js binary. In the future, this will probably be replaced with a from-source build.

```ts
import * as std from "std";
import node, { npmInstall } from "nodejs";

export default () => {
  const npmPackage = npmInstall(
    Brioche.glob("package.json", "package-lock.json", "src"),
  );
  return std.runBash`
    node src/index.js
  `
    .workDir(npmPackage)
    .dependencies(node());
};
```