### PR TITLE
Add ripgrep package

### DIFF
--- a/packages/ripgrep/brioche.lock
+++ b/packages/ripgrep/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -1,0 +1,27 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "ripgrep",
+  version: "14.1.0",
+};
+
+const source = std
+  .download({
+    url: `https://github.com/BurntSushi/ripgrep/archive/refs/tags/${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default () => {
+  return cargoBuild({
+    source,
+    buildParams: {
+      features: ["pcre2"],
+    },
+    runnable: "bin/rg",
+  });
+};

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -112,12 +112,17 @@ async function rust(): Promise<std.Recipe<std.Directory>> {
 }
 export default rust;
 
+interface CargoBuildParameters {
+  features?: string[];
+}
+
 export interface CargoBuildOptions {
   source: std.AsyncRecipe<std.Directory>;
   path?: string;
   runnable?: string;
   dependencies?: std.AsyncRecipe<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
+  buildParams?: CargoBuildParameters;
 }
 
 /**
@@ -133,6 +138,8 @@ export interface CargoBuildOptions {
  *   by default (e.g. `bin/foo`).
  * - `dependencies`: Optionally add additional dependencies to the build.
  * - `env`: Optionally set environment variables for the build.
+ * - `buildParams`: Optional build parameters:
+ *   - `features`: An array of features to enable.
  *
  * ## Example
  *
@@ -147,6 +154,9 @@ export interface CargoBuildOptions {
  *     dependencies: [openssl()],
  *     env: {
  *       CARGO_LOG: "debug",
+ *     },
+ *     buildParams: {
+ *      features: ["foo", "bar"],
  *     },
  *   });
  * };
@@ -195,13 +205,16 @@ export function cargoBuild(options: CargoBuildOptions) {
 
   // Use `cargo install` to build and install the project to `$BRIOCHE_OUTPUT`
   let buildResult = std.runBash`
-    cargo install --path "$crate_path" --frozen
+    cargo install --path "$crate_path" $features --frozen
   `
     .dependencies(rust(), std.toolchain(), ...(options.dependencies ?? []))
     .env({
       CARGO_INSTALL_ROOT: std.outputPath,
       PATH: std.tpl`${std.outputPath}/bin`,
       crate_path: options.path ?? ".",
+      features: options.buildParams?.features
+        ? featuresWrapper(options.buildParams.features)
+        : "",
       ...options.env,
     })
     .workDir(crate)
@@ -251,4 +264,15 @@ function cargoChef(): std.Recipe<std.Directory> {
   return std.directory({
     bin: pkg.unarchive("tar", "gzip"),
   });
+}
+
+/**
+ * Wrapper function to generate a string of features for a Cargo build.
+ *
+ * @param features An array of features.
+ * @returns A string of features for a Cargo build.
+ */
+function featuresWrapper(features: string[]): string {
+  // From ["feature1", "feature2", "feature3"] to '--features feature1,feature2,feature3'
+  return `--features ${features.join(",")}`;
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -212,9 +212,10 @@ export function cargoBuild(options: CargoBuildOptions) {
       CARGO_INSTALL_ROOT: std.outputPath,
       PATH: std.tpl`${std.outputPath}/bin`,
       crate_path: options.path ?? ".",
-      features: options.buildParams?.features
-        ? featuresWrapper(options.buildParams.features)
-        : "",
+      features:
+        options.buildParams?.features != null
+          ? featuresWrapper(options.buildParams.features)
+          : "",
       ...options.env,
     })
     .workDir(crate)


### PR DESCRIPTION
Package [ripgrep](https://github.com/BurntSushi/ripgrep).

Finally, I didn't need #81, since pcre2 library was built from the crate https://github.com/BurntSushi/rust-pcre2.

This PR also contains a new way to set cargo build option based on what's already done with go build parameters.