### PR TITLE
build: update carapace version to 1.0.5

### DIFF
--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -3,14 +3,14 @@ import { goBuild } from "go";
 
 export const project = {
   name: "carapace",
-  version: "1.0.4",
+  version: "1.0.5",
 };
 
 const source = std
   .download({
     url: `https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "745bf9cbbfc205ddc42c8a09b7a05534be792672ed9dc97bd670f74973438e1b",
+      "25555206b1b5350cba3567463cb2c5b87c43fad20d4e8200ab78d49371c0b4db",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
Changelog:

- https://github.com/carapace-sh/carapace-bin/releases/tag/v1.0.5

Tested with:

```bash
bash-5.2$ brioche install -p packages/carapace
Process 12934 [2:12.2 Exited 0]
Process 12923 [2.71s Exited 0]
[100%] Downloaded https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v1.0.5.tar.gz
Build finished, completed 4 jobs in 2:55.2
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ carapace --version
1.0.5
```