### PR TITLE
Add implementation for `Brioche.download()` global function

### DIFF
--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -82,6 +82,19 @@ declare global {
      * ```
      */
     function glob(...patterns: string[]): Recipe<Directory>;
+
+    /**
+     * Download a file from a URL. Unlike `std.download`, this function does
+     * not take a hash, and it **must** be called with a constant string URL.
+     * The hash of the downloaded file will be saved in the lockfile.
+     *
+     * ## Example
+     *
+     * ```typescript
+     * const file = Brioche.download("http://example.com/");
+     * ```
+     */
+    function download(url: string): Recipe<File>;
   }
 }
 
@@ -150,6 +163,27 @@ declare global {
         {
           type: "glob",
           patterns,
+        },
+      );
+    },
+  });
+};
+(globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to download ${url}`);
+  }
+
+  const sourceFile = sourceFrame.fileName;
+
+  return createRecipe(["file"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "download",
+          url,
         },
       );
     },

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -88,6 +88,8 @@ declare global {
      * not take a hash, and it **must** be called with a constant string URL.
      * The hash of the downloaded file will be saved in the lockfile.
      *
+     * See also `std.download`, which can be used even if URL is not constant.
+     *
      * ## Example
      *
      * ```typescript

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -5,6 +5,9 @@ import {
   createRecipe,
 } from "./recipes";
 import { source } from "./source.bri";
+import { BRIOCHE_VERSION } from "./runtime.bri";
+import { semverMatches } from "./semver.bri";
+import { assert } from "./utils.bri";
 
 declare global {
   // eslint-disable-next-line
@@ -171,6 +174,11 @@ declare global {
   });
 };
 (globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
+  assert(
+    semverMatches(BRIOCHE_VERSION, ">=0.1.2"),
+    "Brioche.download(...) requires Brioche v0.1.2 or greater",
+  );
+
   const sourceFrame = source({ depth: 1 }).at(0);
   if (sourceFrame === undefined) {
     throw new Error(`Could not find source file to download ${url}`);

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -9,7 +9,7 @@ export interface DownloadOptions {
 
 /**
  * Returns a recipe that will download a URL, and return
- * a file of its results. A has must be provided, and will
+ * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
  * ## Example

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -12,6 +12,9 @@ export interface DownloadOptions {
  * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
+ * See also `Brioche.download`, which does not require specifying
+ * a hash, but only works with a constant URL.
+ *
  * ## Example
  *
  * std.download({


### PR DESCRIPTION
Companion PR: brioche-dev/brioche#102

Part of brioche-dev/brioche#70

This PR adds an implementation for `Brioche.download()` on the `Brioche` global. Just like with the other functions for statics, the implementation is pretty simple and just uses the `op_brioche_get_static` op to do the heavy lifting

Here's an example snippet that could be used in [the `jq` package](https://github.com/brioche-dev/brioche-packages/blob/f5578a79c7e2e22bfce77438bc2ba4571804a192/packages/jq/project.bri):

```typescript
const source = Brioche.download(
  "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-1.7.1.tar.gz",
)
  .unarchive("tar", "gzip")
  .peel();
```

## Left to do

- [x] Release new stable version of Brioche with support for `Brioche.download()`
- [x] Add version check to prevent usage on prior versions of Brioche