### PR TITLE
feat: Add ruff package

### DIFF
--- a/packages/ruff/brioche.lock
+++ b/packages/ruff/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -12,12 +12,14 @@ const sourceTar = std.download({
     "7d3e1d6405a5c0e9bf13b947b80327ba7330f010060aaba514feecfd6d585251",
   ),
 });
-const source = std.process({
-  command: "tar",
-  args: ["-xf", sourceTar, "--strip-components=1", "-C", std.outputPath],
-  outputScaffold: std.directory(),
-  dependencies: [std.tools()],
-});
+const source = std
+  .process({
+    command: "tar",
+    args: ["-xf", sourceTar, "--strip-components=1", "-C", std.outputPath],
+    outputScaffold: std.directory(),
+    dependencies: [std.tools()],
+  })
+  .toDirectory();
 
 export default () => {
   return cargoBuild({

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -1,0 +1,28 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "ruff",
+  version: "0.5.3",
+};
+
+const sourceTar = std.download({
+  url: `https://github.com/astral-sh/ruff/archive/refs/tags/${project.version}.tar.gz`,
+  hash: std.sha256Hash(
+    "7d3e1d6405a5c0e9bf13b947b80327ba7330f010060aaba514feecfd6d585251",
+  ),
+});
+const source = std.process({
+  command: "tar",
+  args: ["-xf", sourceTar, "--strip-components=1", "-C", std.outputPath],
+  outputScaffold: std.directory(),
+  dependencies: [std.tools()],
+});
+
+export default () => {
+  return cargoBuild({
+    source,
+    path: "crates/ruff",
+    runnable: "bin/ruff",
+  });
+};


### PR DESCRIPTION
Add [ruff](https://github.com/astral-sh/ruff) tool. Based on @kylewlacy's comment https://github.com/brioche-dev/brioche/issues/103#issuecomment-2241778792.

Tested with:

```bash
bash-5.2$ brioche install -p packages/ruff     
[17205]    Compiling ruff_linter v0.5.3 (/home/brioche-runner-d5be76f5f48436b982fa26da047d369eb7ce00bff
eb3f7ee9ed26c61c43572c8/work/crates/ruff_linter)                                                       
[17205]    Compiling clap_complete_command v0.6.1                                                      
[17205]    Compiling cachedir v0.3.1                                                                   
[17205]    Compiling bincode v1.3.3                                                                    
[17205]    Compiling wild v2.2.1                                                                       
[17205]    Compiling ruff_workspace v0.0.0 (/home/brioche-runner-d5be76f5f48436b982fa26da047d369eb7ce00
bffeb3f7ee9ed26c61c43572c8/work/crates/ruff_workspace)                                                 
[17205]    Compiling ruff_server v0.2.2 (/home/brioche-runner-d5be76f5f48436b982fa26da047d369eb7ce00bff
eb3f7ee9ed26c61c43572c8/work/crates/ruff_server)                                                       
[17205]    Compiling tikv-jemallocator v0.6.0                                                          
[17205]     Finished `release` profile [optimized] target(s) in 7m 54s                                 
[17205]   Installing /home/brioche-runner-d5be76f5f48436b982fa26da047d369eb7ce00bffeb3f7ee9ed26c61c4357
2c8/.local/share/brioche/outputs/output-d5be76f5f48436b982fa26da047d369eb7ce00bffeb3f7ee9ed26c61c43572c
8/bin/ruff                                                                                             
[17205]    Installed package `ruff v0.5.3 (/home/brioche-runner-d5be76f5f48436b982fa26da047d369eb7ce00b
ffeb3f7ee9ed26c61c43572c8/work/crates/ruff)` (executable `ruff`)                                       
                                                                                                       
Process 17205 [7:55.1 Exited 0]
Process 17167 [17.92s Exited 0]
Process 17165 [173.1ms Exited 0]
Build finished, completed 5 jobs in 9:18.8
Writing output
Wrote output to /home/container/.local/share/brioche/installed



bash-5.2$ ruff --version
ruff 0.5.3
```