### PR TITLE
feat: Add jujutsu package

### DIFF
--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -1,0 +1,27 @@
+import * as std from "std";
+import openssl from "openssl";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "jujutsu",
+  version: "0.19.0",
+};
+
+const source = std
+  .download({
+    url: `https://github.com/martinvonz/jj/archive/refs/tags/v${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "d0b9db21894e65ec80fd7999f99023f1e65d15fa16b4ec76881247d9cd56dc55",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default () => {
+  return cargoBuild({
+    source,
+    runnable: "bin/jj",
+    path: "cli",
+    dependencies: [openssl()],
+  });
+};


### PR DESCRIPTION
Add the tool [jujutsu](https://github.com/martinvonz/jj)

Tested with:

```bash
bash-5.2$ brioche install -p packages/jujutsu/           
Build finished, completed (no new jobs) in 2.18s
Writing output
Wrote output to /home/container/.local/share/brioche/installed


bash-5.2$ jj --version
jj 0.19.0
```