### PR TITLE
feat: Add alsa-lib package

### DIFF
--- a/packages/alsa_lib/brioche.lock
+++ b/packages/alsa_lib/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 
 export const project = {
-  name: "alsa-lib",
+  name: "alsa_lib",
   version: "1.2.12",
 };
 

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -1,0 +1,32 @@
+import * as std from "std";
+
+export const project = {
+  name: "alsa-lib",
+  version: "1.2.12",
+};
+
+const source = std
+  .download({
+    url: `https://www.alsa-project.org/files/pub/lib/alsa-lib-${project.version}.tar.bz2`,
+    hash: std.sha256Hash(
+      "4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2",
+    ),
+  })
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default (): std.Recipe<std.Directory> => {
+  const alsaLib = std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  return std.setEnv(alsaLib, {
+    CPATH: { path: "include" },
+    LIBRARY_PATH: { path: "lib" },
+    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+  });
+};


### PR DESCRIPTION
Add [alsa-lib](https://github.com/astral-sh/ruff) tool.

There are two possibilities to get the source of alsa-lib:

- through git: https://github.com/alsa-project/alsa-lib
- through their website: https://github.com/alsa-project/alsa-lib

Following what is stated [here](https://github.com/alsa-project/alsa-lib/blob/master/INSTALL), the tarball archive from the website is already pre-configured to compile it, while the git sources needed another step to set up the build process by calling the script `gitcompile`. I decided to follow what is already done on [Nixpkgs store](https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/by-name/al/alsa-lib/package.nix#L39) and on [Homebrew store](https://github.com/Homebrew/homebrew-core/blob/5d936da59a39bab63aad4edd3f6835673388bb27/Formula/a/alsa-lib.rb) by using the tarball archive from the website.

I was trying to package [Sniffnet](https://github.com/GyulyVGC/sniffnet), but alsa-lib is a required package.