### PR TITLE
feat: Add pcre2 package

### DIFF
--- a/packages/pcre2/brioche.lock
+++ b/packages/pcre2/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+
+export const project = {
+  name: "pcre2",
+  version: "10.44",
+};
+
+const source = std
+  .download({
+    url: `https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "07a002e8216382a96f722bc4a831f3d77457fe3e9e62a6dff250a2dd0e9c5e6d",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  let pcre2 = std.runBash`
+    # Some of the build scripts hardcode a few paths, so we need to
+    # create symlinks and set _lt_pkgdatadir to point to the correct
+    # location.
+    mkdir -p "$TMPDIR"/pkgdatadir
+    ln -s "$toolchain"/share/libtool/build-aux "$TMPDIR"/pkgdatadir/build-aux
+    ln -s "$toolchain"/share/libtool "$TMPDIR"/pkgdatadir/libltdl
+    ln -s "$toolchain"/share/aclocal "$TMPDIR"/pkgdatadir/m4
+    export _lt_pkgdatadir="$TMPDIR"/pkgdatadir
+
+    ./autogen.sh
+    ./configure \\
+      --prefix=/ \\
+      --enable-jit \\
+      --enable-pcre2-8 \\
+      --enable-pcre2-16 \\
+      --enable-pcre2-32
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain())
+    .workDir(source)
+    // `GREP` and `SED` are defined in libtool's scripts, but the values are
+    // hardcoded. Setting them here ensures that the build scripts can properly
+    // find them.
+    .env({
+      toolchain: std.toolchain(),
+      GREP: "grep",
+      SED: "sed",
+      ...autotoolsEnv(),
+    })
+    .toDirectory();
+
+  return std.setEnv(pcre2, {
+    CPATH: { path: "include" },
+    LIBRARY_PATH: { path: "lib" },
+    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+  });
+}
+
+// HACK: This should be removed once `std.toolchain()` properly sets
+// these variables for autotools
+function autotoolsEnv(): Record<string, std.ProcessTemplateLike> {
+  return {
+    M4: std.tpl`${std.toolchain()}/bin/m4`,
+    AUTOM4TE: std.tpl`${std.toolchain()}/bin/autom4te`,
+    trailer_m4: std.tpl`${std.toolchain()}/share/autoconf/autoconf/trailer.m4`,
+    PERL5LIB: std.tpl`${std.toolchain()}/share/autoconf:${std.toolchain()}/share/automake-1.16`,
+    autom4te_perllibdir: std.tpl`${std.toolchain()}/share/autoconf`,
+    AC_MACRODIR: std.tpl`${std.toolchain()}/share/autoconf`,
+    ACLOCAL_AUTOMAKE_DIR: std.tpl`${std.toolchain()}/share/aclocal-1.16`,
+    AUTOMAKE_UNINSTALLED: "1",
+    AUTOCONF: std.tpl`${std.toolchain()}/bin/autoconf`,
+    AUTOMAKE_LIBDIR: std.tpl`${std.toolchain()}/share/automake-1.16`,
+  };
+}

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -16,7 +16,7 @@ const source = std
   .peel();
 
 export default function (): std.Recipe<std.Directory> {
-  let pcre2 = std.runBash`
+  const pcre2 = std.runBash`
     # Some of the build scripts hardcode a few paths, so we need to
     # create symlinks and set _lt_pkgdatadir to point to the correct
     # location.


### PR DESCRIPTION
Resolve #45 

Package [pcre2](https://github.com/PCRE2Project/pcre2) which is a common library used by other tools such as `git`, `ripgrep`, etc.

The packaging is a bit hacky due to hard-coded paths in a few build scripts, see the discussion in the related issue #45.

```bash
bash-5.2$ brioche build -p packages/pcre2 -o /tmp/pcre2
Build finished, completed (no new jobs) in 2.76s
Result: 26526a47af9efabb19badc404039cf41aa89874b3bdd1d3bf37f39c743d4715d
Writing output
Wrote output to /tmp/pcre2

bash-5.2$ ls /tmp/pcre2
bin  brioche-env.d  brioche-resources.d  include  lib  share

bash-5.2$ ls /tmp/pcre2/lib/pkgconfig/
libpcre2-16.pc  libpcre2-32.pc  libpcre2-8.pc  libpcre2-posix.pc
```