### PR TITLE
feat: Update eza package version to 0.18.22

### DIFF
--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -3,14 +3,14 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "eza",
-  version: "0.18.20",
+  version: "0.18.22",
 };
 
 const source = std
   .download({
     url: `https://github.com/eza-community/eza/archive/refs/tags/v${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "f85a7c1a1859e4fb7913d9517bd5fd04714811562b631a71705077c5aceacd78",
+      "552fe9997ed4fc6e11dafebffc2aa249ab3fb465a05c614181c7b62e8a0df698",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
Changelog:
- https://github.com/eza-community/eza/releases/tag/v0.18.21
- https://github.com/eza-community/eza/releases/tag/v0.18.22

Tested it locally:

```bash
bash-5.2$ brioche install -p packages/eza
[14352]    = note: `Attributes` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis                                                                                                                                                                                                            
[14352] note: the lint level is defined here                                                                                                                                                                                                                                                                                                     
[14352]   --> src/main.rs:7:9                                                                                                                                                                                                                                                                                                                    
[14352]    |                                                                                                                                                                                                                                                                                                                                     
[14352] 7  | #![warn(unused)]                                                                                                                                                                                                                                                                                                                    
[14352]    |         ^^^^^^                                                                                                                                                                                                                                                                                                                      
[14352]    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`                                                                                                                                                                                                                                                                             
[14352]                                                                                                                                                                                                                                                                                                                                          
[14352] warning: field `row_threshold` is never read                                                                                                                                                                                                                                                                                             
[14352]   --> src/output/grid_details.rs:73:9                                                                                                                                                                                                                                                                                                    
[14352]    |                                                                                                                                                                                                                                                                                                                                     
[14352] 48 | pub struct Render<'a> {                                                                                                                                                                                                                                                                                                             
[14352]    |            ------ field in this struct                                                                                                                                                                                                                                                                                              
[14352] ...                                                                                                                                                                                                                                                                                                                                      
[14352] 73 |     pub row_threshold: RowThreshold,                                                                                                                                                                                                                                                                                                
[14352]    |         ^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                               
[14352]                                                                                                                                                                                                                                                                                                                                          
[14352] warning: `eza` (bin "eza") generated 2 warnings                                                                                                                                                                                                                                                                                          
[14352]     Finished `release` profile [optimized] target(s) in 2m 26s                                                                                                                                                                                                                                                                           
[14352]   Installing /home/brioche-runner-a898dead73c0a0dbf1b520bb931d63b543cbdc9da5e4aaca286e313659b05958/.local/share/brioche/outputs/output-a898dead73c0a0dbf1b520bb931d63b543cbdc9da5e4aaca286e313659b05958/bin/eza                                                                                                                          
[14352]    Installed package `eza v0.18.22 (/home/brioche-runner-a898dead73c0a0dbf1b520bb931d63b543cbdc9da5e4aaca286e313659b05958/work)` (executable `eza`)                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                 
Process 14352 [2:26.6 Exited 0]
Process 14310 [336ms Exited 0]
[100%] Fetched 8448 blobs + 10021 recipes from registry
Build finished, completed 6 jobs in 15:53.8
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ eza --version
eza - A modern, maintained replacement for ls
v0.18.22 [+git]
https://github.com/eza-community/eza
```