### PR TITLE
build: update broot version to 1.41.1

### DIFF
--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -3,14 +3,14 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "broot",
-  version: "1.40.0",
+  version: "1.41.1",
 };
 
 const source = std
   .download({
     url: `https://github.com/Canop/broot/archive/refs/tags/v${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "2b3cd1b01a71f102e5f26836afdf2b6ef24e02ecf7c5459cc9863e2e670a27da",
+      "a784f31833b4cd11386309c2816c8e2f48594cc7658feca63bc57886cd7a566c",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
Changelog:

- https://github.com/Canop/broot/releases/tag/v1.41.0
- https://github.com/Canop/broot/releases/tag/v1.41.1

Tested with:

```bash
Process 103 [6:11.3 Exited 0]
Process 97 [14.03s Exited 0]
Process 95 [200.7ms Exited 0]
Build finished, completed 6 jobs in 7:09.6
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ broot --version
broot 1.41.1
```