### PR TITLE
feat: add buildParams and packagePath options to GoBuildOptions interface

### DIFF
--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -45,8 +45,15 @@ export function go(): std.Recipe<std.Directory> {
 }
 export default go;
 
+interface GoBuildParameters {
+  generate?: boolean;
+  ldflags?: string[];
+}
+
 interface GoBuildOptions {
   goModule: std.AsyncRecipe<std.Directory>;
+  buildParams?: GoBuildParameters;
+  packagePath?: string;
   runnable?: string;
 }
 
@@ -58,6 +65,10 @@ interface GoBuildOptions {
  *
  * - `goModule`: The Go module to build. Should include `go.mod`, as well as
  *   `go.sum` if external dependencies are needed.
+ * - `buildParams`: Optional build parameters:
+ *   - `generate`: Run `go generate` before building.
+ *   - `ldflags`: An array of ldflags to pass to the `go install` command.
+ * - `packagePath`: Optionally set the package path to build (e.g. `./cmd/foo`).
  * - `runnable`: Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
  *
@@ -69,6 +80,14 @@ interface GoBuildOptions {
  * export default function {
  *   return goInstall({
  *     goModule: Brioche.glob("**\/*.go", "go.mod", "go.sum"),
+ *     buildParams: {
+ *       generate: true,
+ *       ldflags: [
+ *         "-s",
+ *         "-w"
+ *       ],
+ *     },
+ *     packagePath: "./cmd/hello",
  *     runnable: "bin/hello",
  *   });
  * };
@@ -80,13 +99,20 @@ export async function goInstall(
   const modules = goModDownload(options.goModule);
 
   let buildResult = std.runBash`
-    go install
+    # Run generate if requested
+    if [ "${options.buildParams?.generate}" = "true" ]; then
+      go generate ./...
+    fi
+
+    go install -ldflags="$ldflags" $package_path
   `
     .workDir(options.goModule)
     .dependencies(go())
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,
+      ldflags: options.buildParams?.ldflags?.join(" ") ?? "",
+      package_path: options.packagePath ?? ".",
     })
     .toDirectory();
 

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -100,18 +100,19 @@ export async function goInstall(
 
   let buildResult = std.runBash`
     # Run generate if requested
-    if [ "${options.buildParams?.generate}" = "true" ]; then
+    if [ "$go_generate" = "true" ]; then
       go generate ./...
     fi
 
-    go install -ldflags="$ldflags" $package_path
+    go install -ldflags="$ldflags" "$package_path"
   `
     .workDir(options.goModule)
     .dependencies(go())
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,
-      ldflags: options.buildParams?.ldflags?.join(" ") ?? "",
+      go_generate: options.buildParams?.generate ?? false ? "true" : "false",
+      ldflags: ldflagsWrapper(options.buildParams?.ldflags ?? []),
       package_path: options.packagePath ?? ".",
     })
     .toDirectory();
@@ -151,4 +152,15 @@ async function goModDownload(
     .env({ GOMODCACHE: std.outputPath })
     .unsafe({ networking: true })
     .toDirectory();
+}
+
+/**
+ * Wrapper function to escape ldflags for use in a shell command.
+ * Escapes single quotes and double quotes.
+ *
+ * @param ldflags An array of ldflags to escape.
+ * @returns A string of escaped ldflags.
+ */
+function ldflagsWrapper(ldflags: string[]): string {
+  return ldflags.map((ldflag) => ldflag.replace(/['"]/g, "\\$&")).join(" ");
 }


### PR DESCRIPTION
The commit adds new options to the `GoBuildOptions` interface in the `go` package. The `buildParams` option allows specifying build parameters such as running `go generate` before building and passing ldflags to the `go install` command. The `packagePath` option allows setting the package path to build. This change enhances the flexibility and customization of the `goInstall` function.