### PR TITLE
feat: Update dust package version to 1.1.1

### DIFF
--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -3,14 +3,14 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "dust",
-  version: "1.0.0",
+  version: "1.1.1",
 };
 
 const source = std
   .download({
     url: `https://github.com/bootandy/dust/archive/refs/tags/v${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "34b72116ab6db9bdb97bc1e49dadf392a1619838204b44b0a4695539d54ffbe8",
+      "98cae3e4b32514e51fcc1ed07fdbe6929d4b80942925348cc6e57b308d9c4cb0",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
Changelog:
- https://github.com/bootandy/dust/releases/tag/v1.1.0
- https://github.com/bootandy/dust/releases/tag/v1.1.1

Tested it locally:

```bash
bash-5.2$ brioche install -p packages/dust
[13021]    Vendoring utf8parse v0.2.1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/utf8parse-0.2.1) to vendor/utf8parse                                                                                                                            
[13021]    Vendoring wait-timeout v0.2.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wait-timeout-0.2.0) to vendor/wait-timeout                                                                                                                   
[13021]    Vendoring wasi v0.11.0+wasi-snapshot-preview1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1) to vendor/wasi                                                                                           
[13021]    Vendoring wasm-bindgen v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.92) to vendor/wasm-bindgen                                                                                                                 
[13021]    Vendoring wasm-bindgen-backend v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-backend-0.2.92) to vendor/wasm-bindgen-backend                                                                                         
[13021]    Vendoring wasm-bindgen-macro v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-macro-0.2.92) to vendor/wasm-bindgen-macro                                                                                               
[13021]    Vendoring wasm-bindgen-macro-support v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-macro-support-0.2.92) to vendor/wasm-bindgen-macro-support                                                                       
[13021]    Vendoring wasm-bindgen-shared v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-shared-0.2.92) to vendor/wasm-bindgen-shared                                                                                            
[13021]    Vendoring winapi v0.3.9 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-0.3.9) to vendor/winapi                                                                                                                                     
[13021]    Vendoring winapi-i686-pc-windows-gnu v0.4.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-i686-pc-windows-gnu-0.4.0) to vendor/winapi-i686-pc-windows-gnu                                                                         
[13021]    Vendoring utf8parse v0.2.1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/utf8parse-0.2.1) to vendor/utf8parse                                                                                                                            
[13021]    Vendoring wait-timeout v0.2.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wait-timeout-0.2.0) to vendor/wait-timeout                                                                                                                   
[13021]    Vendoring wasi v0.11.0+wasi-snapshot-preview1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1) to vendor/wasi                                                                                           
[13021]    Vendoring wasm-bindgen v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.92) to vendor/wasm-bindgen                                                                                                                 
[13021]    Vendoring wasm-bindgen-backend v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-backend-0.2.92) to vendor/wasm-bindgen-backend                                                                                         
[13021]    Vendoring wasm-bindgen-macro v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-macro-0.2.92) to vendor/wasm-bindgen-macro                                                                                               
[13021]    Vendoring utf8parse v0.2.1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/utf8parse-0.2.1) to vendor/utf8parse                                                                                                                            
[13021]    Vendoring wait-timeout v0.2.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wait-timeout-0.2.0) to vendor/wait-timeout                                                                                                                   
[13021]    Vendoring wasi v0.11.0+wasi-snapshot-preview1 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1) to vendor/wasi                                                                                           
[13021]    Vendoring wasm-bindgen v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.92) to vendor/wasm-bindgen                                                                                                                 
[13021]    Vendoring wasm-bindgen-backend v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-backend-0.2.92) to vendor/wasm-bindgen-backend                                                                                         
[13021]    Vendoring wasm-bindgen-macro v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-macro-0.2.92) to vendor/wasm-bindgen-macro                                                                                               
[13021]    Vendoring wasm-bindgen-macro-support v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-macro-support-0.2.92) to vendor/wasm-bindgen-macro-support                                                                       
[13021]    Vendoring wasm-bindgen-shared v0.2.92 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-shared-0.2.92) to vendor/wasm-bindgen-shared                                                                                            
[13021]    Vendoring winapi v0.3.9 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-0.3.9) to vendor/winapi                                                                                                                                     
[13021]    Vendoring winapi-i686-pc-windows-gnu v0.4.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-i686-pc-windows-gnu-0.4.0) to vendor/winapi-i686-pc-windows-gnu                                                                         
[13021]    Vendoring winapi-util v0.1.8 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-util-0.1.8) to vendor/winapi-util                                                                                                                      
[13021]    Vendoring winapi-x86_64-pc-windows-gnu v0.4.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winapi-x86_64-pc-windows-gnu-0.4.0) to vendor/winapi-x86_64-pc-windows-gnu                                                                   
[13021]    Vendoring windows-core v0.52.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/windows-core-0.52.0) to vendor/windows-core                                                                                                                 
[13021]    Vendoring windows-sys v0.48.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/windows-sys-0.48.0) to vendor/windows-sys-0.48.0                                                                                                             
[13021]    Vendoring windows-sys v0.52.0 (/home/brioche-runner-4d1087269516ee993974aa044e40fe1dfb3d0be4c3e48e0c7252190e00878221/.cargo/registry/src/index.crates.io-6f17d22bba15001f/windows-sys-0.52.0) to vendor/windows-sys                                                                                                                    
[13032]    Compiling du-dust v1.1.1 (/home/brioche-runner-5d6ddf01b6c0334ff8db184d69e79e53d7e5d093d3012431172336161d9d19b7/work)                                                                                                                                                                                                                 
[13032]    Compiling dirs-sys v0.3.7                                                                                                                                                                                                                                                                                                             
[13032]    Compiling once_cell v1.19.0                                                                                                                                                                                                                                                                                                           
[13032]    Compiling ryu v1.0.17                                                                                                                                                                                                                                                                                                                 
[13032]    Compiling itoa v1.0.11                                                                                                                                                                                                                                                                                                                
[13032]    Compiling iana-time-zone v0.1.60                                                                                                                                                                                                                                                                                                      
[13032]    Compiling ansi_term v0.12.1                                                                                                                                                                                                                                                                                                           
[13032]    Compiling sysinfo v0.27.8                                                                                                                                                                                                                                                                                                             
[13032]    Compiling lscolors v0.13.0                                                                                                                                                                                                                                                                                                            
[13032]    Compiling chrono v0.4.38                                                                                                                                                                                                                                                                                                              
[13032]    Compiling directories v4.0.1                                                                                                                                                                                                                                                                                                          
[13032]    Compiling ctrlc v3.4.4                                                                                                                                                                                                                                                                                                                
[13032]    Compiling config-file v0.2.3                                                                                                                                                                                                                                                                                                          
[13032]    Compiling regex v1.10.4                                                                                                                                                                                                                                                                                                               
[13032]    Compiling terminal_size v0.2.6                                                                                                                                                                                                                                                                                                        
[13032]    Compiling thousands v0.2.0                                                                                                                                                                                                                                                                                                            
[13032]    Compiling unicode-width v0.1.11                                                                                                                                                                                                                                                                                                       
[13032]    Compiling stfu8 v0.2.7                                                                                                                                                                                                                                                                                                                
[13032]     Finished `release` profile [optimized] target(s) in 1m 05s                                                                                                                                                                                                                                                                           
[13032]   Installing /home/brioche-runner-5d6ddf01b6c0334ff8db184d69e79e53d7e5d093d3012431172336161d9d19b7/.local/share/brioche/outputs/output-5d6ddf01b6c0334ff8db184d69e79e53d7e5d093d3012431172336161d9d19b7/bin/dust                                                                                                                         
[13032]    Installed package `du-dust v1.1.1 (/home/brioche-runner-5d6ddf01b6c0334ff8db184d69e79e53d7e5d093d3012431172336161d9d19b7/work)` (executable `dust`)                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                 
Process 13032 [1:05.5 Exited 0]
Process 13021 [5.74s Exited 0]
Process 13011 [150ms Exited 0]
Build finished, completed 6 jobs in 1:46.3
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ dust --version
Dust 1.1.1
```