### PR TITLE
[Bat] add a unit test

### DIFF
--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -16,9 +16,23 @@ const source = std
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function bat(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/bat",
   });
-};
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(bat --version) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(bat());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `bat ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -6,7 +6,7 @@ import { tools } from "/toolchain";
  * Bash script should create the path `$BRIOCHE_OUTPUT`, which will be used
  * as the output of the recipe.
  *
- * This funtion returns `std.Process`, which can be used for passing in
+ * This function returns `std.Process`, which can be used for passing in
  * extra dependencies or environment variables using `.dependencies()`
  * or `.env()`, respectively, along with other process options.
  *


### PR DESCRIPTION
Add a sort of unit test for `bat` package based on what was done with `openssl`. It helps to figure out if the package is at least built correctly with a basic test.

To run it (not for @kylewlacy since he knows it):

```bash
brioche build -p packages/bat -e test
```

If it suits you (@kylewlacy), I could do the same for the other packages.