### PR TITLE
Add some upstream changes + make OCI images smaller

### DIFF
--- a/packages/std/core/console.bri
+++ b/packages/std/core/console.bri
@@ -6,13 +6,33 @@ declare global {
 
 interface Console {
   log: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
 }
 
 const console = {
-  log: (...args: unknown[]) => {
-    ops.op_brioche_console("log", displayAll(...args).join(" "));
+  log(...args: unknown[]) {
+    logLevel("log", ...args);
+  },
+  debug(...args: unknown[]) {
+    logLevel("debug", ...args);
+  },
+  info(...args: unknown[]) {
+    logLevel("info", ...args);
+  },
+  warn(...args: unknown[]) {
+    logLevel("warn", ...args);
+  },
+  error(...args: unknown[]) {
+    logLevel("error", ...args);
   },
 } satisfies Console;
+
+function logLevel(level: string, ...args: unknown[]) {
+  ops.op_brioche_console(level, displayAll(...args).join(" "));
+}
 
 export function displayAll(...values: unknown[]): string[] {
   if (values.length === 0) {

--- a/packages/std/core/index.bri
+++ b/packages/std/core/index.bri
@@ -2,6 +2,7 @@ export * from "./recipes";
 export { source } from "./source.bri";
 export { assert, unreachable, indoc, mixin, type Awaitable } from "./utils.bri";
 export {
+  BRIOCHE_VERSION,
   utf8Encode,
   utf8Decode,
   tickEncode,

--- a/packages/std/core/recipes/collect_references.bri
+++ b/packages/std/core/recipes/collect_references.bri
@@ -1,0 +1,33 @@
+import { BRIOCHE_VERSION } from "../runtime.bri";
+import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import type { Directory } from "./directory.bri";
+
+/**
+ * Collect all the references within a recipe into a top-level directory
+ * named `brioche-resources.d`. This mirrors the output structure you get
+ * when running `brioche build -o <output_dir>`, and is useful for making
+ * an archive of a recipe.
+ */
+export function collectReferences(
+  recipe: AsyncRecipe<Directory>,
+): Recipe<Directory> {
+  return createRecipe(["directory"], {
+    sourceDepth: 1,
+    briocheSerialize: async (meta) => {
+      // TODO: Use a proper semver check
+      // TODO: Remove once support for v0.1.0 has been dropped
+      if (BRIOCHE_VERSION === "0.1.0") {
+        throw new Error(
+          "std.collectReferences is not supported in v0.1.0, please run `brioche self-update` to update Brioche!",
+        );
+      }
+
+      const serializedRecipe = await (await recipe).briocheSerialize();
+      return {
+        meta,
+        type: "collect_references",
+        recipe: serializedRecipe,
+      };
+    },
+  });
+}

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -18,6 +18,7 @@ export {
 export { memo, createProxy } from "./proxy.bri";
 export { symlink, type SymlinkOptions, Symlink } from "./symlink.bri";
 export { sync } from "./sync.bri";
+export { collectReferences } from "./collect_references.bri";
 export {
   type AsyncRecipe,
   type Recipe,

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -46,6 +46,7 @@ export type RecipeSerialization<T extends Artifact> = runtime.WithMeta &
           | runtime.PeelRecipe
           | runtime.GetRecipe
           | runtime.InsertRecipe
+          | runtime.CollectReferencesRecipe
           | runtime.ProxyRecipe
           | runtime.SyncRecipe
       : T extends Symlink

--- a/packages/std/core/runtime.bri
+++ b/packages/std/core/runtime.bri
@@ -1,3 +1,16 @@
+function getBriocheVersion(): string {
+  const { op_brioche_version } = (globalThis as any).Deno.core.ops;
+
+  // TODO: Remove this check once v0.1.0 is deprecated! Brioche v0.1.0 was
+  // the only version that did not have this op
+  if (op_brioche_version === undefined) {
+    return "0.1.0";
+  }
+  return op_brioche_version();
+}
+
+export const BRIOCHE_VERSION = getBriocheVersion();
+
 export async function bakeAll(recipes: []): Promise<[]>;
 export async function bakeAll(recipes: [Recipe]): Promise<[Artifact]>;
 export async function bakeAll(
@@ -92,6 +105,7 @@ export type Recipe =
   | GetRecipe
   | InsertRecipe
   | SetPermissionsRecipe
+  | CollectReferencesRecipe
   | ProxyRecipe
   | SyncRecipe;
 
@@ -167,6 +181,11 @@ export type SetPermissionsRecipe = WithMeta & {
   type: "set_permissions";
   file: Recipe;
   executable: boolean | null;
+};
+
+export type CollectReferencesRecipe = WithMeta & {
+  type: "collect_references";
+  recipe: Recipe;
 };
 
 export type ProxyRecipe = WithMeta & {

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -33,7 +33,7 @@ export function ociContainerImage(
       ),
     );
 
-    const layerTar = tar(expandResources(options.recipe));
+    const layerTar = tar(collectReferences(options.recipe));
     const [diffId] = await describeBlob(layerTar);
 
     const layerTarGzip = gzip(layerTar);
@@ -141,9 +141,18 @@ async function describeBlob(
   return [shaHash, parseInt(size)];
 }
 
-function expandResources(
+// TODO: Remove once Brioche v0.1.0 is no longer supported
+function collectReferences(
   recipe: std.AsyncRecipe<std.Directory>,
 ): std.Recipe<std.Directory> {
+  // TODO: Use proper semver comparison
+  if (std.BRIOCHE_VERSION !== "0.1.0") {
+    return std.collectReferences(recipe);
+  }
+
+  console.warn(
+    "Using fallback to collect references from artifact, container will be much larger than it should be! Run `brioche self-update` to upgrade to the latest version of Brioche",
+  );
   return runBash`
     if [ -d "$BRIOCHE_RESOURCE_DIR" -a -n "$(ls -A "$BRIOCHE_RESOURCE_DIR")" ]; then
       mkdir -p "$BRIOCHE_OUTPUT"/brioche-resources.d/


### PR DESCRIPTION
This PR exposes a few upstream features, and uses them to make OCI container images smaller:

- Add `std.BRIOCHE_VERSION` export. This uses the ops introduced in brioche-dev/brioche#59 / brioche-dev/brioche#60 to return the current Brioche version. This is useful for feature-gating things that depend on new Brioche versions
  - Since this op wasn't present on v0.1.0, we set the version to v0.1.0 if the op is not present
- Add new `std.collectReferences()` function. It takes a directory recipe and returns a new directory recipe that explicitly includes a `brioche-resources.d` directory. This is useful creating self-contained tarballs of recipes, e.g. for OCI container images
  -  This is feature-gated for Brioche >=v0.1.1 (v0.1.1 should go out very shortly)
- Update `std.ociContainerImage()` to use `std.collectReferences()` internally
  - Previously, extra references not used by the container image were being included in the OCI image layer. This has been fixed now that there's runtime support
  - The legacy method for building the OCI image layer is still present, and will be used when on Brioche v0.1.0 (with a warning to upgrade)