### PR TITLE
Add inline documentation for most functions

### DIFF
--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -5,6 +5,12 @@ export const project = {
   version: "20.14.0",
 };
 
+/**
+ * The main Node.js recipe. Returns a recipe containing the following:
+ *
+ * - `bin/node`
+ * - `bin/npm`
+ */
 function nodejs(): std.Recipe<std.Directory> {
   let node = std
     .download({
@@ -29,6 +35,33 @@ interface NpmInstallOptions {
   npmPackage: std.AsyncRecipe<std.Directory>;
 }
 
+/**
+ * Install the dependencies from an NPM package. Returns a recipe containing
+ * everything from the package, plus a `node_modules` directory.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ * import nodejs, { npmInstall } from "nodejs";
+ *
+ * export default () => {
+ *   // Get all the files for the NPM package
+ *   let npmPackage = Brioche.glob("src", "package.lock", "package.json");
+ *
+ *   // Install the dependencies
+ *   npmPackage = npmInstall({ npmPackage });
+ *
+ *   // Run the build script and save the output from `dist/`
+ *   return std.runBash`
+ *     npm run build
+ *     mv dist "$BRIOCHE_OUTPUT"
+ *   `
+ *     .workDir(npmPackage)
+ *     .dependencies(nodejs());
+ * };
+ * ```
+ */
 export function npmInstall(
   options: NpmInstallOptions,
 ): std.Recipe<std.Directory> {

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -110,7 +110,6 @@ export default rust;
 export interface CargoBuildOptions {
   crate: std.AsyncRecipe<std.Directory>;
   toolchain?: std.AsyncRecipe<std.Directory>;
-  profile?: string;
   runnable?: string;
 }
 

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -109,7 +109,6 @@ export default rust;
 
 export interface CargoBuildOptions {
   crate: std.AsyncRecipe<std.Directory>;
-  toolchain?: std.AsyncRecipe<std.Directory>;
   runnable?: string;
 }
 
@@ -145,7 +144,7 @@ export function cargoBuild(options: CargoBuildOptions) {
   let buildResult = std.runBash`
     cargo install --path . --frozen
   `
-    .dependencies(rust(), toolchain)
+    .dependencies(rust(), std.toolchain())
     .env({
       CARGO_INSTALL_ROOT: std.outputPath,
       PATH: std.tpl`${std.outputPath}/bin`,

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -29,6 +29,14 @@ const Manifest = t.object({
   profiles: t.record(t.string(), t.array(t.string())),
 });
 
+/**
+ * The main Rust recipe. Returns a recipe containing the following:
+ *
+ * - `bin/rustc`
+ * - `bin/cargo`
+ *
+ * ...among other binaries.
+ */
 async function rust(): Promise<std.Recipe<std.Directory>> {
   const manifestToml = await std
     .download({
@@ -112,9 +120,30 @@ export interface CargoBuildOptions {
   runnable?: string;
 }
 
+/**
+ * Build a Cargo crate. Defaults to the release profile. Calls
+ * `cargo install` internally, and returns the contents of `$CARGO_INSTALL_ROOT`
+ *
+ * ## Options
+ *
+ * - `crate`: The crate to build.
+ * - `runnable`: Optionally set a path to the binary to run
+ *   by default (e.g. `bin/foo`).
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import { cargoBuild } from "rust";
+ *
+ * export default () => {
+ *   return cargoBuild({
+ *     crate: Brioche.glob("src", "Cargo.*"),
+ *     runnable: "bin/hello",
+ *   });
+ * };
+ * ```
+ */
 export function cargoBuild(options: CargoBuildOptions) {
-  const toolchain = options.toolchain ?? std.toolchain();
-
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies
   const skeletonCrate = createSkeletonCrate(options.crate);

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -7,8 +7,78 @@ import {
 import { source } from "./source.bri";
 
 export interface BriocheGlobal {
+  /**
+   * Include a file from the filesystem. The path is relative to the
+   * current Brioche module, and cannot go outside the project root.
+   *
+   * ## Example
+   *
+   * ```
+   * project/
+   * ├── project.bri
+   * └── file.txt
+   * ```
+   *
+   * ```typescript
+   * // project.bri
+   *
+   * // Returns a file recipe with the contents of `file.txt`
+   * const file = Brioche.includeFile("file.txt");
+   * ```
+   */
   includeFile(path: string): Recipe<File>;
+
+  /**
+   * Include a directory from the filesystem. The path is relative to the
+   * current Brioche module, and cannot go outside the project root.
+   *
+   * ## Example
+   *
+   * ```
+   * project/
+   * ├── project.bri
+   * └── src/
+   *    ├── fizz.txt
+   *    └── buzz.txt
+   * ```
+   *
+   * ```typescript
+   * // project.bri
+   *
+   * // Returns a directory containing `fizz.txt` and `buzz.txt`
+   * const file = Brioche.includeDirectory("src");
+   * ```
+   */
   includeDirectory(path: string): Recipe<Directory>;
+
+  /**
+   * Include multiple files from the filesystem using a glob pattern. The
+   * returned directory structure preserves the relative paths of the files,
+   * relative to the current Brioche module. The glob pattern will not
+   * match any paths if it tries going outside the current module directory.
+   *
+   * ## Example
+   *
+   * ```
+   * project/
+   * ├── project.bri
+   * ├── hello.txt
+   * └── src/
+   *    ├── foo.txt
+   *    └── secretfile.env
+   * ```
+   *
+   * ```typescript
+   * // project.bri
+   *
+   * // Returns a directory with this structure:
+   * // .
+   * // ├── hello.txt
+   * // └── src/
+   * //    └── foo.txt
+   * const file = Brioche.glob("hello.txt, src/*.txt")
+   * ```
+   */
   glob(...patterns: string[]): Recipe<Directory>;
 }
 

--- a/packages/std/core/recipes/directory.bri
+++ b/packages/std/core/recipes/directory.bri
@@ -9,6 +9,20 @@ import {
 } from "./recipe.bri";
 import { artifactType } from "./artifact_type.bri";
 
+/**
+ * Constructs a new directory. Takes an object argument, where each key
+ * is a filename and each value is a recipe
+ *
+ * ## Example
+ *
+ * ```typescript
+ * std.directory({
+ *   "hello": std.directory({
+ *     "world.txt": std.file("Hello, world!"),
+ *   }),
+ * });
+ * ```
+ */
 export function directory(
   entries: Record<string, AsyncRecipe> = {},
 ): Recipe<Directory> {
@@ -37,6 +51,10 @@ export function directory(
   });
 }
 
+/**
+ * Perform a deep merge of two or more directories. The rightmost directory
+ * takes precedence.
+ */
 export function merge(
   ...directories: AsyncRecipe<Directory>[]
 ): Recipe<Directory> {

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -7,6 +7,20 @@ export interface DownloadOptions {
   hash: Hash;
 }
 
+/**
+ * Returns a recipe that will download a URL, and return
+ * a file of its results. A has must be provided, and will
+ * be used to verify the downloaded contents.
+ *
+ * ## Example
+ *
+ * std.download({
+ *   url: "https://gist.githubusercontent.com/kylewlacy/c0f1a43e2641686f377178880fcce6ae/raw/f48155695445aa218e558fba824b61cf718d5e55/lorem-ipsum.txt",
+ *   hash: std.sha256Hash(
+ *     "642e3f58cc2bcc0d12d2e1e21dd9ea131f058a98e23e9beac79881bb0a324d06"
+ *   ),
+ * });
+ */
 export function download(opts: DownloadOptions): Recipe<File> {
   return createRecipe(["file"], {
     sourceDepth: 1,

--- a/packages/std/core/recipes/file.bri
+++ b/packages/std/core/recipes/file.bri
@@ -3,6 +3,15 @@ import { assert } from "../utils.bri";
 import { type Recipe, createRecipe, fileRecipeUtils } from "./recipe.bri";
 import { artifactType } from "./artifact_type.bri";
 
+/**
+ * Create a new file, which contains the provided content.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * std.file("Hello, world!");
+ * ```
+ */
 export function file(content: string | Uint8Array): Recipe<File> {
   const serializedContent = runtime.bstring(content);
   return createRecipe(["file"], {

--- a/packages/std/core/recipes/hash.bri
+++ b/packages/std/core/recipes/hash.bri
@@ -1,6 +1,10 @@
 import * as runtime from "../runtime.bri";
 import { assert } from "../utils.bri";
 
+/**
+ * Represents an expected SHA-256 hash. Should be a hex-encoded
+ * string of 64 characters.
+ */
 export function sha256Hash(value: string): Sha256Hash {
   assert(runtime.isHex(value));
   return new Sha256Hash(value);

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -23,13 +23,72 @@ export interface ProcessUnsafe {
 export type Process = Recipe & ProcessUtils;
 
 export interface ProcessUtils {
+  /**
+   * Returns a new process with more environment variables set.
+   */
   env(values: Record<string, ProcessTemplateLike>): Process;
+
+  /**
+   * Returns a new process with more dependencies added. The new
+   * dependencies take precedence over the old ones.
+   */
   dependencies(...dependencies: AsyncRecipe<Directory>[]): Process;
+
+  /**
+   * Returns a new process with a different working directory.
+   */
   workDir(workDir: AsyncRecipe<Directory>): Process;
+
+  /**
+   * Returns a new process with a different output scaffold.
+   */
   outputScaffold(outputScaffold: AsyncRecipe): Process;
+
+  /**
+   * Returns a new process with unsafe options set.
+   */
   unsafe(unsafeOptions: ProcessUnsafe): Process;
 }
 
+/**
+ * Create a recipe that will run a process, returning the contents that
+ * the process writes to the path `$BRIOCHE_OUTPUT`. The process can
+ * write a file, directory, or symlink to this path.
+ *
+ * Most options can be passed as a string literal, or as a template using
+ * the template function `std.tpl`. Recipes in the template will be
+ * expanded to an absolute path when the process runs.
+ *
+ * ## Options
+ *
+ * These options can be passed when calling `std.process()`, or can be
+ * set by calling methods on another process recipe (these methods are
+ * **immutable**, so make sure to assign the result to a variable!)
+ *
+ * - `command`: The command to run. Should either be a template, or a
+ *   string referencing a command from `dependencies`.
+ * - `args`: An array of arguments to pass to the command.
+ * - `env`: An object containing environment variables to set for the process.
+ * - `dependencies`: An array of dependencies to call the process with.
+ *   Dependencies will be merged into the process's environment.
+ * - `workDir`: Set to a directory recipe that will be copied into the
+ *   process's starting working directory.
+ * - `outputScaffold`: Set to a recipe that will be be used to initialize
+ *   `$BRIOCHE_OUTPUT`, which the process can then manipulate.
+ * - `unsafe`: Set to `true` to use unsafe options. You must take extra
+ *   care to ensure that running the process is hermetic when using these
+ *   options! The following options are available:
+ *   - `networking`: Set to `true` to allow the process to access the network.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * // Call Bash and write "Hello world!" to the output path
+ * std.process({
+ *   command: std.tpl`${std.tools()}/bin/bash`,
+ *   args: ["-c", 'echo "Hello world!" > "$BRIOCHE_OUTPUT"'],
+ * });
+ */
 export function process(options: ProcessOptions): Process {
   const env: Record<string, ProcessTemplateLike> = {
     BRIOCHE_OUTPUT: outputPath,
@@ -131,6 +190,11 @@ export function processTemplate(
   return new ProcessTemplate(...components);
 }
 
+/**
+ * Create a process template, which can be used to include recipe paths
+ * or other pre-defined values for the command, arguments, or environment
+ * variables for a process.
+ */
 export function tpl(
   strings: TemplateStringsArray,
   ...items: ProcessTemplateLike[]
@@ -147,11 +211,42 @@ export function tpl(
   return new ProcessTemplate(...components);
 }
 
+/**
+ * Expands to the path where the process should write its output. Equivalent
+ * to the default environment variable `$BRIOCHE_OUTPUT`.
+ */
 export const outputPath: unique symbol = Symbol("outputPath");
+
+/**
+ * Expands to the directory where the process can write resources to that
+ * can then be referenced by files in the process's output. Equivalent
+ * to the default environment variable `$BRIOCHE_RESOURCE_DIR`.
+ */
 export const resourceDir: unique symbol = Symbol("resourceDir");
+
+/**
+ * Expands to a `:`-delimited list of directories where the process can find
+ * resources from its inputs. These directories are normally read-only.
+ * Equivalent to the default environment variable `$BRIOCHE_INPUT_RESOURCE_DIRS`.
+ */
 export const inputResourceDirs: unique symbol = Symbol("inputResourceDirs");
+
+/**
+ * Expands to the home directory when the process runs. Equivalent to the
+ * default environment variable `$HOME`.
+ */
 export const homeDir: unique symbol = Symbol("homeDir");
+
+/**
+ * Expands to the the "work directory" of the process. This is the directory
+ * a process starts in by default (which is usually `$HOME/work`).
+ */
 export const workDir: unique symbol = Symbol("workDir");
+
+/**
+ * Expands to the temporary directory where the process can write temporary
+ * files. Equivalent to the default environment variable `$TMPDIR`.
+ */
 export const tempDir: unique symbol = Symbol("tempDir");
 
 export type ProcessTemplateLike = Awaitable<ProcessTemplateComponent>;

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -10,6 +10,10 @@ import {
   createRecipe,
 } from "./recipe.bri";
 
+/**
+ * Memoize a function that returns a recipe. The return value will be
+ * converted to a proxy automatically (see `std.createProxy()`).
+ */
 export function memo<Args extends Equatable[], Ret extends Artifact>(
   f: (...args: Args) => AsyncRecipe<Ret>,
 ): (...args: Args) => Recipe<Ret> {
@@ -27,6 +31,14 @@ export function memo<Args extends Equatable[], Ret extends Artifact>(
   };
 }
 
+/**
+ * Convert a recipe into a proxy. When baked, the proxy will bake the
+ * inner recipe.
+ *
+ * This is used as an internal optimization for cases where a recipe
+ * is repeated a lot in a build script, and effectively caches the
+ * recipe's serialization.
+ */
 export function createProxy<T extends Artifact>(
   recipe: AsyncRecipe<T>,
 ): Recipe<T> {

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -63,6 +63,12 @@ export type RecipeSerialization<T extends Artifact> = runtime.WithMeta &
 // to `RecipeCommon<Artifact>` in TypeScript messages. This is mainly done for the LSP.
 const recipeMarker: unique symbol = Symbol("recipeMarker");
 
+/**
+ * A "recipe" is a type that describes how to create an artifact in Brioche.
+ * When you call `brioche build`, the returned recipe is "baked" to produce
+ * an output artifact. Recipes are lazy and won't do anything until `.bake()`
+ * is called on them.
+ */
 export type Recipe<T extends Artifact = Artifact> = {
   [recipeMarker]?: undefined;
 } & RecipeCommon<T> &
@@ -76,6 +82,11 @@ export type Recipe<T extends Artifact = Artifact> = {
           ? object
           : never);
 
+/**
+ * A recipe that may be wrapped in a promise. An `AsyncRecipe` can be converted
+ * to a `Recipe` using the `std.recipe()` function, even when not in
+ * an async function.
+ */
 export type AsyncRecipe<T extends Artifact = Artifact> = Awaitable<Recipe<T>>;
 
 export function briocheDeserializeAny(
@@ -94,6 +105,11 @@ export function briocheDeserializeAny(
   }
 }
 
+/**
+ * Create a recipe from an `AsyncRecipe`. This function itself is not async,
+ * meaning it can even be called from a synchronous function. Under the hood,
+ * this will defer the async call until the recipe is baked (or serialized).
+ */
 export function recipe<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
   return createRecipe<T>(
     ["file", "directory", "symlink"] as ArtifactType<T>[],
@@ -109,6 +125,12 @@ export function recipe<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
   );
 }
 
+/**
+ * Create a recipe from a function that returns an `AsyncRecipe`. This function
+ * itself is not async, meaning it can even be called from a synchronous
+ * function. Under the hood, this will defer the function call until the
+ * recipe is baked (or serialized).
+ */
 export function recipeFn<T extends Artifact>(
   f: () => AsyncRecipe<T>,
 ): Recipe<T> {
@@ -146,6 +168,13 @@ export type CreateRecipeOptions<T extends Artifact> = {
     }
 );
 
+/**
+ * Create a new recipe by providing either a list of possible output types,
+ * plus either a `bake` method or a `briocheSerialize` method. The returned
+ * recipe can be used interchangeably with other, normal recipes.
+ *
+ * > **Note**: Providing only a `.bake()` function can be really inefficient!
+ */
 export function createRecipe<T extends Artifact>(
   types: ArtifactType<T>[],
   opts: CreateRecipeOptions<T>,
@@ -185,30 +214,116 @@ export function createRecipe<T extends Artifact>(
 }
 
 interface RecipeCommon<T extends Artifact> extends RecipeUtils<T> {
+  /**
+   * Bake a recipe, returning a promise that will contain the resulting
+   * artifact. Normally, you won't need to call this function yourself, as
+   * you can instead return a recipe directly, where the runtime will
+   * automatically bake it.
+   */
   bake(): Awaitable<T>;
+
+  /**
+   * Serialize a recipe to a plain JSON-style object for the Brioche runtime
+   * to handle. This is useful for wrapping another recipe, avoiding the need
+   * to call `.bake()` when implementing custom recipes.
+   */
   briocheSerialize(): Awaitable<RecipeSerialization<T>>;
 }
 
 interface RecipeUtils<T extends Artifact> {
+  /**
+   * Cast a recipe to a more specific type. This is useful for cases like
+   * `std.process()`, where the output type is not known until runtime. The
+   * cast will be validated when the recipe is baked.
+   *
+   * ## Example
+   *
+   * ```typescript
+   *
+   * ```typescript
+   * // We know this Bash scirpt will output a file, so call `.cast("file")`
+   * // to convert it to a `Recipe<File>`. We can then call file-specific
+   * // methods on the recipe.
+   * std.runBash`
+   *  echo "hi" > "$BRIOCHE_OUTPUT"
+   * `.cast("file");
+   * ```
+   */
   cast<To extends ArtifactType<T> & keyof ArtifactTypes>(
     to: To,
   ): Recipe<ArtifactTypes[To] & T>;
 }
 
 interface FileRecipeUtils extends RecipeUtils<File> {
+  /**
+   * Returns a new file with the given permissions set.
+   *
+   * ## Example
+   *
+   * ```typescript
+   * // Create a shell script and mark it as executable
+   * std.file(std.indoc`
+   *   #!/usr/bin/env bash
+   *   echo "Hello, world!"
+   * `).withPermissions({ executable: true });
+   * ```
+   */
   withPermissions(permissions: Partial<FilePermissions>): Recipe<File>;
+
+  /**
+   * Unarchive a (possibly compressed) archive file, returning a directory.
+   *
+   * ## Example
+   *
+   * ```typescript
+   * Brioche.includeFile("archive.tar.gz").unarchive("tar", "gzip");
+   * ```
+   */
   unarchive(
     archiveFormat: runtime.ArchiveFormat,
     compressionFormat?: runtime.CompressionFormat,
   ): Recipe<Directory>;
+
+  /**
+   * Read the contents of the file into a `Uint8Array`.
+   */
   readBytes(): Promise<Uint8Array>;
+
+  /**
+   * Read the contents of the file as a string. The file must be
+   * UTF-8 encoded.
+   */
   read(): Promise<string>;
 }
 
 interface DirectoryRecipeUtils extends RecipeUtils<Directory> {
+  /**
+   * Get a file, directory, or symlink from a directory by path.
+   */
   get(...paths: string[]): Recipe<Artifact>;
+
+  /**
+   * Return a new directory with the given recipe inserted at the provided
+   * path. If the directory already contains a file at the path, it will be
+   * replaced. If the path descends into a non-directory, baking the recipe
+   * will fail.
+   */
   insert(path: string, recipe: AsyncRecipe<Artifact>): Recipe<Directory>;
+
+  /**
+   * Return a new directory with the given recipe removed at the provided
+   * path. If the directory does not contain a file at the path, then the
+   * directory will be returned unchanged. If the path descends into a
+   * non-directory, baking the recipe will fail.
+   */
   remove(path: string): Recipe<Directory>;
+
+  /**
+   * Peel a directory, which removes an outer layer of the directory. Baking
+   * will fail if the directory does not contain exactly one item.
+   *
+   * Passing `depth` will repeat the peeling process multiple times (default: 1)
+   */
   peel(depth?: number): Recipe;
 }
 

--- a/packages/std/core/recipes/symlink.bri
+++ b/packages/std/core/recipes/symlink.bri
@@ -8,6 +8,13 @@ export interface SymlinkOptions {
   target: string;
 }
 
+/**
+ * Create a new symlink pointing at a provided path.
+ *
+ * ## Options
+ *
+ * - `target`: The target path of the symlink.
+ */
 export function symlink(opts: SymlinkOptions): Symlink {
   return new Symlink({
     target: runtime.bstring(opts.target),

--- a/packages/std/core/recipes/sync.bri
+++ b/packages/std/core/recipes/sync.bri
@@ -7,6 +7,11 @@ import {
   createRecipe,
 } from "./recipe.bri";
 
+/**
+ * Wrap a recipe, making it so it can be synced to the registry. Only a subset
+ * of recipes get synced normally, so this allows explicitly syncing a
+ * recipe that would otherwise not be synced.
+ */
 export function sync<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
   return createRecipe(["file", "directory", "symlink"] as ArtifactType<T>[], {
     sourceDepth: 1,

--- a/packages/std/core/utils.bri
+++ b/packages/std/core/utils.bri
@@ -1,3 +1,6 @@
+/**
+ * Throws an exception if a condition is not met.
+ */
 export function assert(
   condition: boolean,
   message?: string,
@@ -7,6 +10,28 @@ export function assert(
   }
 }
 
+/**
+ * Used as a type-checked assertion that a codepath is unreachable, such
+ * as for pattern matching. Throws an error if called.
+ *
+ * ## Example
+ *
+ * ```ts
+ * type Fizzbuzz = "fizz" | "buzz";
+ *
+ * function fizzOrBuzz(value: Fizzbuzz): string {
+ *   switch (value) {
+ *     case "fizz":
+ *       return "fizz!";
+ *     case "buzz":
+ *       return "buzz!";
+ *     default:
+ *       // This branch can never be reached
+ *       // (if a new variant is added, this will become a type error)
+ *       return unreachable(value);
+ * }
+ * ```
+ */
 export function unreachable(never: never): never {
   const value: any = never;
   throw new Error(`reached unreachable code with value: ${value}`);
@@ -26,6 +51,10 @@ export interface SerializeEquatable {
   briocheSerialize: () => Equatable;
 }
 
+/**
+ * Perform a deep-equality check between two values. This also works
+ * with types that have a `.briocheSerialize()` method.
+ */
 export function equal<T extends Equatable>(a: T, b: T): boolean {
   if (!isEquatable(a) || !isEquatable(b)) {
     throw new Error("Tried to compare values, but they could not be compared");
@@ -126,6 +155,10 @@ export function isEquatable(value: unknown): value is Equatable {
   }
 }
 
+/**
+ * Serialize a value as JSON. If the value implements `.briocheSerialize()`,
+ * then that will be used for serialization.
+ */
 export function jsonSerialize(value: Equatable): string {
   return JSON.stringify(value, (_key, value) => {
     if (isSerializeEquatable(value)) {
@@ -136,6 +169,33 @@ export function jsonSerialize(value: Equatable): string {
   });
 }
 
+/**
+ * A template function that strips extra indentation from a string, useful
+ * for including multiline strings, such as shell scripts or patch files.
+ *
+ * The first and last lines are removed if they are empty, and the level
+ * of indentation is determined by the line with the smallest indentation.
+ *
+ * ## Example
+ *
+ * ```
+ * const script = std.indoc`
+ *   #!/bin/bash
+ *   if [ -f "file.txt" ]; then
+ *     echo "file exists"
+ *   fi
+ * `;
+ * ```
+ *
+ * `script` will contain the following string:
+ *
+ * ```
+ * #!/bin/bash
+ * if [ -f "file.txt" ]; then
+ *   echo "file exists"
+ * fi
+ * ```
+ */
 export function indoc(
   strings: TemplateStringsArray,
   ...values: string[]
@@ -174,6 +234,11 @@ export function indoc(
   return lines.map((line) => line.slice(minIndentation)).join("\n");
 }
 
+/**
+ * Create a "mixin" by merging an object with some extra utilities along
+ * with it. This is useful for custom recipe subtypes that provide additional
+ * helper methods (see `std.process()` for an example).
+ */
 export function mixin<T extends object, U extends object>(
   base: T,
   mixin: U,

--- a/packages/std/extra/autowrap.bri
+++ b/packages/std/extra/autowrap.bri
@@ -11,6 +11,11 @@ export interface AutowrapOptions {
   runtimeLibraryDirs?: string[];
 }
 
+/**
+ * Automatically wrap dynamic executables so that their dynamic dependencies
+ * get loaded correctly when they are run inside and outside of Brioche. This
+ * is useful for packaging executables built from outside of Brioche.
+ */
 export function autowrap(
   recipe: std.AsyncRecipe<std.Directory>,
   options: AutowrapOptions,

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -8,11 +8,50 @@ import {
 export type BashRunnable = std.Recipe<std.Directory> & BashRunnableUtils;
 
 export interface BashRunnableUtils {
+  /**
+   * Merge a recipe into the root of the returned recipe. This is useful for
+   * wrapping another recipe so that you can call `brioche run` on it. In
+   * the Bash script, you can get the path to the recipe root with the
+   * `$root` environment variable.
+   */
   root(recipe: std.AsyncRecipe<std.Directory>): BashRunnable;
+
+  /**
+   * Set environment variables when the Bash script gets run.
+   */
   env(values: Record<string, RunnableTemplateValue>): BashRunnable;
+
+  /**
+   * Include additonal dependencies when the Bash script gets run. This
+   * will set the `$PATH` environment variable.
+   */
   dependencies(...dependencies: std.AsyncRecipe<std.Directory>[]): BashRunnable;
 }
 
+/**
+ * Build a Bash script into a self-contained runnable recipe. This does not
+ * run the Bash script, but allows it to be run outside of Brioche, such
+ * as by calling `brioche run` or by putting it into an OCI container image.
+ *
+ * The Bash script will be called with the `-e`, `-u`, and `-o pipefail`
+ * settings. Extra arguments are accessible through `$@`, just like a normal
+ * Bash script.
+ *
+ * See also `std.runBash` to run a Bash script while baking!
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ *
+ * // Running `brioche run` will print "Hello, world!"
+ * export default () => {
+ *   return std.bashRunnable`
+ *     echo "Hello, world!"
+ *   `;
+ * }
+ * ```
+ */
 export function bashRunnable(
   strings: TemplateStringsArray,
   ...values: string[]

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -6,6 +6,16 @@ interface OciContainerImageOptions {
   entrypoint?: string[];
 }
 
+/**
+ * Create an OCI container image from a recipe. The recipe
+ * will be included as a layer in the image.
+ *
+ * ## Options
+ *
+ * - `recipe`: The recipe to use as the image layer.
+ * - `entrypoint`: The entrypoint to use for the image.
+ *   Defaults to `["/brioche-run"]`.
+ */
 export function ociContainerImage(
   options: OciContainerImageOptions,
 ): std.Recipe<std.File> {

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -1,6 +1,39 @@
 import * as std from "/core";
 import { tools } from "/toolchain";
 
+/**
+ * Create a process recipe that runs the provided Bash script when baked. The
+ * Bash script should create the path `$BRIOCHE_OUTPUT`, which will be used
+ * as the output of the recipe.
+ *
+ * This funtion returns `std.Process`, which can be used for passing in
+ * extra dependencies or environment variables using `.dependencies()`
+ * or `.env()`, respectively, along with other process options.
+ *
+ * See also `std.bashRunnable,` which will return a recipe that packages
+ * up a Bash script that can be run outside of Brioche.
+ *
+ * ## Example
+ *
+ * ``` typescript
+ * import * as std from "std";
+ *
+ * // Running `brioche build -o output` will create a directory `output`
+ * // with the file `hello.txt`. The result is cached, so the script won't
+ * // re-run unless the script changes or its inputs change.
+ * export default () => {
+ *   const file = std.file("Hello, world!");
+ *
+ *   // Return a recipe that will call the script, with `$file` set to
+ *   // the absolute path of the file above
+ *   return std.runBash`
+ *     mkdir -p "$BRIOCHE_OUTPUT"
+ *     cp "$file" > "$BRIOCHE_OUTPUT/hello.txt"
+ *   `
+ *     .env({ file });
+ * }
+ * ```
+ */
 export function runBash(
   strings: TemplateStringsArray,
   ...values: string[]

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -4,6 +4,26 @@ export type EnvValues = Record<string, EnvValue | EnvValue[]>;
 
 export type EnvValue = { path: string };
 
+/**
+ * Returns a new recipe with some environment variables. These environment
+ * variables will be set when the recipe is included as a dependency for a
+ * procss recipe.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * let myLibrary = std.runBash`
+ *   mkdir -p "$BRIOCHE_OUTPUT/lib"
+ *   # ... build a library ...
+ * `;
+ *
+ * // When myLibrary gets included as a dependency, `$LIBRARY_PATH`
+ * // will get set to the absolute path of the `lib` directory
+ * myLibrary = std.setEnv(myLibrary, {
+ *   LIBRARY_PATH: { path: "lib" },
+ * });
+ * ```
+ */
 export function setEnv(
   recipe: std.AsyncRecipe<std.Directory>,
   env: EnvValues,

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -1,5 +1,34 @@
 import * as std from "/core";
 
+/**
+ * Returns a new recipe that has a symlink used when the recipe is
+ * run with `brioche run` or when the recipe is put into an OCI container
+ * image.
+ *
+ * This will add a symlink from `brioche-run` to the specified path, which
+ * is used by `brioche run` to determine the executable to run.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ *
+ * export default () => {
+ *   // Build a C program from the `src` directory
+ *   let program = std.runBash`
+ *     mkdir -p "$BRIOCHE_OUTPUT/bin"
+ *     gcc -o "$BRIOCHE_OUTPUT/bin/hello" src/hello.c
+ *   `
+ *     .workDir(Brioche.glob("src"))
+ *     .dependencies(std.toolchain());
+ *
+ *   // Add a symlink so that `brioche run` will run `bin/hello`
+ *   program = std.withRunnableLink(program, "bin/hello");
+ *
+ *   return program;
+ * };
+ * ```
+ */
 export function withRunnableLink(
   recipe: std.AsyncRecipe<std.Directory>,
   runPath: string,

--- a/packages/std/project.bri
+++ b/packages/std/project.bri
@@ -1,3 +1,28 @@
+/**
+ * The `std` package is the standard library for Brioche, containing many
+ * core types and functions, plus some important utilities used by most
+ * Brioche projects. It also includes the definitions for several important
+ * global functions, including `console.log` and `Brioche.glob`.
+ *
+ * Most Brioche projects will import the standard library like this:
+ *
+ * ```typescript
+ * import * as std from "std";
+ * ```
+ *
+ * Internally, the `std` package is broken up into 3 major sections:
+ *
+ * - `core`: Core types and functions, including recipes and standalone
+ *   utilities.
+ * - `toolchain`: A bootstrapped toolchain with a set of standard Unix-like
+ *   tools. This includes builds for `gcc`, `bash`, and others. This module
+ *   defines the `std.tools()` and `std.toolchain()` exports.
+ * - `extra`: Additional high-level types and functions, which usually depend
+ *   on the toolchain. This includes the `std.runBash()` export.
+ *
+ * @packageDocumentation
+ */
+
 import type { BriocheGlobal } from "./core/global.bri";
 import { toolchain } from "./toolchain";
 

--- a/packages/std/toolchain/index.bri
+++ b/packages/std/toolchain/index.bri
@@ -18,6 +18,12 @@ export { default as stage1 } from "./stage1";
 export { default as stage2 } from "./stage2";
 export { default as native, bash, tools } from "./native";
 
+/**
+ * A recipe containing a full C toolchain, including a C compiler, linker,
+ * libc, Make, and other common utilities. The toolchain also contains
+ * everything from `std.tools()`, including a shell and common Unix-style
+ * utilities.
+ */
 export function toolchain(): std.Recipe<std.Directory> {
   return nativeToolchain();
 }

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -64,6 +64,9 @@ import patchelf from "./patchelf.bri";
 
 export { bash };
 
+/**
+ * Returns a set of common Unix-style utilities
+ */
 export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
   let tools = std.merge(
     zlib(),


### PR DESCRIPTION
This PR adds documentation to most inline functions, as well as a few minor tweaks to the `rust.cargoBuild()` function (namely, removing the `profile` and `toolchain` options; the former wasn't actually used and the latter is... more complex).