### PR TITLE
Fix `cargoBuild()` failing when crate contains file `.cargo/config`

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -157,6 +157,15 @@ export function cargoBuild(options: CargoBuildOptions) {
   const vendoredSkeletonCrate = std.runBash`
     cd "$BRIOCHE_OUTPUT"
     mkdir -p .cargo
+
+    # If the crate has a .cargo/config file, then move it to .cargo/config.toml
+    # Cargo prefers the config over config.toml, so we need to rename it
+    # to avoid any conflits. It will still need to be removed from the merged
+    # crate later too
+    if [ -f .cargo/config ]; then
+      mv .cargo/config .cargo/config.toml
+    fi
+
     # Always add a newline in case the file already exists and
     # doesn't end with a newline
     echo $'\n'"$(cargo vendor --locked)" >> .cargo/config.toml
@@ -174,6 +183,10 @@ export function cargoBuild(options: CargoBuildOptions) {
     ".cargo/config.toml",
     vendoredSkeletonCrate.get(".cargo/config.toml"),
   );
+
+  // Remove the conflicting `cargo/config` file if it existed in the original
+  // crate. It will have already been copied over to `.cargo/config.toml`
+  crate = crate.remove(".cargo/config");
 
   // Use `cargo install` to build and install the project to `$BRIOCHE_OUTPUT`
   let buildResult = std.runBash`


### PR DESCRIPTION
Resolves #39 

The issue was described in [this comment](https://github.com/brioche-dev/brioche-packages/issues/39#issuecomment-2208214878), but basically the problem boils down to the `cargo vendor` command creating a new `.cargo/config.toml` file, while the crate contained a `.cargo/config` file. When this happens, Cargo prefers `.cargo/config`, meaning the config from `cargo vendor` was being ignored.

The fix I went with was to move `.cargo/config` to `.cargo/config.toml` if it exists in the crate before vendoring. After we merge the vendored crate with the original, we then remove `.cargo/config`, since `.cargo/config.toml` would have the final config by this point. I'm not confident this is the cleanest solution to the problem, but it seems fix the issue seen when trying to build `xplr` at least...