### PR TITLE
feat: expose PKG_CONFIG_PATH in OpenSSL package

### DIFF
--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -31,6 +31,7 @@ export default function (): std.Recipe<std.Directory> {
   openssl = std.setEnv(openssl, {
     LIBRARY_PATH: { path: "lib" },
     CPATH: { path: "include" },
+    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
   });
 
   return std.withRunnableLink(openssl, "bin/openssl");

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -29,8 +29,8 @@ export default function (): std.Recipe<std.Directory> {
     .toDirectory();
 
   openssl = std.setEnv(openssl, {
-    LIBRARY_PATH: { path: "lib" },
     CPATH: { path: "include" },
+    LIBRARY_PATH: { path: "lib" },
     PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
   });
 


### PR DESCRIPTION
Needed to build the Nushell tool, otherwise this error is emitted:

```
error: failed to run custom build command for `openssl-sys v0.9.102`

Caused by:
  process didn't exit successfully: `/home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/work/target/release/build/openssl-sys-ec786e98e368251d/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  run pkg_config fail:
  pkg-config exited with status code 1
  > PKG_CONFIG_PATH=/home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/.local/share/brioche/locals/bb53690d859a874183e8a2b071eadbe73c5402bf33bf8359c2f1cc701ee13d54/lib/pkgconfig:/home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/.local/share/brioche/locals/15153b6793f1756dc79b2aa8a8740f4a75f445b92f8c22805a6a4452b75633cf/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags openssl

  The system library `openssl` required by crate `openssl-sys` was not found.
  The file `openssl.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  PKG_CONFIG_PATH contains the following:
      - /home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/.local/share/brioche/locals/bb53690d859a874183e8a2b071eadbe73c5402bf33bf8359c2f1cc701ee13d54/lib/pkgconfig
      - /home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/.local/share/brioche/locals/15153b6793f1756dc79b2aa8a8740f4a75f445b92f8c22805a6a4452b75633cf/lib/pkgconfig

  HINT: you may need to install a package such as openssl, openssl-dev or openssl-devel.


  --- stderr
  thread 'main' panicked at /home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/work/vendor/openssl-sys/build/find_normal.rs:190:5:


  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.102


  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: failed to compile `nu v0.95.0 (/home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/work)`, intermediate artifacts can be found at `/home/brioche-runner-c6d4477cc819ddcba40e878ffddbe16cd5781b95641aa1b868d2536c156545f2/work/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```