### PR TITLE
build: update curl version to 8.9.1

### DIFF
--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -3,14 +3,14 @@ import openssl from "openssl";
 
 export const project = {
   name: "curl",
-  version: "8.8.0",
+  version: "8.9.1",
 };
 
 const source = std
   .download({
     url: `https://curl.se/download/curl-${project.version}.tar.gz`,
     hash: std.sha256Hash(
-      "77c0e1cd35ab5b45b659645a93b46d660224d0024f1185e8a95cdb27ae3d787d",
+      "291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5",
     ),
   })
   .unarchive("tar", "gzip")


### PR DESCRIPTION
Changelog:

- https://curl.se/changes.html

Tested with:

```bash
53423f8941b5cbe61/work'                                                                                 
Process 22101 [19:01.6 Exited 0]
[100%] Downloaded https://curl.se/download/curl-8.9.1.tar.gz
[100%] Unarchived
Build finished, completed 3 jobs in 19:17.5
Writing output
Wrote output to /home/container/.local/share/brioche/installed
bash-5.2$ curl --version
curl 8.9.1 (x86_64-pc-linux-gnu) libcurl/8.9.1 OpenSSL/3.3.1 zlib/1.2.13 zstd/1.5.5
Release-Date: 2024-07-31
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS HSTS HTTPS-proxy IPv6 Largefile libz NTLM SSL threadsafe TLS-SRP UnixSockets zstd
```