### PR TITLE
[Package] Normalize install options

### DIFF
--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -23,7 +23,7 @@ export default () => {
       generate: true,
       ldflags: ["-s", "-w", `-X main.version=${project.version}`],
     },
-    packagePath: "./cmd/carapace",
+    path: "./cmd/carapace",
     runnable: "bin/carapace",
   });
 };

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -58,7 +58,7 @@ interface GoBuildOptions {
   goModule: std.AsyncRecipe<std.Directory>;
   env?: Record<string, std.ProcessTemplateLike>;
   buildParams?: GoBuildParameters;
-  packagePath?: string;
+  path?: string;
   runnable?: string;
 }
 
@@ -76,7 +76,7 @@ interface GoBuildOptions {
  *   - `trimpath`: Set the `-trimpath` flag.
  *   - `mod`: Set the `-mod` flag to one of `"readonly"`, `"vendor"`, or `"mod"`.
  * - `env`: Optionally set environment variables for the build.
- * - `packagePath`: Optionally set the package path to build (e.g. `./cmd/foo`).
+ * - `path`: Optionally set the package path to build (e.g. `./cmd/foo`).
  * - `runnable`: Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
  *
@@ -100,7 +100,7 @@ interface GoBuildOptions {
  *         "-w"
  *       ],
  *     },
- *     packagePath: "./cmd/hello",
+ *     path: "./cmd/hello",
  *     runnable: "bin/hello",
  *   });
  * };
@@ -142,7 +142,7 @@ export async function goInstall(
       ldflags: ldflagsWrapper(options.buildParams?.ldflags ?? []),
       trimpath: options.buildParams?.trimpath ?? false ? "true" : "false",
       mod: options.buildParams?.mod ?? "",
-      package_path: options.packagePath ?? ".",
+      package_path: options.path ?? ".",
       ...options.env,
     })
     .toDirectory();

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -19,7 +19,7 @@ const goModule = std
 export default () => {
   return goInstall({
     goModule,
-    packagePath: "./cmd/tofu",
+    path: "./cmd/tofu",
     buildParams: {
       ldflags: ["-s", "-w", `-X github.com/opentofu/opentofu/version.dev=no`],
       mod: "readonly",

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -117,6 +117,7 @@ export interface CargoBuildOptions {
   path?: string;
   runnable?: string;
   dependencies?: std.AsyncRecipe<std.Directory>[];
+  env?: Record<string, std.ProcessTemplateLike>;
 }
 
 /**
@@ -131,6 +132,7 @@ export interface CargoBuildOptions {
  * - `runnable`: Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
  * - `dependencies`: Optionally add additional dependencies to the build.
+ * - `env`: Optionally set environment variables for the build.
  *
  * ## Example
  *
@@ -143,6 +145,9 @@ export interface CargoBuildOptions {
  *     crate: Brioche.glob("src", "Cargo.*"),
  *     runnable: "bin/hello",
  *     dependencies: [openssl()],
+ *     env: {
+ *       CARGO_LOG: "debug",
+ *     },
  *   });
  * };
  * ```
@@ -197,6 +202,7 @@ export function cargoBuild(options: CargoBuildOptions) {
       CARGO_INSTALL_ROOT: std.outputPath,
       PATH: std.tpl`${std.outputPath}/bin`,
       crate_path: options.path ?? ".",
+      ...options.env,
     })
     .workDir(crate)
     .toDirectory();


### PR DESCRIPTION
Two commits:

- first one to normalize the usage of `path` in GoBuildOptions interface to make it consistent with other interfaces
- second one to add the ability to set environment variables that could be injected in the `cargo install` command. Some crates rely on these env vars to be customized