### PR TITLE
[git] Add `gitCheckout` utility function

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import openssl from "openssl";
 import curl from "curl";
+import caCertificates from "ca_certificates";
 
 export const project = {
   name: "git",
@@ -18,7 +19,7 @@ const source = std
   .peel();
 
 export default (): std.Recipe<std.Directory> => {
-  const git = std.runBash`
+  let git = std.runBash`
     make prefix=/ all
     make prefix=/ install DESTDIR="$BRIOCHE_OUTPUT"
   `
@@ -26,5 +27,11 @@ export default (): std.Recipe<std.Directory> => {
     .dependencies(std.toolchain(), openssl(), curl())
     .toDirectory();
 
-  return std.withRunnableLink(git, "bin/git");
+  git = std.setEnv(git, {
+    GIT_EXEC_PATH: { path: "libexec/git-core" },
+    GIT_TEMPLATE_DIR: { path: "share/git-core/templates" },
+  });
+  git = std.withRunnableLink(git, "bin/git");
+
+  return git;
 };

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -18,7 +18,7 @@ const source = std
   .unarchive("tar", "gzip")
   .peel();
 
-export default (): std.Recipe<std.Directory> => {
+export default function git(): std.Recipe<std.Directory> {
   let git = std.runBash`
     make prefix=/ all
     make prefix=/ install DESTDIR="$BRIOCHE_OUTPUT"
@@ -34,4 +34,46 @@ export default (): std.Recipe<std.Directory> => {
   git = std.withRunnableLink(git, "bin/git");
 
   return git;
-};
+}
+
+interface GitCheckoutOptions {
+  repository: string;
+  commit: string;
+}
+
+/**
+ * Checkout a git repository at a specific commit. The specified commit will
+ * be cloned without any history.
+ *
+ * ## Options
+ *
+ * - `repository`: The URL of the git repository to checkout.
+ * - `commit`: The full commit hash to checkout.
+ */
+export function gitCheckout(
+  options: GitCheckoutOptions,
+): std.Recipe<std.Directory> {
+  // Validate that the commit is a hash
+  std.assert(
+    /^[0-9a-f]{40}$/.test(options.commit),
+    `Invalid git commit hash: ${options.commit}`,
+  );
+
+  // Clone and fetch only the specified commit. See this article:
+  // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    git -c init.defaultBranch=main init
+    git remote add origin "$repository"
+    git fetch --depth 1 origin "$commit"
+    git -c advice.detachedHead=false checkout FETCH_HEAD
+  `
+    .dependencies(git(), caCertificates())
+    .env({
+      repository: options.repository,
+      commit: options.commit,
+    })
+    .outputScaffold(std.directory())
+    .unsafe({ networking: true })
+    .toDirectory();
+}


### PR DESCRIPTION
Closes #43

This PR adds a new `gitCheckout` utility function to the `git` package. It takes a repository URL and a commit hash, and returns a recipe with the repo checked out with just that one commit. As mentioned in #43, this was based on the technique described in this article: https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/

The commit hash is validated to be a 40-character hex string to ensure that it's a full commit hash. This will prevent cloning from a branch/tag (which could change over time) or from a short commit hash (which could be ambiguous as more commits are added to the upstream repo).

Also, I updated the git package to set some environment variables that needed to be set to use git within Brioche (within the `gitCheckout` function specifically):

- `GIT_EXEC_PATH`: Used to find the paths to some built-in git commands (like `git-remote-https`, needed for cloning a repo over HTTPS)
- `GIT_TEMPLATE_DIR`: A directory containing templates, e.g. when initializing an empty repo