### PR TITLE
mistakenly added std.toolchain to go package

### DIFF
--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -134,7 +134,7 @@ export async function goInstall(
     go install "\${goargs[@]}" "$package_path"
   `
     .workDir(options.goModule)
-    .dependencies(go(), std.toolchain())
+    .dependencies(go())
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -19,9 +19,6 @@ const goModule = std
 export default () => {
   return goInstall({
     goModule,
-    env: {
-      CGO_ENABLED: "0",
-    },
     packagePath: "./cmd/tofu",
     buildParams: {
       ldflags: ["-s", "-w", `-X github.com/opentofu/opentofu/version.dev=no`],


### PR DESCRIPTION
This created a problem where CGO kept trying to be used by default.