### PR TITLE
feat: update ca_certificates version to "2024-07-02"

### DIFF
--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -2,14 +2,14 @@ import * as std from "std";
 
 export const project = {
   name: "ca_certificates",
-  version: "2024-03-11",
+  version: "2024-07-02",
 };
 
 export default (): std.Recipe<std.Directory> => {
   const cacert = std.download({
     url: `https://curl.se/ca/cacert-${project.version}.pem`,
     hash: std.sha256Hash(
-      "1794c1d4f7055b7d02c2170337b61b48a2ef6c90d77e95444fd2596f4cac609f",
+      "1bf458412568e134a4514f5e170a328d11091e071c7110955c9884ed87972ac9",
     ),
   });
 


### PR DESCRIPTION
Update ca_certificates to "2024-07-02": https://curl.se/docs/caextract.html

Tested locally:

```bash
bash-5.2$ brioche install -p packages/ca_certificates
[100%] Downloaded https://curl.se/ca/cacert-2024-07-02.pem
Build finished, completed 1 job in 1.8s
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ ls /home/container/.local/share/brioche/installed
bin  brioche-env.d  brioche-resources.d  etc
bash-5.2$ cat /home/container/.local/share/brioche/installed/etc/ssl/certs/ca-bundle.crt 
##
## Bundle of CA Root Certificates
##
## Certificate data from Mozilla as of: Tue Jul  2 03:12:04 2024 GMT
##
## This is a bundle of X.509 certificates of public Certificate Authorities
## (CA). These were automatically extracted from Mozilla's root certificates
## file (certdata.txt).  This file can be found in the mozilla source tree:
## https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
##
## It contains the certificates in PEM format and therefore
## can be directly used with curl / libcurl / php_curl, or with
## an Apache+mod_ssl webserver for SSL client authentication.
## Just configure this file as the SSLCACertificateFile.
##
## Conversion done with mk-ca-bundle.pl version 1.29.
## SHA256: 456ff095dde6dd73354c5c28c73d9c06f53b61a803963414cb91a1d92945cdd3
##

....
....
....
```

