### PR TITLE
Tweak `mpfr` build in `std.toolchain()` to speed up initial setup

### DIFF
--- a/packages/std/toolchain/native/mpfr.bri
+++ b/packages/std/toolchain/native/mpfr.bri
@@ -42,17 +42,25 @@ export default std.memo((): std.Recipe<std.Directory> => {
     })
     .cast("directory");
 
-  const libtoolArchive = mpfr.get("lib/libmpfr.la").cast("file");
-  const newLibtoolArchive = std.recipeFn(async () => {
-    let libtoolArchiveContents = await libtoolArchive.read();
-    libtoolArchiveContents = libtoolArchiveContents.replace(
-      /\/\/lib\/libgmp\.la/g,
-      "-lgmp",
-    );
-    return std.file(libtoolArchiveContents);
-  });
+  let libtoolArchive = mpfr.get("lib/libmpfr.la");
+  libtoolArchive = std
+    .process({
+      command: std.tpl`${stage2()}/bin/bash`,
+      args: [
+        "-c",
+        `
+          set -euo pipefail
+          sed 's|//lib/libgmp.la|-lgmp|' "$libtoolArchive" > "$BRIOCHE_OUTPUT"
+        `,
+      ],
+      env: {
+        PATH: std.tpl`${stage2()}/bin`,
+        libtoolArchive,
+      },
+    })
+    .cast("file");
 
-  mpfr = mpfr.insert("lib/libmpfr.la", newLibtoolArchive);
+  mpfr = mpfr.insert("lib/libmpfr.la", libtoolArchive);
 
   return mpfr;
 });


### PR DESCRIPTION
This PR adjusts the build for `mpfr` used in `std.toolchain()`. The previous iteration called `std.recipeFn()`, which internally called `.bake()` on the recipe. This made it so everything before this point in the build would need to fetch, including the earlier stages of the build.

Now, we use a basic process with a `sed` command. This handles the work lazily, in a way that allows the client to pull a lot less from the registry.

Here's a comparison before:

```sh-session
$ time brioche run -r hello_world
[100%] Fetched 2 blobs + 10 recipes from registry
[100%] Fetched 11323 blobs + 14295 recipes from registry
[100%] Fetched 687 blobs + 1609 recipes from registry
Build finished, completed 73 jobs in 9:19.5
Running brioche-run
Hello, world!

real    9m19.513s
user    0m28.139s
sys     0m17.396s
```

...and after:

```sh-session
$ time brioche run -p ./packages/hello_world/
[100%] Fetched 2 blobs + 10 recipes from registry
[100%] Fetched 20984 blobs + 24529 recipes from registry
[100%] Fetched 1508 blobs + 2560 recipes from registry
Build finished, completed 3 jobs in 5:55.7
Running brioche-run
Hello, world!

real    5m55.846s
user    0m17.255s
sys     0m10.027s
```