### PR TITLE
feat: Update broot version to 1.40.0

### DIFF
--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -3,14 +3,14 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "broot",
-  version: "1.39.0",
+  version: "1.40.0",
 };
 
 const source = std
   .download({
     url: `https://github.com/Canop/broot/archive/refs/tags/v${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "d1d2ccc11543ff4ea645d57a5e78639542a6f510b585a78c31ddb3a24399bf61",
+      "2b3cd1b01a71f102e5f26836afdf2b6ef24e02ecf7c5459cc9863e2e670a27da",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
I updated the broot package to 1.40.0

Changelog: https://github.com/Canop/broot/releases/tag/v1.40.0

Tested locally:

```bash
bash-5.2$ brioche install -p packages/broot
[133]    Compiling uzers v0.11.3                                                                                                                                                                                                                                                                                                                 
[133]    Compiling memmap2 v0.9.4                                                                                                                                                                                                                                                                                                                
[133]    Compiling splitty v1.0.1                                                                                                                                                                                                                                                                                                                
[133]    Compiling custom_error v1.9.2                                                                                                                                                                                                                                                                                                           
[133]    Compiling rustc-hash v1.1.0                                                                                                                                                                                                                                                                                                             
[133]    Compiling bet v1.0.3                                                                                                                                                                                                                                                                                                                    
[133]    Compiling pathdiff v0.2.1                                                                                                                                                                                                                                                                                                               
[133]    Compiling glob v0.3.1                                                                                                                                                                                                                                                                                                                   
[133]    Compiling id-arena v2.2.1                                                                                                                                                                                                                                                                                                               
[133]    Compiling strict v0.1.4                                                                                                                                                                                                                                                                                                                 
[133]    Compiling char_reader v0.1.1                                                                                                                                                                                                                                                                                                            
[133]    Compiling onig v6.4.0                                                                                                                                                                                                                                                                                                                   
[133]    Compiling syntect-no-panic v4.6.1                                                                                                                                                                                                                                                                                                       
[133]    Compiling git2 v0.14.4                                                                                                                                                                                                                                                                                                                  
[133]     Finished `release` profile [optimized] target(s) in 5m 43s                                                                                                                                                                                                                                                                             
[133]   Installing /home/brioche-runner-366c8d39554df222c3a587a0b20dc3b8d419aac80370a495bd867401fab48630/.local/share/brioche/outputs/output-366c8d39554df222c3a587a0b20dc3b8d419aac80370a495bd867401fab48630/bin/broot                                                                                                                          
[133]    Installed package `broot v1.40.0 (/home/brioche-runner-366c8d39554df222c3a587a0b20dc3b8d419aac80370a495bd867401fab48630/work)` (executable `broot`)                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                 
Process 133 [5:43.3 Exited 0]
Process 115 [11.63s Exited 0]
Process 113 [150.7ms Exited 0]
Build finished, completed 12 jobs in 7:13.4
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ broot --version
broot 1.40.0
```