### PR TITLE
Add Rust package (binary-only)

### DIFF
--- a/projects/rust/brioche.lock
+++ b/projects/rust/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/projects/rust/project.bri
+++ b/projects/rust/project.bri
@@ -1,0 +1,106 @@
+import * as std from "std";
+import * as TOML from "smol_toml";
+import * as t from "typer";
+
+export const project = {
+  name: "rust",
+  version: "1.78.0",
+};
+
+const ManifestPkgTarget = t.discriminatedUnion("available", [
+  t.object({
+    available: t.literal(true),
+    hash: t.string(),
+    url: t.string(),
+  }),
+  t.object({
+    available: t.literal(false),
+  }),
+]);
+
+const ManifestPkg = t.object({
+  target: t.record(t.string(), ManifestPkgTarget),
+});
+
+const Manifest = t.object({
+  "manifest-version": t.literal("2"),
+  pkg: t.record(t.string(), ManifestPkg),
+  profiles: t.record(t.string(), t.array(t.string())),
+});
+
+export default async (): Promise<std.Recipe<std.Directory>> => {
+  const manifestToml = await std
+    .download({
+      url: "https://static.rust-lang.org/dist/channel-rust-1.78.0.toml",
+      hash: std.sha256Hash(
+        "a29520b3a7245100b20f1701f56cb9d69aa177430f1875156f044a28f1a2c195",
+      ),
+    })
+    .read();
+  const manifest = t.parse(Manifest, TOML.parse(manifestToml));
+
+  // TODO: Support other profiles
+  const profilePackages = manifest.profiles.minimal;
+  if (profilePackages === undefined) {
+    throw new Error("Rustup minimal profile not found");
+  }
+
+  let result = std.directory();
+  for (const pkgName of profilePackages) {
+    const pkg = manifest.pkg[pkgName];
+    if (pkg === undefined) {
+      throw new Error(`Rustup package ${pkgName} not found`);
+    }
+
+    const pkgTarget = pkg.target["x86_64-unknown-linux-gnu"];
+    if (pkgTarget?.available !== true) {
+      continue;
+    }
+
+    // FIXME: We unarchive within the process because unarchiving `rust-docs`
+    // fails for some reason
+    const pkgTargetArchive = std.download({
+      url: pkgTarget.url,
+      hash: std.sha256Hash(pkgTarget.hash),
+    });
+
+    const installedPkg = std.runBash`
+      tar -xf $pkgTargetArchive --strip-components=1
+      ./install.sh \\
+        --prefix="$BRIOCHE_OUTPUT" \\
+        --disable-ldconfig
+    `
+      .env({ pkgTargetArchive })
+      .cast("directory");
+
+    result = std.merge(result, installedPkg);
+  }
+
+  const localLibs = await std.runBash`
+    find lib -type f -name '*.so' -print0 > "$BRIOCHE_OUTPUT"
+  `
+    .workDir(result)
+    .cast("file")
+    .read()
+    .then((libs) => libs.split("\0").filter((lib) => lib !== ""));
+  const localLibNames = localLibs
+    .map((lib) => lib.split("/").at(-1))
+    .flatMap((name) => (name != null ? [name] : []));
+
+  result = std.autowrap(result, {
+    executables: [
+      "bin/cargo",
+      "bin/rustc",
+      "bin/rustdoc",
+      "libexec/rust-analyzer-proc-macro-srv",
+    ],
+    libraries: [std.tpl`${std.outputPath}/lib`],
+    skipLibraries: localLibNames,
+    runtimeLibraryDirs: ["../lib"],
+  });
+  result = std.autowrap(result, {
+    executables: ["lib/librustc_driver-d6f66a8619a171d6.so"],
+    libraries: [std.tpl`${std.outputPath}/lib`],
+  });
+  return result;
+};

--- a/projects/rust/project.bri
+++ b/projects/rust/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import * as TOML from "smol_toml";
 import * as t from "typer";
