### PR TITLE
Append newline when vendoring Rust dependencies

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -153,7 +153,9 @@ export function cargoBuild(options: CargoBuildOptions) {
   const vendoredSkeletonCrate = std.runBash`
     cd "$BRIOCHE_OUTPUT"
     mkdir -p .cargo
-    cargo vendor --locked >> .cargo/config.toml
+    # Always add a newline in case the file already exists and
+    # doesn't end with a newline
+    echo $'\n'"$(cargo vendor --locked)" >> .cargo/config.toml
   `
     .dependencies(rust(), caCertificates())
     .outputScaffold(skeletonCrate)


### PR DESCRIPTION
Resolve the issue https://github.com/brioche-dev/brioche-packages/issues/32.

Before:

```rust
[target.x86_64-pc-windows-msvc]
# increase the default windows stack size
# statically link the CRT so users don't have to install it
rustflags = ["-C", "link-args=-stack:10000000", "-C", "target-feature=+crt-static"]

# keeping this but commentting out in case we need them in the future

# set a 2 gb stack size (0x80000000 = 2147483648 bytes = 2 GB)
# [target.x86_64-unknown-linux-gnu]
# rustflags = ["-C", "link-args=-Wl,-z stack-size=0x80000000"]

# set a 2 gb stack size (0x80000000 = 2147483648 bytes = 2 GB)
# [target.x86_64-apple-darwin]
# rustflags = ["-C", "link-args=-Wl,-stack_size,0x80000000"]

# How to use mold in linux and mac

# [target.x86_64-unknown-linux-gnu]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

# [target.x86_64-apple-darwin]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

# [target.aarch64-apple-darwin]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

[target.aarch64-apple-darwin]
# We can guarantee that this target will always run on a CPU with _at least_
# these capabilities, so let's optimize for them
rustflags = ["-Ctarget-cpu=apple-m1"][source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
```

After:

```rust
[target.x86_64-pc-windows-msvc]
# increase the default windows stack size
# statically link the CRT so users don't have to install it
rustflags = ["-C", "link-args=-stack:10000000", "-C", "target-feature=+crt-static"]

# keeping this but commentting out in case we need them in the future

# set a 2 gb stack size (0x80000000 = 2147483648 bytes = 2 GB)
# [target.x86_64-unknown-linux-gnu]
# rustflags = ["-C", "link-args=-Wl,-z stack-size=0x80000000"]

# set a 2 gb stack size (0x80000000 = 2147483648 bytes = 2 GB)
# [target.x86_64-apple-darwin]
# rustflags = ["-C", "link-args=-Wl,-stack_size,0x80000000"]

# How to use mold in linux and mac

# [target.x86_64-unknown-linux-gnu]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

# [target.x86_64-apple-darwin]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

# [target.aarch64-apple-darwin]
# linker = "clang"
# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

[target.aarch64-apple-darwin]
# We can guarantee that this target will always run on a CPU with _at least_
# these capabilities, so let's optimize for them
rustflags = ["-Ctarget-cpu=apple-m1"]
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
``` 