### PR TITLE
feat: Add oniguruma package

### DIFF
--- a/packages/oniguruma/brioche.lock
+++ b/packages/oniguruma/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -1,0 +1,70 @@
+import * as std from "std";
+
+export const project = {
+  name: "oniguruma",
+  version: "6.9.9",
+};
+
+const source = std
+  .download({
+    url: `https://github.com/kkos/oniguruma/archive/refs/tags/v${project.version}.tar.gz`,
+    hash: std.sha256Hash(
+      "001aa1202e78448f4c0bf1a48c76e556876b36f16d92ce3207eccfd61d99f2a0",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  let oniguruma = std.runBash`
+    # Some of the build scripts hardcode a few paths, so we need to
+    # create symlinks and set _lt_pkgdatadir to point to the correct
+    # location.
+    mkdir -p "$TMPDIR"/pkgdatadir
+    ln -s "$toolchain"/share/libtool/build-aux "$TMPDIR"/pkgdatadir/build-aux
+    ln -s "$toolchain"/share/libtool "$TMPDIR"/pkgdatadir/libltdl
+    ln -s "$toolchain"/share/aclocal "$TMPDIR"/pkgdatadir/m4
+    export _lt_pkgdatadir="$TMPDIR"/pkgdatadir
+
+    autoreconf --install --force --verbose -I "$aclocal_dir"
+    ./configure \\
+      --prefix=/ \\
+      --enable-posix-api=yes
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain())
+    .workDir(source)
+    .env({
+      toolchain: std.toolchain(),
+      aclocal_dir: std.tpl`${std.toolchain()}/share/aclocal`,
+      ...autotoolsEnv(),
+    })
+    .toDirectory();
+
+  oniguruma = std.setEnv(oniguruma, {
+    CPATH: { path: "include" },
+    LIBRARY_PATH: { path: "lib" },
+    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+  });
+
+  return std.withRunnableLink(oniguruma, "bin/onig-config");
+}
+
+// HACK: This should be removed once `std.toolchain()` properly sets
+// these variables for autotools
+function autotoolsEnv(): Record<string, std.ProcessTemplateLike> {
+  return {
+    M4: std.tpl`${std.toolchain()}/bin/m4`,
+    AUTOM4TE: std.tpl`${std.toolchain()}/bin/autom4te`,
+    trailer_m4: std.tpl`${std.toolchain()}/share/autoconf/autoconf/trailer.m4`,
+    PERL5LIB: std.tpl`${std.toolchain()}/share/autoconf:${std.toolchain()}/share/automake-1.16`,
+    autom4te_perllibdir: std.tpl`${std.toolchain()}/share/autoconf`,
+    AC_MACRODIR: std.tpl`${std.toolchain()}/share/autoconf`,
+    ACLOCAL_AUTOMAKE_DIR: std.tpl`${std.toolchain()}/share/aclocal-1.16`,
+    AUTOMAKE_UNINSTALLED: "1",
+    AUTOCONF: std.tpl`${std.toolchain()}/bin/autoconf`,
+    AUTOMAKE_LIBDIR: std.tpl`${std.toolchain()}/share/automake-1.16`,
+    AUTOHEADER: std.tpl`${std.toolchain()}/bin/autoheader`,
+  };
+}


### PR DESCRIPTION
Resolve #50 

Add [oniguruma](https://github.com/kkos/oniguruma) package.

Some hacks have been taken from #81, but it also contains two additional modifications:

1. `AUTOHEADER`is set as part of the `autotoolsEnv(). Without it, the tool wasn't found correctly
2. I also set `aclocal_dir` to give it as input to `autoreconf` to find correctly the tool `libtool`

Tested with:

```bash
bash-5.2$ brioche install -p packages/oniguruma                  
Build finished, completed (no new jobs) in 1.48s
Writing output
Wrote output to /home/container/.local/share/brioche/installed


bash-5.2$ onig-config 
Usage: onig-config [OPTION]

  Values for OPTION are:
  --prefix[=DIR]       change prefix to DIR
  --prefix             print prefix
  --exec-prefix[=DIR]  change exec_prefix to DIR
  --exec-prefix        print exec_prefix
  --cflags             print C compiler flags
  --libs               print library information
  --version            print oniguruma version
  --help               print this help
```