+import caCertificates from "ca_certificates";
 
 export const project = {
   name: "rust",
@@ -28,7 +29,7 @@ const Manifest = t.object({
   profiles: t.record(t.string(), t.array(t.string())),
 });
 
-export default async (): Promise<std.Recipe<std.Directory>> => {
+async function rust(): Promise<std.Recipe<std.Directory>> {
   const manifestToml = await std
     .download({
       url: "https://static.rust-lang.org/dist/channel-rust-1.78.0.toml",
@@ -103,4 +104,84 @@ export default async (): Promise<std.Recipe<std.Directory>> => {
     libraries: [std.tpl`${std.outputPath}/lib`],
   });
   return result;
-};
+}
+export default rust;
+
+export interface CargoInstallOptions {
+  crate: std.AsyncRecipe<std.Directory>;
+  toolchain?: std.AsyncRecipe<std.Directory>;
+  profile?: string;
+}
+
+export function cargoBuild(options: CargoInstallOptions) {
+  const toolchain = options.toolchain ?? std.toolchain();
+
+  // Create a skeleton crate so we have enough information to vendor the
+  // dependencies
+  const skeletonCrate = createSkeletonCrate(options.crate);
+
+  // Vendor the dependencies with network access and save the Cargo config.toml
+  // file, so the vendored dependencies are used
+  const vendoredSkeletonCrate = std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    mkdir -p .cargo
+    cargo vendor --locked >> .cargo/config.toml
+  `
+    .dependencies(rust(), caCertificates())
+    .outputScaffold(skeletonCrate)
+    .unsafe({ networking: true })
+    .cast("directory");
+
+  // Combine the original crate with the vendored dependencies
+  const crate = std.merge(vendoredSkeletonCrate, options.crate);
+
+  // Use `cargo install` to build and install the project to `$BRIOCHE_OUTPUT`
+  return std.runBash`
+    cargo install --path . --frozen
+  `
+    .dependencies(rust(), toolchain)
+    .env({
+      CARGO_INSTALL_ROOT: std.outputPath,
+      PATH: std.tpl`${std.outputPath}/bin`,
+    })
+    .workDir(crate)
+    .cast("directory");
+}
+
+/**
+ * Create a "skeleton crate" for a Rust crate. This is a crate that has
+ * the minimal set of files needed for Cargo to consider it a valid crate,
+ * namely so we can vendor dependencies. Without doing this, we would need
+ * to re-vendor the crates any time the source code changes!
+ */
+export function createSkeletonCrate(
+  crate: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  const recipe = std.runBash`
+    cargo chef prepare --recipe-path "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust(), cargoChef())
+    .workDir(crate)
+    .cast("file");
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    cargo chef cook --recipe-path "$recipe" --no-build
+  `
+    .dependencies(rust(), cargoChef())
+    .env({ recipe })
+    .outputScaffold(std.directory())
+    .cast("directory");
+}
+
+function cargoChef(): std.Recipe<std.Directory> {
+  const pkg = std.download({
+    url: "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
+    hash: std.sha256Hash(
+      "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc",
+    ),
+  });
+
+  return std.directory({
+    bin: pkg.unarchive("tar", "gzip"),
+  });
+}

--- a/projects/smol_toml/brioche.lock
+++ b/projects/smol_toml/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/projects/smol_toml/date.bri
+++ b/projects/smol_toml/date.bri
@@ -1,0 +1,147 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Hopefully this class will disappear once Temporal lands in JS
+// But for now we have to reinvent the wheel once more!
+
+type Offset = string | null;
+
+let DATE_TIME_RE =
+  /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
+
+export class TomlDate extends Date {
+  #hasDate = false;
+  #hasTime = false;
+  #offset: Offset = null;
+
+  constructor(date: string | Date) {
+    let hasDate = true;
+    let hasTime = true;
+    let offset: Offset = "Z";
+
+    if (typeof date === "string") {
+      let match = date.match(DATE_TIME_RE);
+      if (match) {
+        if (!match[1]) {
+          hasDate = false;
+          date = `0000-01-01T${date}`;
+        }
+
+        hasTime = !!match[2];
+        // Do not allow rollover hours
+        if (match[2] && +match[2] > 23) {
+          date = "";
+        } else {
+          offset = match[3] || null;
+          date = date.toUpperCase();
+          if (!offset && hasTime) date += "Z";
+        }
+      } else {
+        date = "";
+      }
+    }
+
+    super(date);
+    if (!isNaN(this.getTime())) {
+      this.#hasDate = hasDate;
+      this.#hasTime = hasTime;
+      this.#offset = offset;
+    }
+  }
+
+  isDateTime() {
+    return this.#hasDate && this.#hasTime;
+  }
+
+  isLocal() {
+    return !this.#hasDate || !this.#hasTime || !this.#offset;
+  }
+
+  isDate() {
+    return this.#hasDate && !this.#hasTime;
+  }
+
+  isTime() {
+    return this.#hasTime && !this.#hasDate;
+  }
+
+  isValid() {
+    return this.#hasDate || this.#hasTime;
+  }
+
+  override toISOString() {
+    let iso = super.toISOString();
+
+    // Local Date
+    if (this.isDate()) return iso.slice(0, 10);
+
+    // Local Time
+    if (this.isTime()) return iso.slice(11, 23);
+
+    // Local DateTime
+    if (this.#offset === null) return iso.slice(0, -1);
+
+    // Offset DateTime
+    if (this.#offset === "Z") return iso;
+
+    // This part is quite annoying: JS strips the original timezone from the ISO string representation
+    // Instead of using a "modified" date and "Z", we restore the representation "as authored"
+
+    let offset = +this.#offset.slice(1, 3) * 60 + +this.#offset.slice(4, 6);
+    offset = this.#offset[0] === "-" ? offset : -offset;
+
+    let offsetDate = new Date(this.getTime() - offset * 60e3);
+    return offsetDate.toISOString().slice(0, -1) + this.#offset;
+  }
+
+  static wrapAsOffsetDateTime(jsDate: Date, offset = "Z") {
+    let date = new TomlDate(jsDate);
+    date.#offset = offset;
+    return date;
+  }
+
+  static wrapAsLocalDateTime(jsDate: Date) {
+    let date = new TomlDate(jsDate);
+    date.#offset = null;
+    return date;
+  }
+
+  static wrapAsLocalDate(jsDate: Date) {
+    let date = new TomlDate(jsDate);
+    date.#hasTime = false;
+    date.#offset = null;
+    return date;
+  }
+
+  static wrapAsLocalTime(jsDate: Date) {
+    let date = new TomlDate(jsDate);
+    date.#hasDate = false;
+    date.#offset = null;
+    return date;
+  }
+}

--- a/projects/smol_toml/date.bri
+++ b/projects/smol_toml/date.bri
@@ -31,7 +31,7 @@
 
 type Offset = string | null;
 
-let DATE_TIME_RE =
+const DATE_TIME_RE =
   /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
 
 export class TomlDate extends Date {
@@ -45,21 +45,21 @@ export class TomlDate extends Date {
     let offset: Offset = "Z";
 
     if (typeof date === "string") {
-      let match = date.match(DATE_TIME_RE);
-      if (match) {
-        if (!match[1]) {
+      const match = date.match(DATE_TIME_RE);
+      if (match != null) {
+        if (match[1] == null || match[1] === "") {
           hasDate = false;
           date = `0000-01-01T${date}`;
         }
 
-        hasTime = !!match[2];
+        hasTime = match[2] != null && match[2] !== "";
         // Do not allow rollover hours
-        if (match[2] && +match[2] > 23) {
+        if (match[2] != null && match[2] !== "" && +match[2] > 23) {
           date = "";
         } else {
-          offset = match[3] || null;
+          offset = match[3] != null && match[3] !== "" ? match[3] : null;
           date = date.toUpperCase();
-          if (!offset && hasTime) date += "Z";
+          if (offset == null && hasTime) date += "Z";
         }
       } else {
         date = "";
@@ -79,7 +79,12 @@ export class TomlDate extends Date {
   }
 
   isLocal() {
-    return !this.#hasDate || !this.#hasTime || !this.#offset;
+    return (
+      !this.#hasDate ||
+      !this.#hasTime ||
+      this.#offset == null ||
+      this.#offset === ""
+    );
   }
 
   isDate() {
@@ -95,7 +100,7 @@ export class TomlDate extends Date {
   }
 
   override toISOString() {
-    let iso = super.toISOString();
+    const iso = super.toISOString();
 
     // Local Date
     if (this.isDate()) return iso.slice(0, 10);
@@ -113,33 +118,33 @@ export class TomlDate extends Date {
     // Instead of using a "modified" date and "Z", we restore the representation "as authored"
 
     let offset = +this.#offset.slice(1, 3) * 60 + +this.#offset.slice(4, 6);
-    offset = this.#offset[0] === "-" ? offset : -offset;
+    offset = this.#offset.startsWith("-") ? offset : -offset;
 
-    let offsetDate = new Date(this.getTime() - offset * 60e3);
+    const offsetDate = new Date(this.getTime() - offset * 60e3);
     return offsetDate.toISOString().slice(0, -1) + this.#offset;
   }
 
   static wrapAsOffsetDateTime(jsDate: Date, offset = "Z") {
-    let date = new TomlDate(jsDate);
+    const date = new TomlDate(jsDate);
     date.#offset = offset;
     return date;
   }
 
   static wrapAsLocalDateTime(jsDate: Date) {
-    let date = new TomlDate(jsDate);
+    const date = new TomlDate(jsDate);
     date.#offset = null;
     return date;
   }
 
   static wrapAsLocalDate(jsDate: Date) {
-    let date = new TomlDate(jsDate);
+    const date = new TomlDate(jsDate);
     date.#hasTime = false;
     date.#offset = null;
     return date;
   }
 
   static wrapAsLocalTime(jsDate: Date) {
-    let date = new TomlDate(jsDate);
+    const date = new TomlDate(jsDate);
     date.#hasDate = false;
     date.#offset = null;
     return date;

--- a/projects/smol_toml/error.bri
+++ b/projects/smol_toml/error.bri
@@ -1,0 +1,77 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+type TomlErrorOptions = ErrorOptions & {
+  toml: string;
+  ptr: number;
+};
+
+function getLineColFromPtr(string: string, ptr: number): [number, number] {
+  let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
+  return [lines.length, lines.pop()!.length + 1];
+}
+
+function makeCodeBlock(string: string, line: number, column: number) {
+  let lines = string.split(/\r\n|\n|\r/g);
+  let codeblock = "";
+
+  let numberLen = (Math.log10(line + 1) | 0) + 1;
+
+  for (let i = line - 1; i <= line + 1; i++) {
+    let l = lines[i - 1];
+    if (!l) continue;
+
+    codeblock += i.toString().padEnd(numberLen, " ");
+    codeblock += ":  ";
+    codeblock += l;
+    codeblock += "\n";
+
+    if (i === line) {
+      codeblock += " ".repeat(numberLen + column + 2);
+      codeblock += "^\n";
+    }
+  }
+
+  return codeblock;
+}
+
+export class TomlError extends Error {
+  line: number;
+  column: number;
+  codeblock: string;
+
+  constructor(message: string, options: TomlErrorOptions) {
+    const [line, column] = getLineColFromPtr(options.toml, options.ptr);
+    const codeblock = makeCodeBlock(options.toml, line, column);
+
+    super(`Invalid TOML document: ${message}\n\n${codeblock}`, options);
+    this.line = line;
+    this.column = column;
+    this.codeblock = codeblock;
+  }
+}

--- a/projects/smol_toml/error.bri
+++ b/projects/smol_toml/error.bri
@@ -32,19 +32,19 @@ type TomlErrorOptions = ErrorOptions & {
 };
 
 function getLineColFromPtr(string: string, ptr: number): [number, number] {
-  let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
-  return [lines.length, lines.pop()!.length + 1];
+  const lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
+  return [lines.length, (lines.pop() as string).length + 1];
 }
 
 function makeCodeBlock(string: string, line: number, column: number) {
-  let lines = string.split(/\r\n|\n|\r/g);
+  const lines = string.split(/\r\n|\n|\r/g);
   let codeblock = "";
 
-  let numberLen = (Math.log10(line + 1) | 0) + 1;
+  const numberLen = (Math.log10(line + 1) | 0) + 1;
 
   for (let i = line - 1; i <= line + 1; i++) {
-    let l = lines[i - 1];
-    if (!l) continue;
+    const l = lines[i - 1];
+    if (l == null || l === "") continue;
 
     codeblock += i.toString().padEnd(numberLen, " ");
     codeblock += ":  ";

--- a/projects/smol_toml/extract.bri
+++ b/projects/smol_toml/extract.bri
@@ -46,7 +46,7 @@ function sliceAndTrimEndOf(
 ): [string, number] {
   let value = str.slice(startPtr, endPtr);
 
-  let commentIdx = value.indexOf("#");
+  const commentIdx = value.indexOf("#");
   if (commentIdx > -1) {
     // The call to skipComment allows to "validate" the comment
     // (absence of control characters)
@@ -54,10 +54,10 @@ function sliceAndTrimEndOf(
     value = value.slice(0, commentIdx);
   }
 
-  let trimmed = value.trimEnd();
+  const trimmed = value.trimEnd();
 
-  if (!allowNewLines) {
-    let newlineIdx = value.indexOf("\n", trimmed.length);
+  if (allowNewLines !== true) {
+    const newlineIdx = value.indexOf("\n", trimmed.length);
     if (newlineIdx > -1) {
       throw new TomlError("newlines are not allowed in inline tables", {
         toml: str,
@@ -74,14 +74,14 @@ export function extractValue(
   ptr: number,
   end?: string,
 ): [TomlPrimitive, number] {
-  let c = str[ptr];
+  const c = str[ptr];
   if (c === "[" || c === "{") {
-    let [value, endPtr] =
+    const [value, endPtr] =
       c === "[" ? parseArray(str, ptr) : parseInlineTable(str, ptr);
 
-    let newPtr = skipUntil(str, endPtr, ",", end);
+    const newPtr = skipUntil(str, endPtr, ",", end);
     if (end === "}") {
-      let nextNewLine = indexOfNewline(str, endPtr, newPtr);
+      const nextNewLine = indexOfNewline(str, endPtr, newPtr);
       if (nextNewLine > -1) {
         throw new TomlError("newlines are not allowed in inline tables", {
           toml: str,
@@ -96,12 +96,13 @@ export function extractValue(
   let endPtr;
   if (c === '"' || c === "'") {
     endPtr = getStringEnd(str, ptr);
-    let parsed = parseString(str, ptr, endPtr);
-    if (end) {
+    const parsed = parseString(str, ptr, endPtr);
+    if (end != null && end !== "") {
       endPtr = skipVoid(str, endPtr, end !== "]");
 
       if (
-        str[endPtr] &&
+        str[endPtr] != null &&
+        str[endPtr] !== "" &&
         str[endPtr] !== "," &&
         str[endPtr] !== end &&
         str[endPtr] !== "\n" &&
@@ -120,13 +121,13 @@ export function extractValue(
   }
 
   endPtr = skipUntil(str, ptr, ",", end);
-  let slice = sliceAndTrimEndOf(
+  const slice = sliceAndTrimEndOf(
     str,
     ptr,
     endPtr - +(str[endPtr - 1] === ","),
     end === "]",
   );
-  if (!slice[0]) {
+  if ((slice[0] as unknown) == null) {
     throw new TomlError(
       "incomplete key-value declaration: no value specified",
       {
@@ -136,7 +137,7 @@ export function extractValue(
     );
   }
 
-  if (end && slice[1] > -1) {
+  if (end != null && end !== "" && slice[1] > -1) {
     endPtr = skipVoid(str, ptr + slice[1]);
     endPtr += +(str[endPtr] === ",");
   }

--- a/projects/smol_toml/extract.bri
+++ b/projects/smol_toml/extract.bri
@@ -1,0 +1,145 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { parseString, parseValue } from "./primitive.bri";
+import { parseArray, parseInlineTable } from "./struct.bri";
+import {
+  type TomlPrimitive,
+  indexOfNewline,
+  skipVoid,
+  skipUntil,
+  skipComment,
+  getStringEnd,
+} from "./util.bri";
+import { TomlError } from "./error.bri";
+
+function sliceAndTrimEndOf(
+  str: string,
+  startPtr: number,
+  endPtr: number,
+  allowNewLines?: boolean,
+): [string, number] {
+  let value = str.slice(startPtr, endPtr);
+
+  let commentIdx = value.indexOf("#");
+  if (commentIdx > -1) {
+    // The call to skipComment allows to "validate" the comment
+    // (absence of control characters)
+    skipComment(str, commentIdx);
+    value = value.slice(0, commentIdx);
+  }
+
+  let trimmed = value.trimEnd();
+
+  if (!allowNewLines) {
+    let newlineIdx = value.indexOf("\n", trimmed.length);
+    if (newlineIdx > -1) {
+      throw new TomlError("newlines are not allowed in inline tables", {
+        toml: str,
+        ptr: startPtr + newlineIdx,
+      });
+    }
+  }
+
+  return [trimmed, commentIdx];
+}
+
+export function extractValue(
+  str: string,
+  ptr: number,
+  end?: string,
+): [TomlPrimitive, number] {
+  let c = str[ptr];
+  if (c === "[" || c === "{") {
+    let [value, endPtr] =
+      c === "[" ? parseArray(str, ptr) : parseInlineTable(str, ptr);
+
+    let newPtr = skipUntil(str, endPtr, ",", end);
+    if (end === "}") {
+      let nextNewLine = indexOfNewline(str, endPtr, newPtr);
+      if (nextNewLine > -1) {
+        throw new TomlError("newlines are not allowed in inline tables", {
+          toml: str,
+          ptr: nextNewLine,
+        });
+      }
+    }
+
+    return [value, newPtr];
+  }
+
+  let endPtr;
+  if (c === '"' || c === "'") {
+    endPtr = getStringEnd(str, ptr);
+    let parsed = parseString(str, ptr, endPtr);
+    if (end) {
+      endPtr = skipVoid(str, endPtr, end !== "]");
+
+      if (
+        str[endPtr] &&
+        str[endPtr] !== "," &&
+        str[endPtr] !== end &&
+        str[endPtr] !== "\n" &&
+        str[endPtr] !== "\r"
+      ) {
+        throw new TomlError("unexpected character encountered", {
+          toml: str,
+          ptr: endPtr,
+        });
+      }
+
+      endPtr += +(str[endPtr] === ",");
+    }
+
+    return [parsed, endPtr];
+  }
+
+  endPtr = skipUntil(str, ptr, ",", end);
+  let slice = sliceAndTrimEndOf(
+    str,
+    ptr,
+    endPtr - +(str[endPtr - 1] === ","),
+    end === "]",
+  );
+  if (!slice[0]) {
+    throw new TomlError(
+      "incomplete key-value declaration: no value specified",
+      {
+        toml: str,
+        ptr: ptr,
+      },
+    );
+  }
+
+  if (end && slice[1] > -1) {
+    endPtr = skipVoid(str, ptr + slice[1]);
+    endPtr += +(str[endPtr] === ",");
+  }
+
+  return [parseValue(slice[0], str, ptr), endPtr];
+}

--- a/projects/smol_toml/index.bri
+++ b/projects/smol_toml/index.bri
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export { TomlError } from "./error.bri";
+export { TomlDate } from "./date.bri";
+
+export { parse } from "./parse.bri";
+export { stringify } from "./stringify.bri";
+
+export type { TomlPrimitive } from "./util.bri";

--- a/projects/smol_toml/parse.bri
+++ b/projects/smol_toml/parse.bri
@@ -1,0 +1,212 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { parseKey } from "./struct.bri";
+import { extractValue } from "./extract.bri";
+import { type TomlPrimitive, skipVoid } from "./util.bri";
+import { TomlError } from "./error.bri";
+
+const enum Type {
+  DOTTED,
+  EXPLICIT,
+  ARRAY,
+  ARRAY_DOTTED,
+}
+
+type MetaState = { t: Type; d: boolean; i: number; c: MetaRecord };
+type MetaRecord = { [k: string]: MetaState };
+type PeekResult = [string, Record<string, TomlPrimitive>, MetaRecord] | null;
+
+function peekTable(
+  key: string[],
+  table: Record<string, TomlPrimitive>,
+  meta: MetaRecord,
+  type: Type,
+): PeekResult {
+  let t: any = table;
+  let m = meta;
+  let k: string;
+  let hasOwn = false;
+  let state: MetaState;
+
+  for (let i = 0; i < key.length; i++) {
+    if (i) {
+      t = hasOwn! ? t[k!] : (t[k!] = {});
+      m = (state = m[k!]!).c;
+
+      if (
+        type === Type.DOTTED &&
+        (state.t === Type.EXPLICIT || state.t === Type.ARRAY)
+      ) {
+        return null;
+      }
+
+      if (state.t === Type.ARRAY) {
+        let l = t.length - 1;
+        t = t[l];
+        m = m[l]!.c;
+      }
+    }
+
+    k = key[i]!;
+    if ((hasOwn = Object.hasOwn(t, k)) && m[k]?.t === Type.DOTTED && m[k]?.d) {
+      return null;
+    }
+
+    if (!hasOwn) {
+      if (k === "__proto__") {
+        Object.defineProperty(t, k, {
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+        Object.defineProperty(m, k, {
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+
+      m[k] = {
+        t: i < key.length - 1 && type === Type.ARRAY ? Type.ARRAY_DOTTED : type,
+        d: false,
+        i: 0,
+        c: {},
+      };
+    }
+  }
+
+  state = m[k!]!;
+  if (
+    state.t !== type &&
+    !(type === Type.EXPLICIT && state.t === Type.ARRAY_DOTTED)
+  ) {
+    // Bad key type!
+    return null;
+  }
+
+  if (type === Type.ARRAY) {
+    if (!state.d) {
+      state.d = true;
+      t[k!] = [];
+    }
+
+    t[k!].push((t = {}));
+    state.c[state.i++] = state = { t: Type.EXPLICIT, d: false, i: 0, c: {} };
+  }
+
+  if (state.d) {
+    // Redefining a table!
+    return null;
+  }
+
+  state.d = true;
+  if (type === Type.EXPLICIT) {
+    t = hasOwn ? t[k!] : (t[k!] = {});
+  } else if (type === Type.DOTTED && hasOwn) {
+    return null;
+  }
+
+  return [k!, t, state.c];
+}
+
+export function parse(toml: string): Record<string, TomlPrimitive> {
+  let res = {};
+  let meta = {};
+
+  let tbl = res;
+  let m = meta;
+
+  for (let ptr = skipVoid(toml, 0); ptr < toml.length; ) {
+    if (toml[ptr] === "[") {
+      let isTableArray = toml[++ptr] === "[";
+      let k = parseKey(toml, (ptr += +isTableArray), "]");
+
+      if (isTableArray) {
+        if (toml[k[1] - 1] !== "]") {
+          throw new TomlError("expected end of table declaration", {
+            toml: toml,
+            ptr: k[1] - 1,
+          });
+        }
+
+        k[1]++;
+      }
+
+      let p = peekTable(
+        k[0],
+        res,
+        meta,
+        isTableArray ? Type.ARRAY : Type.EXPLICIT,
+      );
+      if (!p) {
+        throw new TomlError(
+          "trying to redefine an already defined table or value",
+          {
+            toml: toml,
+            ptr: ptr,
+          },
+        );
+      }
+
+      m = p[2];
+      tbl = p[1];
+      ptr = k[1];
+    } else {
+      let k = parseKey(toml, ptr);
+      let p = peekTable(k[0], tbl, m, Type.DOTTED);
+      if (!p) {
+        throw new TomlError(
+          "trying to redefine an already defined table or value",
+          {
+            toml: toml,
+            ptr: ptr,
+          },
+        );
+      }
+
+      let v = extractValue(toml, k[1]);
+      p[1][p[0]] = v[0];
+      ptr = v[1];
+    }
+
+    ptr = skipVoid(toml, ptr, true);
+    if (toml[ptr] && toml[ptr] !== "\n" && toml[ptr] !== "\r") {
+      throw new TomlError(
+        "each key-value declaration must be followed by an end-of-line",
+        {
+          toml: toml,
+          ptr: ptr,
+        },
+      );
+    }
+    ptr = skipVoid(toml, ptr);
+  }
+
+  return res;
+}

--- a/projects/smol_toml/parse.bri
+++ b/projects/smol_toml/parse.bri
@@ -50,14 +50,14 @@ function peekTable(
 ): PeekResult {
   let t: any = table;
   let m = meta;
-  let k: string;
+  let k: string | undefined = undefined;
   let hasOwn = false;
   let state: MetaState;
 
   for (let i = 0; i < key.length; i++) {
-    if (i) {
-      t = hasOwn! ? t[k!] : (t[k!] = {});
-      m = (state = m[k!]!).c;
+    if (i !== 0) {
+      t = hasOwn ? t[k as string] : (t[k as string] = {});
+      m = (state = m[k as string] as MetaState).c;
 
       if (
         type === Type.DOTTED &&
@@ -67,14 +67,18 @@ function peekTable(
       }
 
       if (state.t === Type.ARRAY) {
-        let l = t.length - 1;
+        const l = t.length - 1;
         t = t[l];
-        m = m[l]!.c;
+        m = (m[l] as MetaState).c;
       }
     }
 
-    k = key[i]!;
-    if ((hasOwn = Object.hasOwn(t, k)) && m[k]?.t === Type.DOTTED && m[k]?.d) {
+    k = key[i] as string;
+    if (
+      (hasOwn = Object.hasOwn(t, k)) &&
+      m[k]?.t === Type.DOTTED &&
+      m[k]?.d === true
+    ) {
       return null;
     }
 
@@ -101,7 +105,7 @@ function peekTable(
     }
   }
 
-  state = m[k!]!;
+  state = m[k as string] as MetaState;
   if (
     state.t !== type &&
     !(type === Type.EXPLICIT && state.t === Type.ARRAY_DOTTED)
@@ -113,10 +117,10 @@ function peekTable(
   if (type === Type.ARRAY) {
     if (!state.d) {
       state.d = true;
-      t[k!] = [];
+      t[k as string] = [];
     }
 
-    t[k!].push((t = {}));
+    t[k as string].push((t = {}));
     state.c[state.i++] = state = { t: Type.EXPLICIT, d: false, i: 0, c: {} };
   }
 
@@ -127,25 +131,25 @@ function peekTable(
 
   state.d = true;
   if (type === Type.EXPLICIT) {
-    t = hasOwn ? t[k!] : (t[k!] = {});
+    t = hasOwn ? t[k as string] : (t[k as string] = {});
   } else if (type === Type.DOTTED && hasOwn) {
     return null;
   }
 
-  return [k!, t, state.c];
+  return [k as string, t, state.c];
 }
 
 export function parse(toml: string): Record<string, TomlPrimitive> {
-  let res = {};
-  let meta = {};
+  const res = {};
+  const meta = {};
 
   let tbl = res;
   let m = meta;
 
   for (let ptr = skipVoid(toml, 0); ptr < toml.length; ) {
     if (toml[ptr] === "[") {
-      let isTableArray = toml[++ptr] === "[";
-      let k = parseKey(toml, (ptr += +isTableArray), "]");
+      const isTableArray = toml[++ptr] === "[";
+      const k = parseKey(toml, (ptr += +isTableArray), "]");
 
       if (isTableArray) {
         if (toml[k[1] - 1] !== "]") {
@@ -158,13 +162,13 @@ export function parse(toml: string): Record<string, TomlPrimitive> {
         k[1]++;
       }
 
-      let p = peekTable(
+      const p = peekTable(
         k[0],
         res,
         meta,
         isTableArray ? Type.ARRAY : Type.EXPLICIT,
       );
-      if (!p) {
+      if (p == null) {
         throw new TomlError(
           "trying to redefine an already defined table or value",
           {
@@ -178,9 +182,9 @@ export function parse(toml: string): Record<string, TomlPrimitive> {
       tbl = p[1];
       ptr = k[1];
     } else {
-      let k = parseKey(toml, ptr);
-      let p = peekTable(k[0], tbl, m, Type.DOTTED);
-      if (!p) {
+      const k = parseKey(toml, ptr);
+      const p = peekTable(k[0], tbl, m, Type.DOTTED);
+      if (p == null) {
         throw new TomlError(
           "trying to redefine an already defined table or value",
           {
@@ -190,13 +194,13 @@ export function parse(toml: string): Record<string, TomlPrimitive> {
         );
       }
 
-      let v = extractValue(toml, k[1]);
+      const v = extractValue(toml, k[1]);
       p[1][p[0]] = v[0];
       ptr = v[1];
     }
 
     ptr = skipVoid(toml, ptr, true);
-    if (toml[ptr] && toml[ptr] !== "\n" && toml[ptr] !== "\r") {
+    if (toml[ptr] != null && toml[ptr] !== "\n" && toml[ptr] !== "\r") {
       throw new TomlError(
         "each key-value declaration must be followed by an end-of-line",
         {

--- a/projects/smol_toml/primitive.bri
+++ b/projects/smol_toml/primitive.bri
@@ -30,12 +30,13 @@ import { skipVoid } from "./util.bri";
 import { TomlDate } from "./date.bri";
 import { TomlError } from "./error.bri";
 
-let INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
-let FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
-let LEADING_ZERO = /^[+-]?0[0-9_]/;
-let ESCAPE_REGEX = /^[0-9a-f]{4,8}$/i;
+const INT_REGEX =
+  /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
+const FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
+const LEADING_ZERO = /^[+-]?0[0-9_]/;
+const ESCAPE_REGEX = /^[0-9a-f]{4,8}$/i;
 
-let ESC_MAP = {
+const ESC_MAP = {
   b: "\b",
   t: "\t",
   n: "\n",
@@ -46,8 +47,8 @@ let ESC_MAP = {
 };
 
 export function parseString(str: string, ptr = 0, endPtr = str.length): string {
-  let isLiteral = str[ptr] === "'";
-  let isMultiline = str[ptr++] === str[ptr] && str[ptr] === str[ptr + 1];
+  const isLiteral = str[ptr] === "'";
+  const isMultiline = str[ptr++] === str[ptr] && str[ptr] === str[ptr + 1];
 
   if (isMultiline) {
     endPtr -= 2;
@@ -60,7 +61,7 @@ export function parseString(str: string, ptr = 0, endPtr = str.length): string {
   let parsed = "";
   let sliceStart = ptr;
   while (ptr < endPtr - 1) {
-    let c = str[ptr++]!;
+    const c = str[ptr++] as string;
     if (c === "\n" || (c === "\r" && str[ptr] === "\n")) {
       if (!isMultiline) {
         throw new TomlError("newlines are not allowed in strings", {
@@ -75,11 +76,11 @@ export function parseString(str: string, ptr = 0, endPtr = str.length): string {
       });
     }
 
-    if (isEscape) {
+    if (isEscape === true) {
       isEscape = false;
       if (c === "u" || c === "U") {
         // Unicode escape
-        let code = str.slice(ptr, (ptr += c === "u" ? 4 : 8));
+        const code = str.slice(ptr, (ptr += c === "u" ? 4 : 8));
         if (!ESCAPE_REGEX.test(code)) {
           throw new TomlError("invalid unicode escape", {
             toml: str,
@@ -156,7 +157,7 @@ export function parseValue(
       });
     }
 
-    let numeric = +value.replace(/_/g, "");
+    const numeric = +value.replace(/_/g, "");
     if (isNaN(numeric)) {
       throw new TomlError("invalid number", {
         toml: toml,
@@ -174,7 +175,7 @@ export function parseValue(
     return numeric;
   }
 
-  let date = new TomlDate(value);
+  const date = new TomlDate(value);
   if (!date.isValid()) {
     throw new TomlError("invalid value", {
       toml: toml,

--- a/projects/smol_toml/primitive.bri
+++ b/projects/smol_toml/primitive.bri
@@ -1,0 +1,186 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { skipVoid } from "./util.bri";
+import { TomlDate } from "./date.bri";
+import { TomlError } from "./error.bri";
+
+let INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
+let FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
+let LEADING_ZERO = /^[+-]?0[0-9_]/;
+let ESCAPE_REGEX = /^[0-9a-f]{4,8}$/i;
+
+let ESC_MAP = {
+  b: "\b",
+  t: "\t",
+  n: "\n",
+  f: "\f",
+  r: "\r",
+  '"': '"',
+  "\\": "\\",
+};
+
+export function parseString(str: string, ptr = 0, endPtr = str.length): string {
+  let isLiteral = str[ptr] === "'";
+  let isMultiline = str[ptr++] === str[ptr] && str[ptr] === str[ptr + 1];
+
+  if (isMultiline) {
+    endPtr -= 2;
+    if (str[(ptr += 2)] === "\r") ptr++;
+    if (str[ptr] === "\n") ptr++;
+  }
+
+  let tmp = 0;
+  let isEscape;
+  let parsed = "";
+  let sliceStart = ptr;
+  while (ptr < endPtr - 1) {
+    let c = str[ptr++]!;
+    if (c === "\n" || (c === "\r" && str[ptr] === "\n")) {
+      if (!isMultiline) {
+        throw new TomlError("newlines are not allowed in strings", {
+          toml: str,
+          ptr: ptr - 1,
+        });
+      }
+    } else if ((c < "\x20" && c !== "\t") || c === "\x7f") {
+      throw new TomlError("control characters are not allowed in strings", {
+        toml: str,
+        ptr: ptr - 1,
+      });
+    }
+
+    if (isEscape) {
+      isEscape = false;
+      if (c === "u" || c === "U") {
+        // Unicode escape
+        let code = str.slice(ptr, (ptr += c === "u" ? 4 : 8));
+        if (!ESCAPE_REGEX.test(code)) {
+          throw new TomlError("invalid unicode escape", {
+            toml: str,
+            ptr: tmp,
+          });
+        }
+
+        try {
+          parsed += String.fromCodePoint(parseInt(code, 16));
+        } catch {
+          throw new TomlError("invalid unicode escape", {
+            toml: str,
+            ptr: tmp,
+          });
+        }
+      } else if (
+        isMultiline &&
+        (c === "\n" || c === " " || c === "\t" || c === "\r")
+      ) {
+        // Multiline escape
+        ptr = skipVoid(str, ptr - 1, true);
+        if (str[ptr] !== "\n" && str[ptr] !== "\r") {
+          throw new TomlError(
+            "invalid escape: only line-ending whitespace may be escaped",
+            {
+              toml: str,
+              ptr: tmp,
+            },
+          );
+        }
+        ptr = skipVoid(str, ptr);
+      } else if (c in ESC_MAP) {
+        // Classic escape
+        parsed += ESC_MAP[c as keyof typeof ESC_MAP];
+      } else {
+        throw new TomlError("unrecognized escape sequence", {
+          toml: str,
+          ptr: tmp,
+        });
+      }
+
+      sliceStart = ptr;
+    } else if (!isLiteral && c === "\\") {
+      tmp = ptr - 1;
+      isEscape = true;
+      parsed += str.slice(sliceStart, tmp);
+    }
+  }
+
+  return parsed + str.slice(sliceStart, endPtr - 1);
+}
+
+export function parseValue(
+  value: string,
+  toml: string,
+  ptr: number,
+): boolean | number | TomlDate {
+  // Constant values
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "-inf") return -Infinity;
+  if (value === "inf" || value === "+inf") return Infinity;
+  if (value === "nan" || value === "+nan" || value === "-nan") return NaN;
+
+  if (value === "-0") return 0; // Avoid FP representation of -0
+
+  // Numbers
+  let isInt;
+  if ((isInt = INT_REGEX.test(value)) || FLOAT_REGEX.test(value)) {
+    if (LEADING_ZERO.test(value)) {
+      throw new TomlError("leading zeroes are not allowed", {
+        toml: toml,
+        ptr: ptr,
+      });
+    }
+
+    let numeric = +value.replace(/_/g, "");
+    if (isNaN(numeric)) {
+      throw new TomlError("invalid number", {
+        toml: toml,
+        ptr: ptr,
+      });
+    }
+
+    if (isInt && !Number.isSafeInteger(numeric)) {
+      throw new TomlError("integer value cannot be represented losslessly", {
+        toml: toml,
+        ptr: ptr,
+      });
+    }
+
+    return numeric;
+  }
+
+  let date = new TomlDate(value);
+  if (!date.isValid()) {
+    throw new TomlError("invalid value", {
+      toml: toml,
+      ptr: ptr,
+    });
+  }
+
+  return date;
+}

--- a/projects/smol_toml/project.bri
+++ b/projects/smol_toml/project.bri
@@ -1,0 +1,26 @@
+/**
+ * This is a manually vendored version of the `smol-toml` NPM package,
+ * used for parsing TOML files. It has been tweaked slightly to be packaged
+ * in Brioche.
+ */
+
+export * from "./index.bri";
+
+export const projcet = {
+  name: "smol_toml",
+  version: "1.2.0",
+};
+
+// HACK: This default export is a workaround so that `brioche build -p ./smol_toml`
+// will not error out, which is used in CI/CD. This will be removed
+// eventually.
+export default function (): never {
+  return {
+    briocheSerialize: () => {
+      return {
+        type: "directory",
+        entries: {},
+      };
+    },
+  } as any as never;
+}

--- a/projects/smol_toml/stringify.bri
+++ b/projects/smol_toml/stringify.bri
@@ -29,7 +29,7 @@
 const BARE_KEY = /^[a-z0-9-_]+$/i;
 
 function extendedTypeOf(obj: any) {
-  let type = typeof obj;
+  const type = typeof obj;
   if (type === "object") {
     if (Array.isArray(obj)) return "array";
     if (obj instanceof Date) return "date";
@@ -39,11 +39,11 @@ function extendedTypeOf(obj: any) {
 }
 
 function isArrayOfTables(obj: any[]) {
-  for (let i = 0; i < obj.length; i++) {
-    if (extendedTypeOf(obj[i]) !== "object") return false;
+  for (const element of obj) {
+    if (extendedTypeOf(element) !== "object") return false;
   }
 
-  return obj.length != 0;
+  return obj.length !== 0;
 }
 
 function formatString(s: string) {
@@ -84,13 +84,13 @@ function stringifyValue(val: any, type = extendedTypeOf(val)) {
 }
 
 function stringifyInlineTable(obj: any) {
-  let keys = Object.keys(obj);
+  const keys = Object.keys(obj);
   if (keys.length === 0) return "{}";
 
   let res = "{ ";
   for (let i = 0; i < keys.length; i++) {
-    let k = keys[i]!;
-    if (i) res += ", ";
+    const k = keys[i] as string;
+    if (i !== 0) res += ", ";
 
     res += BARE_KEY.test(k) ? k : formatString(k);
     res += " = ";
@@ -105,7 +105,7 @@ function stringifyArray(array: any[]) {
 
   let res = "[ ";
   for (let i = 0; i < array.length; i++) {
-    if (i) res += ", ";
+    if (i !== 0) res += ", ";
     if (array[i] === null || array[i] === void 0) {
       throw new TypeError("arrays cannot contain null or undefined values");
     }
@@ -118,9 +118,9 @@ function stringifyArray(array: any[]) {
 
 function stringifyArrayTable(array: any[], key: string) {
   let res = "";
-  for (let i = 0; i < array.length; i++) {
+  for (const element of array) {
     res += `[[${key}]]\n`;
-    res += stringifyTable(array[i], key);
+    res += stringifyTable(element, key);
     res += "\n\n";
   }
 
@@ -131,24 +131,23 @@ function stringifyTable(obj: any, prefix = "") {
   let preamble = "";
   let tables = "";
 
-  let keys = Object.keys(obj);
-  for (let i = 0; i < keys.length; i++) {
-    let k = keys[i]!;
+  const keys = Object.keys(obj);
+  for (const k of keys) {
     if (obj[k] !== null && obj[k] !== void 0) {
-      let type = extendedTypeOf(obj[k]);
+      const type = extendedTypeOf(obj[k]);
       if (type === "symbol" || type === "function") {
         throw new TypeError(`cannot serialize values of type '${type}'`);
       }
 
-      let key = BARE_KEY.test(k) ? k : formatString(k);
+      const key = BARE_KEY.test(k) ? k : formatString(k);
 
       if (type === "array" && isArrayOfTables(obj[k])) {
         tables += stringifyArrayTable(
           obj[k],
-          prefix ? `${prefix}.${key}` : key,
+          prefix !== "" ? `${prefix}.${key}` : key,
         );
       } else if (type === "object") {
-        let tblKey = prefix ? `${prefix}.${key}` : key;
+        const tblKey = prefix !== "" ? `${prefix}.${key}` : key;
         tables += `[${tblKey}]\n`;
         tables += stringifyTable(obj[k], tblKey);
         tables += "\n\n";

--- a/projects/smol_toml/stringify.bri
+++ b/projects/smol_toml/stringify.bri
@@ -1,0 +1,173 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const BARE_KEY = /^[a-z0-9-_]+$/i;
+
+function extendedTypeOf(obj: any) {
+  let type = typeof obj;
+  if (type === "object") {
+    if (Array.isArray(obj)) return "array";
+    if (obj instanceof Date) return "date";
+  }
+
+  return type;
+}
+
+function isArrayOfTables(obj: any[]) {
+  for (let i = 0; i < obj.length; i++) {
+    if (extendedTypeOf(obj[i]) !== "object") return false;
+  }
+
+  return obj.length != 0;
+}
+
+function formatString(s: string) {
+  return JSON.stringify(s).replace(/\x7f/g, "\\u007f");
+}
+
+function stringifyValue(val: any, type = extendedTypeOf(val)) {
+  if (type === "number") {
+    if (isNaN(val)) return "nan";
+    if (val === Infinity) return "inf";
+    if (val === -Infinity) return "-inf";
+    return val.toString();
+  }
+
+  if (type === "bigint" || type === "boolean") {
+    return val.toString();
+  }
+
+  if (type === "string") {
+    return formatString(val);
+  }
+
+  if (type === "date") {
+    if (isNaN(val.getTime())) {
+      throw new TypeError("cannot serialize invalid date");
+    }
+
+    return val.toISOString();
+  }
+
+  if (type === "object") {
+    return stringifyInlineTable(val);
+  }
+
+  if (type === "array") {
+    return stringifyArray(val);
+  }
+}
+
+function stringifyInlineTable(obj: any) {
+  let keys = Object.keys(obj);
+  if (keys.length === 0) return "{}";
+
+  let res = "{ ";
+  for (let i = 0; i < keys.length; i++) {
+    let k = keys[i]!;
+    if (i) res += ", ";
+
+    res += BARE_KEY.test(k) ? k : formatString(k);
+    res += " = ";
+    res += stringifyValue(obj[k]);
+  }
+
+  return res + " }";
+}
+
+function stringifyArray(array: any[]) {
+  if (array.length === 0) return "[]";
+
+  let res = "[ ";
+  for (let i = 0; i < array.length; i++) {
+    if (i) res += ", ";
+    if (array[i] === null || array[i] === void 0) {
+      throw new TypeError("arrays cannot contain null or undefined values");
+    }
+
+    res += stringifyValue(array[i]);
+  }
+
+  return res + " ]";
+}
+
+function stringifyArrayTable(array: any[], key: string) {
+  let res = "";
+  for (let i = 0; i < array.length; i++) {
+    res += `[[${key}]]\n`;
+    res += stringifyTable(array[i], key);
+    res += "\n\n";
+  }
+
+  return res;
+}
+
+function stringifyTable(obj: any, prefix = "") {
+  let preamble = "";
+  let tables = "";
+
+  let keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i++) {
+    let k = keys[i]!;
+    if (obj[k] !== null && obj[k] !== void 0) {
+      let type = extendedTypeOf(obj[k]);
+      if (type === "symbol" || type === "function") {
+        throw new TypeError(`cannot serialize values of type '${type}'`);
+      }
+
+      let key = BARE_KEY.test(k) ? k : formatString(k);
+
+      if (type === "array" && isArrayOfTables(obj[k])) {
+        tables += stringifyArrayTable(
+          obj[k],
+          prefix ? `${prefix}.${key}` : key,
+        );
+      } else if (type === "object") {
+        let tblKey = prefix ? `${prefix}.${key}` : key;
+        tables += `[${tblKey}]\n`;
+        tables += stringifyTable(obj[k], tblKey);
+        tables += "\n\n";
+      } else {
+        preamble += key;
+        preamble += " = ";
+        preamble += stringifyValue(obj[k], type);
+        preamble += "\n";
+      }
+    }
+  }
+
+  return `${preamble}\n${tables}`.trim();
+}
+
+export function stringify(obj: any) {
+  if (extendedTypeOf(obj) !== "object") {
+    throw new TypeError("stringify can only be called with an object");
+  }
+
+  return stringifyTable(obj);
+}

--- a/projects/smol_toml/struct.bri
+++ b/projects/smol_toml/struct.bri
@@ -1,0 +1,253 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { parseString } from "./primitive.bri";
+import { extractValue } from "./extract.bri";
+import {
+  type TomlPrimitive,
+  skipComment,
+  indexOfNewline,
+  getStringEnd,
+  skipVoid,
+} from "./util.bri";
+import { TomlError } from "./error.bri";
+
+let KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
+
+export function parseKey(
+  str: string,
+  ptr: number,
+  end = "=",
+): [string[], number] {
+  let dot = ptr - 1;
+  let parsed = [];
+
+  let endPtr = str.indexOf(end, ptr);
+  if (endPtr < 0) {
+    throw new TomlError("incomplete key-value: cannot find end of key", {
+      toml: str,
+      ptr: ptr,
+    });
+  }
+
+  do {
+    let c = str[(ptr = ++dot)];
+
+    // If it's whitespace, ignore
+    if (c !== " " && c !== "\t") {
+      // If it's a string
+      if (c === '"' || c === "'") {
+        if (c === str[ptr + 1] && c === str[ptr + 2]) {
+          throw new TomlError("multiline strings are not allowed in keys", {
+            toml: str,
+            ptr: ptr,
+          });
+        }
+
+        let eos = getStringEnd(str, ptr);
+        if (eos < 0) {
+          throw new TomlError("unfinished string encountered", {
+            toml: str,
+            ptr: ptr,
+          });
+        }
+
+        dot = str.indexOf(".", eos);
+        let strEnd = str.slice(eos, dot < 0 || dot > endPtr ? endPtr : dot);
+
+        let newLine = indexOfNewline(strEnd);
+        if (newLine > -1) {
+          throw new TomlError("newlines are not allowed in keys", {
+            toml: str,
+            ptr: ptr + dot + newLine,
+          });
+        }
+
+        if (strEnd.trimStart()) {
+          throw new TomlError("found extra tokens after the string part", {
+            toml: str,
+            ptr: eos,
+          });
+        }
+
+        if (endPtr < eos) {
+          endPtr = str.indexOf(end, eos);
+          if (endPtr < 0) {
+            throw new TomlError(
+              "incomplete key-value: cannot find end of key",
+              {
+                toml: str,
+                ptr: ptr,
+              },
+            );
+          }
+        }
+
+        parsed.push(parseString(str, ptr, eos));
+      } else {
+        // Normal raw key part consumption and validation
+        dot = str.indexOf(".", ptr);
+        let part = str.slice(ptr, dot < 0 || dot > endPtr ? endPtr : dot);
+        if (!KEY_PART_RE.test(part)) {
+          throw new TomlError(
+            "only letter, numbers, dashes and underscores are allowed in keys",
+            {
+              toml: str,
+              ptr: ptr,
+            },
+          );
+        }
+
+        parsed.push(part.trimEnd());
+      }
+    }
+    // Until there's no more dot
+  } while (dot + 1 && dot < endPtr);
+
+  return [parsed, skipVoid(str, endPtr + 1, true, true)];
+}
+
+export function parseInlineTable(
+  str: string,
+  ptr: number,
+): [Record<string, TomlPrimitive>, number] {
+  let res: Record<string, TomlPrimitive> = {};
+  let seen = new Set();
+  let c: string;
+  let comma = 0;
+
+  ptr++;
+  while ((c = str[ptr++]!) !== "}" && c) {
+    if (c === "\n") {
+      throw new TomlError("newlines are not allowed in inline tables", {
+        toml: str,
+        ptr: ptr - 1,
+      });
+    } else if (c === "#") {
+      throw new TomlError("inline tables cannot contain comments", {
+        toml: str,
+        ptr: ptr - 1,
+      });
+    } else if (c === ",") {
+      throw new TomlError("expected key-value, found comma", {
+        toml: str,
+        ptr: ptr - 1,
+      });
+    } else if (c !== " " && c !== "\t") {
+      let k: string;
+      let t: any = res;
+      let hasOwn = false;
+
+      let [key, keyEndPtr] = parseKey(str, ptr - 1);
+      for (let i = 0; i < key.length; i++) {
+        if (i) t = hasOwn! ? t[k!] : (t[k!] = {});
+
+        k = key[i]!;
+        if (
+          (hasOwn = Object.hasOwn(t, k)) &&
+          (typeof t[k] !== "object" || seen.has(t[k]))
+        ) {
+          throw new TomlError("trying to redefine an already defined value", {
+            toml: str,
+            ptr: ptr,
+          });
+        }
+
+        if (!hasOwn && k === "__proto__") {
+          Object.defineProperty(t, k, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+          });
+        }
+      }
+
+      if (hasOwn) {
+        throw new TomlError("trying to redefine an already defined value", {
+          toml: str,
+          ptr: ptr,
+        });
+      }
+
+      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}");
+      seen.add(value);
+
+      t[k!] = value;
+      ptr = valueEndPtr;
+      comma = str[ptr - 1] === "," ? ptr - 1 : 0;
+    }
+  }
+
+  if (comma) {
+    throw new TomlError("trailing commas are not allowed in inline tables", {
+      toml: str,
+      ptr: comma,
+    });
+  }
+
+  if (!c) {
+    throw new TomlError("unfinished table encountered", {
+      toml: str,
+      ptr: ptr,
+    });
+  }
+
+  return [res, ptr];
+}
+
+export function parseArray(
+  str: string,
+  ptr: number,
+): [TomlPrimitive[], number] {
+  let res: TomlPrimitive[] = [];
+  let c;
+
+  ptr++;
+  while ((c = str[ptr++]) !== "]" && c) {
+    if (c === ",") {
+      throw new TomlError("expected value, found comma", {
+        toml: str,
+        ptr: ptr - 1,
+      });
+    } else if (c === "#") ptr = skipComment(str, ptr);
+    else if (c !== " " && c !== "\t" && c !== "\n" && c !== "\r") {
+      let e = extractValue(str, ptr - 1, "]");
+      res.push(e[0]);
+      ptr = e[1];
+    }
+  }
+
+  if (!c) {
+    throw new TomlError("unfinished array encountered", {
+      toml: str,
+      ptr: ptr,
+    });
+  }
+
+  return [res, ptr];
+}

--- a/projects/smol_toml/struct.bri
+++ b/projects/smol_toml/struct.bri
@@ -37,7 +37,7 @@ import {
 } from "./util.bri";
 import { TomlError } from "./error.bri";
 
-let KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
+const KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
 
 export function parseKey(
   str: string,
@@ -45,7 +45,7 @@ export function parseKey(
   end = "=",
 ): [string[], number] {
   let dot = ptr - 1;
-  let parsed = [];
+  const parsed = [];
 
   let endPtr = str.indexOf(end, ptr);
   if (endPtr < 0) {
@@ -56,7 +56,7 @@ export function parseKey(
   }
 
   do {
-    let c = str[(ptr = ++dot)];
+    const c = str[(ptr = ++dot)];
 
     // If it's whitespace, ignore
     if (c !== " " && c !== "\t") {
@@ -69,7 +69,7 @@ export function parseKey(
           });
         }
 
-        let eos = getStringEnd(str, ptr);
+        const eos = getStringEnd(str, ptr);
         if (eos < 0) {
           throw new TomlError("unfinished string encountered", {
             toml: str,
@@ -78,9 +78,9 @@ export function parseKey(
         }
 
         dot = str.indexOf(".", eos);
-        let strEnd = str.slice(eos, dot < 0 || dot > endPtr ? endPtr : dot);
+        const strEnd = str.slice(eos, dot < 0 || dot > endPtr ? endPtr : dot);
 
-        let newLine = indexOfNewline(strEnd);
+        const newLine = indexOfNewline(strEnd);
         if (newLine > -1) {
           throw new TomlError("newlines are not allowed in keys", {
             toml: str,
@@ -88,7 +88,7 @@ export function parseKey(
           });
         }
 
-        if (strEnd.trimStart()) {
+        if (strEnd.trimStart() !== "") {
           throw new TomlError("found extra tokens after the string part", {
             toml: str,
             ptr: eos,
@@ -112,7 +112,7 @@ export function parseKey(
       } else {
         // Normal raw key part consumption and validation
         dot = str.indexOf(".", ptr);
-        let part = str.slice(ptr, dot < 0 || dot > endPtr ? endPtr : dot);
+        const part = str.slice(ptr, dot < 0 || dot > endPtr ? endPtr : dot);
         if (!KEY_PART_RE.test(part)) {
           throw new TomlError(
             "only letter, numbers, dashes and underscores are allowed in keys",
@@ -127,7 +127,7 @@ export function parseKey(
       }
     }
     // Until there's no more dot
-  } while (dot + 1 && dot < endPtr);
+  } while (dot + 1 !== 0 && dot < endPtr);
 
   return [parsed, skipVoid(str, endPtr + 1, true, true)];
 }
@@ -136,13 +136,13 @@ export function parseInlineTable(
   str: string,
   ptr: number,
 ): [Record<string, TomlPrimitive>, number] {
-  let res: Record<string, TomlPrimitive> = {};
-  let seen = new Set();
+  const res: Record<string, TomlPrimitive> = {};
+  const seen = new Set();
   let c: string;
   let comma = 0;
 
   ptr++;
-  while ((c = str[ptr++]!) !== "}" && c) {
+  while ((c = str[ptr++] as string) !== "}" && c !== "") {
     if (c === "\n") {
       throw new TomlError("newlines are not allowed in inline tables", {
         toml: str,
@@ -159,15 +159,15 @@ export function parseInlineTable(
         ptr: ptr - 1,
       });
     } else if (c !== " " && c !== "\t") {
-      let k: string;
+      let k: string | undefined = undefined;
       let t: any = res;
       let hasOwn = false;
 
-      let [key, keyEndPtr] = parseKey(str, ptr - 1);
+      const [key, keyEndPtr] = parseKey(str, ptr - 1);
       for (let i = 0; i < key.length; i++) {
-        if (i) t = hasOwn! ? t[k!] : (t[k!] = {});
+        if (i !== 0) t = hasOwn ? t[k as string] : (t[k as string] = {});
 
-        k = key[i]!;
+        k = key[i] as string;
         if (
           (hasOwn = Object.hasOwn(t, k)) &&
           (typeof t[k] !== "object" || seen.has(t[k]))
@@ -194,23 +194,23 @@ export function parseInlineTable(
         });
       }
 
-      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}");
+      const [value, valueEndPtr] = extractValue(str, keyEndPtr, "}");
       seen.add(value);
 
-      t[k!] = value;
+      t[k as string] = value;
       ptr = valueEndPtr;
       comma = str[ptr - 1] === "," ? ptr - 1 : 0;
     }
   }
 
-  if (comma) {
+  if (comma !== 0) {
     throw new TomlError("trailing commas are not allowed in inline tables", {
       toml: str,
       ptr: comma,
     });
   }
 
-  if (!c) {
+  if (c === "") {
     throw new TomlError("unfinished table encountered", {
       toml: str,
       ptr: ptr,
@@ -224,11 +224,11 @@ export function parseArray(
   str: string,
   ptr: number,
 ): [TomlPrimitive[], number] {
-  let res: TomlPrimitive[] = [];
+  const res: TomlPrimitive[] = [];
   let c;
 
   ptr++;
-  while ((c = str[ptr++]) !== "]" && c) {
+  while ((c = str[ptr++]) !== "]" && c != null && c !== "") {
     if (c === ",") {
       throw new TomlError("expected value, found comma", {
         toml: str,
@@ -236,13 +236,13 @@ export function parseArray(
       });
     } else if (c === "#") ptr = skipComment(str, ptr);
     else if (c !== " " && c !== "\t" && c !== "\n" && c !== "\r") {
-      let e = extractValue(str, ptr - 1, "]");
+      const e = extractValue(str, ptr - 1, "]");
       res.push(e[0]);
       ptr = e[1];
     }
   }
 
-  if (!c) {
+  if (c == null || c === "") {
     throw new TomlError("unfinished array encountered", {
       toml: str,
       ptr: ptr,

--- a/projects/smol_toml/util.bri
+++ b/projects/smol_toml/util.bri
@@ -1,0 +1,143 @@
+/*!
+ * Copyright (c) Squirrel Chat et al., All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import type { TomlDate } from "./date.bri";
+import { TomlError } from "./error.bri";
+
+export type TomlPrimitive =
+  | string
+  | number
+  | boolean
+  | TomlDate
+  | { [key: string]: TomlPrimitive }
+  | TomlPrimitive[];
+
+export function indexOfNewline(str: string, start = 0, end = str.length) {
+  let idx = str.indexOf("\n", start);
+  if (str[idx - 1] === "\r") idx--;
+  return idx <= end ? idx : -1;
+}
+
+export function skipComment(str: string, ptr: number) {
+  for (let i = ptr; i < str.length; i++) {
+    let c = str[i]!;
+    if (c === "\n") return i;
+
+    if (c === "\r" && str[i + 1] === "\n") return i + 1;
+
+    if ((c < "\x20" && c !== "\t") || c === "\x7f") {
+      throw new TomlError("control characters are not allowed in comments", {
+        toml: str,
+        ptr: ptr,
+      });
+    }
+  }
+
+  return str.length;
+}
+
+export function skipVoid(
+  str: string,
+  ptr: number,
+  banNewLines?: boolean,
+  banComments?: boolean,
+): number {
+  let c;
+
+  while (
+    (c = str[ptr]) === " " ||
+    c === "\t" ||
+    (!banNewLines && (c === "\n" || (c === "\r" && str[ptr + 1] === "\n")))
+  )
+    ptr++;
+
+  return banComments || c !== "#"
+    ? ptr
+    : skipVoid(str, skipComment(str, ptr), banNewLines);
+}
+
+export function skipUntil(
+  str: string,
+  ptr: number,
+  sep: string,
+  end?: string,
+  banNewLines: boolean = false,
+) {
+  if (!end) {
+    ptr = indexOfNewline(str, ptr);
+    return ptr < 0 ? str.length : ptr;
+  }
+
+  for (let i = ptr; i < str.length; i++) {
+    let c = str[i];
+    if (c === "#") {
+      i = indexOfNewline(str, i);
+    } else if (c === sep) {
+      return i + 1;
+    } else if (c === end) {
+      return i;
+    } else if (
+      banNewLines &&
+      (c === "\n" || (c === "\r" && str[i + 1] === "\n"))
+    ) {
+      return i;
+    }
+  }
+
+  throw new TomlError("cannot find end of structure", {
+    toml: str,
+    ptr: ptr,
+  });
+}
+
+export function getStringEnd(str: string, seek: number) {
+  let first = str[seek]!;
+  let target =
+    first === str[seek + 1] && str[seek + 1] === str[seek + 2]
+      ? str.slice(seek, seek + 3)
+      : first;
+
+  seek += target.length - 1;
+  do seek = str.indexOf(target, ++seek);
+  while (
+    seek > -1 &&
+    first !== "'" &&
+    str[seek - 1] === "\\" &&
+    str[seek - 2] !== "\\"
+  );
+
+  if (seek > -1) {
+    seek += target.length;
+    if (target.length > 1) {
+      if (str[seek] === first) seek++;
+      if (str[seek] === first) seek++;
+    }
+  }
+
+  return seek;
+}

--- a/projects/smol_toml/util.bri
+++ b/projects/smol_toml/util.bri
@@ -45,7 +45,7 @@ export function indexOfNewline(str: string, start = 0, end = str.length) {
 
 export function skipComment(str: string, ptr: number) {
   for (let i = ptr; i < str.length; i++) {
-    let c = str[i]!;
+    const c = str[i] as string;
     if (c === "\n") return i;
 
     if (c === "\r" && str[i + 1] === "\n") return i + 1;
@@ -72,11 +72,12 @@ export function skipVoid(
   while (
     (c = str[ptr]) === " " ||
     c === "\t" ||
-    (!banNewLines && (c === "\n" || (c === "\r" && str[ptr + 1] === "\n")))
+    (banNewLines !== true &&
+      (c === "\n" || (c === "\r" && str[ptr + 1] === "\n")))
   )
     ptr++;
 
-  return banComments || c !== "#"
+  return banComments === true || c !== "#"
     ? ptr
     : skipVoid(str, skipComment(str, ptr), banNewLines);
 }
@@ -88,13 +89,13 @@ export function skipUntil(
   end?: string,
   banNewLines: boolean = false,
 ) {
-  if (!end) {
+  if (end == null || end === "") {
     ptr = indexOfNewline(str, ptr);
     return ptr < 0 ? str.length : ptr;
   }
 
   for (let i = ptr; i < str.length; i++) {
-    let c = str[i];
+    const c = str[i];
     if (c === "#") {
       i = indexOfNewline(str, i);
     } else if (c === sep) {
@@ -116,8 +117,8 @@ export function skipUntil(
 }
 
 export function getStringEnd(str: string, seek: number) {
-  let first = str[seek]!;
-  let target =
+  const first = str[seek] as string;
+  const target =
     first === str[seek + 1] && str[seek + 1] === str[seek + 2]
       ? str.slice(seek, seek + 3)
       : first;

--- a/projects/typer/project.bri
+++ b/projects/typer/project.bri
@@ -300,6 +300,50 @@ export function object<T extends object>(
   };
 }
 
+export function record<K extends string | number | symbol, V>(
+  keyChecker: Checker<K>,
+  valueChecker: Checker<V>,
+): Checker<Record<K, V>> {
+  return createChecker((value) => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return { result: "mismatch", message: "expected an object" };
+    }
+
+    const childErrors = Object.entries(value).flatMap(
+      ([key, value]): ChildError[] => {
+        const results = [];
+        const keyResult = keyChecker[checkSymbol](key);
+        const valueResult = valueChecker[checkSymbol](value);
+
+        if (keyResult.result === "mismatch") {
+          results.push({
+            path: key,
+            error: keyResult,
+          });
+        }
+        if (valueResult.result === "mismatch") {
+          results.push({
+            path: key,
+            error: valueResult,
+          });
+        }
+
+        return results;
+      },
+    );
+
+    if (childErrors.length === 0) {
+      return { result: "matches", value: value as Record<K, V> };
+    } else {
+      return {
+        result: "mismatch",
+        message: "one or more record entries did not match",
+        children: childErrors,
+      };
+    }
+  });
+}
+
 export function union<Ts extends unknown[]>(
   ...checkers: { [K in keyof Ts]: Checker<Ts[K]> }
 ): Checker<Ts[number]> {


### PR DESCRIPTION
This PR adds a new `rust` package:

- Using the default export as a dependency gives you `rustc` and `cargo`, among other standard Rust binaries
- The function `rust.cargoBuild()` lets you build a crate, including caching dependency downloads and validating the lockfile is up to date

Rather than build from source, the current version of the `rust` package installs Rust by downloading a manifest file (the same one used by Rustup) and calling the `install.sh` file for each desired component. This ends up using the official Rust binaries.

To parse the manifest, I had to make two other changes:

- Add `typer.record()` function for parsing objects based on key/value type
- Add `smol_toml` package. The Rustup manifests are TOML, so to parse them, I vendored the [`small-toml`](https://github.com/squirrelchat/smol-toml) NPM package as the `smol_toml` Brioche package (I made a few manual changes to silence warnings and to match the formatting conventions for `.bri` files)

As part of caching dependencies properly, I internally pulled in a precompiled binary for [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef/tree/main), namely to create a "skeleton crate" so dependencies can be cached based only on the `Cargo.toml` and `Cargo.lock` files (instead of all of the source code, which would effectively be uncached). I also tried to use this to cache builds of dependencies, but I was thwarted because each build runs in a different `$HOME`, and Cargo fingerprints the cache based on the source path. Caching dependencies will take some more work