### PR TITLE
Add in terraform package

### DIFF
--- a/packages/terraform/brioche.lock
+++ b/packages/terraform/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/terraform/brioche.lock
+++ b/packages/terraform/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/hashicorp/terraform/archive/refs/tags/v1.9.2.tar.gz": {
+      "type": "sha256",
+      "value": "4f61b84d5e55648dfe576ead2744bd09aba8db00d8f780a2d498f30537e287f1"
+    }
+  }
 }

--- a/packages/terraform/brioche.lock
+++ b/packages/terraform/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/hashicorp/terraform/archive/refs/tags/v1.9.2.tar.gz": {
+    "https://github.com/hashicorp/terraform/archive/refs/tags/v1.9.5.tar.gz": {
       "type": "sha256",
-      "value": "4f61b84d5e55648dfe576ead2744bd09aba8db00d8f780a2d498f30537e287f1"
+      "value": "89d558e5093d5c62f410d6975dfbd1e08714bf89d24c2d1d52a693965340114b"
     }
   }
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -1,0 +1,31 @@
+import * as std from "std";
+import { goInstall } from "go";
+
+export const project = {
+  name: "terraform",
+  version: "1.9.2",
+};
+
+const goModule = std
+  .download({
+    url: `https://github.com/hashicorp/terraform/archive/refs/tags/v${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "4f61b84d5e55648dfe576ead2744bd09aba8db00d8f780a2d498f30537e287f1",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default () => {
+  return goInstall({
+    goModule,
+    env: {
+      CGO_ENABLED: "0",
+    },
+    buildParams: {
+      ldflags: ["-w", "-s", `-X github.com/hashicorp/terraform/version.dev=no`],
+      mod: "readonly",
+    },
+    runnable: "bin/terraform",
+  });
+};

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -3,7 +3,7 @@ import { goBuild } from "go";
 
 export const project = {
   name: "terraform",
-  version: "1.9.2",
+  version: "1.9.5",
 };
 
 const source = Brioche.download(

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -6,17 +6,13 @@ export const project = {
   version: "1.9.2",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/hashicorp/terraform/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "4f61b84d5e55648dfe576ead2744bd09aba8db00d8f780a2d498f30537e287f1",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/hashicorp/terraform/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return goBuild({
     source,
     buildParams: {
@@ -25,4 +21,4 @@ export default () => {
     },
     runnable: "bin/terraform",
   });
-};
+}

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -19,9 +19,6 @@ const goModule = std
 export default () => {
   return goInstall({
     goModule,
-    env: {
-      CGO_ENABLED: "0",
-    },
     buildParams: {
       ldflags: ["-w", "-s", `-X github.com/hashicorp/terraform/version.dev=no`],
       mod: "readonly",


### PR DESCRIPTION
This package relies on updating the go package first to support globbing of `go.mod` files across directories. Once [Brioche Issue 79](https://github.com/brioche-dev/brioche/issues/79) is completed we can then update the go package for issue number #62