### PR TITLE
Add `jwt-cli` package

### DIFF
--- a/packages/jwt_cli/brioche.lock
+++ b/packages/jwt_cli/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -1,0 +1,24 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "jwt_cli",
+  version: "6.1.0",
+};
+
+const crate = std
+  .download({
+    url: `https://github.com/mike-engel/jwt-cli/archive/refs/tags/${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "9bc2232f052f0fcc3171d95a301911b29b8dff12fcb7ea80718c0ef1c993f9b9",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function () {
+  return cargoBuild({
+    crate,
+    runnable: "bin/jwt",
+  });
+}


### PR DESCRIPTION
This PR adds a package for the [`jwt-cli`](https://github.com/mike-engel/jwt-cli) command-line tool. There's at least one other project with the same name, but the one from mike-engel seems to be the most popular and has the name in a few other package repositories.

The package includes the `jwt` binary, which is used for encoding and decoding JSON web tokens (JWTs)