### PR TITLE
Fix build errors from upgrade to Rust 1.80.0

### DIFF
--- a/packages/joshuto/joshuto-v0.9.8.patch
+++ b/packages/joshuto/joshuto-v0.9.8.patch
@@ -1,0 +1,742 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 0640c44..ab970fc 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -22,18 +22,18 @@ dependencies = [
+
+ [[package]]
+ name = "aho-corasick"
+-version = "1.1.2"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
++checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+ dependencies = [
+  "memchr",
+ ]
+
+ [[package]]
+ name = "allocator-api2"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
++checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+ [[package]]
+ name = "alphanumeric-sort"
+@@ -117,9 +117,9 @@ dependencies = [
+
+ [[package]]
+ name = "autocfg"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
++checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+ [[package]]
+ name = "base64"
+@@ -141,9 +141,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+ [[package]]
+ name = "bitflags"
+-version = "2.4.2"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
++checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+ dependencies = [
+  "serde",
+ ]
+@@ -161,9 +161,9 @@ dependencies = [
+
+ [[package]]
+ name = "bumpalo"
+-version = "3.15.4"
++version = "3.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
++checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+ [[package]]
+ name = "bytemuck"
+@@ -194,9 +194,9 @@ dependencies = [
+
+ [[package]]
+ name = "cc"
+-version = "1.0.90"
++version = "1.0.94"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
++checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+ dependencies = [
+  "jobserver",
+  "libc",
+@@ -216,23 +216,23 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+ [[package]]
+ name = "chrono"
+-version = "0.4.35"
++version = "0.4.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
++checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+ dependencies = [
+  "android-tzdata",
+  "iana-time-zone",
+  "js-sys",
+  "num-traits",
+  "wasm-bindgen",
+- "windows-targets 0.52.4",
++ "windows-targets 0.52.5",
+ ]
+
+ [[package]]
+ name = "clap"
+-version = "4.5.3"
++version = "4.5.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
++checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -252,23 +252,23 @@ dependencies = [
+
+ [[package]]
+ name = "clap_complete"
+-version = "4.5.1"
++version = "4.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
++checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+ dependencies = [
+  "clap",
+ ]
+
+ [[package]]
+ name = "clap_derive"
+-version = "4.5.3"
++version = "4.5.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
++checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+ dependencies = [
+  "heck 0.5.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -459,9 +459,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+ [[package]]
+ name = "either"
+-version = "1.10.0"
++version = "1.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
++checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+ [[package]]
+ name = "endian-type"
+@@ -582,9 +582,9 @@ dependencies = [
+
+ [[package]]
+ name = "getrandom"
+-version = "0.2.12"
++version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
++checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+ dependencies = [
+  "cfg-if",
+  "libc",
+@@ -603,11 +603,11 @@ dependencies = [
+
+ [[package]]
+ name = "git2"
+-version = "0.18.2"
++version = "0.18.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
++checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "libc",
+  "libgit2-sys",
+  "log",
+@@ -629,9 +629,9 @@ dependencies = [
+
+ [[package]]
+ name = "half"
+-version = "2.4.0"
++version = "2.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
++checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+ dependencies = [
+  "cfg-if",
+  "crunchy",
+@@ -727,9 +727,9 @@ dependencies = [
+
+ [[package]]
+ name = "indexmap"
+-version = "2.2.5"
++version = "2.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
++checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+ dependencies = [
+  "equivalent",
+  "hashbrown",
+@@ -737,9 +737,9 @@ dependencies = [
+
+ [[package]]
+ name = "indoc"
+-version = "2.0.4"
++version = "2.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
++checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+ [[package]]
+ name = "inotify"
+@@ -797,15 +797,15 @@ dependencies = [
+
+ [[package]]
+ name = "itoa"
+-version = "1.0.10"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
++checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+ [[package]]
+ name = "jobserver"
+-version = "0.1.28"
++version = "0.1.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
++checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+ dependencies = [
+  "libc",
+ ]
+@@ -816,7 +816,7 @@ version = "0.9.8"
+ dependencies = [
+  "alphanumeric-sort",
+  "ansi-to-tui",
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "chrono",
+  "clap",
+  "clap_complete",
+@@ -922,31 +922,30 @@ dependencies = [
+
+ [[package]]
+ name = "libredox"
+-version = "0.0.1"
++version = "0.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
++checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "libc",
+  "redox_syscall",
+ ]
+
+ [[package]]
+ name = "libredox"
+-version = "0.0.2"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
++checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "libc",
+- "redox_syscall",
+ ]
+
+ [[package]]
+ name = "libz-sys"
+-version = "1.1.15"
++version = "1.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
++checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -996,9 +995,9 @@ dependencies = [
+
+ [[package]]
+ name = "memchr"
+-version = "2.7.1"
++version = "2.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
++checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+ [[package]]
+ name = "minimal-lexical"
+@@ -1054,7 +1053,7 @@ version = "0.28.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "cfg-if",
+  "cfg_aliases",
+  "libc",
+@@ -1076,7 +1075,7 @@ version = "6.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "crossbeam-channel",
+  "filetime",
+  "fsevent-sys",
+@@ -1208,7 +1207,7 @@ dependencies = [
+  "phf_shared",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -1253,9 +1252,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.79"
++version = "1.0.80"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
++checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -1271,9 +1270,9 @@ dependencies = [
+
+ [[package]]
+ name = "quote"
+-version = "1.0.35"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -1324,7 +1323,7 @@ version = "0.26.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "cassowary",
+  "compact_str",
+  "indoc",
+@@ -1357,9 +1356,9 @@ dependencies = [
+
+ [[package]]
+ name = "rayon"
+-version = "1.9.0"
++version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
++checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+ dependencies = [
+  "either",
+  "rayon-core",
+@@ -1392,20 +1391,20 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+ [[package]]
+ name = "redox_users"
+-version = "0.4.4"
++version = "0.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
++checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+ dependencies = [
+  "getrandom",
+- "libredox 0.0.1",
++ "libredox 0.1.3",
+  "thiserror",
+ ]
+
+ [[package]]
+ name = "regex"
+-version = "1.10.3"
++version = "1.10.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
++checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -1426,17 +1425,17 @@ dependencies = [
+
+ [[package]]
+ name = "regex-syntax"
+-version = "0.8.2"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
++checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+ [[package]]
+ name = "rustix"
+-version = "0.38.31"
++version = "0.38.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
++checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "errno",
+  "libc",
+  "linux-raw-sys",
+@@ -1445,9 +1444,9 @@ dependencies = [
+
+ [[package]]
+ name = "rustversion"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
++checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+ [[package]]
+ name = "rustyline"
+@@ -1455,7 +1454,7 @@ version = "12.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "cfg-if",
+  "clipboard-win",
+  "fd-lock",
+@@ -1510,7 +1509,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -1585,9 +1584,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+ [[package]]
+ name = "smallvec"
+-version = "1.13.1"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+ [[package]]
+ name = "spin"
+@@ -1622,9 +1621,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+ [[package]]
+ name = "strsim"
+-version = "0.11.0"
++version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
++checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+ [[package]]
+ name = "strum"
+@@ -1645,7 +1644,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "rustversion",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -1661,9 +1660,9 @@ dependencies = [
+
+ [[package]]
+ name = "syn"
+-version = "2.0.52"
++version = "2.0.59"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
++checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -1711,7 +1710,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -1727,9 +1726,9 @@ dependencies = [
+
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -1750,9 +1749,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",
+@@ -1775,9 +1774,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+ [[package]]
+ name = "toml"
+-version = "0.8.11"
++version = "0.8.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
++checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+ dependencies = [
+  "serde",
+  "serde_spanned",
+@@ -1796,9 +1795,9 @@ dependencies = [
+
+ [[package]]
+ name = "toml_edit"
+-version = "0.22.7"
++version = "0.22.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
++checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+ dependencies = [
+  "indexmap",
+  "serde",
+@@ -1894,9 +1893,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+ [[package]]
+ name = "uuid"
+-version = "1.7.0"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
++checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+ dependencies = [
+  "getrandom",
+  "rand",
+@@ -1905,13 +1904,13 @@ dependencies = [
+
+ [[package]]
+ name = "uuid-macro-internal"
+-version = "1.7.0"
++version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7abb14ae1a50dad63eaa768a458ef43d298cd1bd44951677bd10b732a9ba2a2d"
++checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]
+@@ -1969,7 +1968,7 @@ dependencies = [
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+  "wasm-bindgen-shared",
+ ]
+
+@@ -1991,7 +1990,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+@@ -2066,7 +2065,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+ dependencies = [
+- "windows-targets 0.52.4",
++ "windows-targets 0.52.5",
+ ]
+
+ [[package]]
+@@ -2084,7 +2083,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+ dependencies = [
+- "windows-targets 0.52.4",
++ "windows-targets 0.52.5",
+ ]
+
+ [[package]]
+@@ -2104,17 +2103,18 @@ dependencies = [
+
+ [[package]]
+ name = "windows-targets"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
++checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.52.4",
+- "windows_aarch64_msvc 0.52.4",
+- "windows_i686_gnu 0.52.4",
+- "windows_i686_msvc 0.52.4",
+- "windows_x86_64_gnu 0.52.4",
+- "windows_x86_64_gnullvm 0.52.4",
+- "windows_x86_64_msvc 0.52.4",
++ "windows_aarch64_gnullvm 0.52.5",
++ "windows_aarch64_msvc 0.52.5",
++ "windows_i686_gnu 0.52.5",
++ "windows_i686_gnullvm",
++ "windows_i686_msvc 0.52.5",
++ "windows_x86_64_gnu 0.52.5",
++ "windows_x86_64_gnullvm 0.52.5",
++ "windows_x86_64_msvc 0.52.5",
+ ]
+
+ [[package]]
+@@ -2125,9 +2125,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
++checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+ [[package]]
+ name = "windows_aarch64_msvc"
+@@ -2137,9 +2137,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+ [[package]]
+ name = "windows_aarch64_msvc"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
++checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+ [[package]]
+ name = "windows_i686_gnu"
+@@ -2149,9 +2149,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+ [[package]]
+ name = "windows_i686_gnu"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
++checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
++
++[[package]]
++name = "windows_i686_gnullvm"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+ [[package]]
+ name = "windows_i686_msvc"
+@@ -2161,9 +2167,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+ [[package]]
+ name = "windows_i686_msvc"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
++checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+ [[package]]
+ name = "windows_x86_64_gnu"
+@@ -2173,9 +2179,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+ [[package]]
+ name = "windows_x86_64_gnu"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
++checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+@@ -2185,9 +2191,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
++checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+ [[package]]
+ name = "windows_x86_64_msvc"
+@@ -2197,15 +2203,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+ [[package]]
+ name = "windows_x86_64_msvc"
+-version = "0.52.4"
++version = "0.52.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
++checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+ [[package]]
+ name = "winnow"
+-version = "0.6.5"
++version = "0.6.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
++checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+ dependencies = [
+  "memchr",
+ ]
+@@ -2233,7 +2239,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.59",
+ ]
+
+ [[package]]

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -16,7 +16,8 @@ const source = std
   .unarchive("tar", "gzip")
   .peel();
 
-// This patch is derived from the `Cargo.lock` from this commit in Joshuto:
+// Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
+// from the `Cargo.lock` from this commit in Joshuto:
 // https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
 const patch = Brioche.includeFile("joshuto-v0.9.8.patch");
 

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -16,9 +16,21 @@ const source = std
   .unarchive("tar", "gzip")
   .peel();
 
+// This patch is derived from the `Cargo.lock` from this commit in Joshuto:
+// https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
+const patch = Brioche.includeFile("joshuto-v0.9.8.patch");
+
 export default () => {
+  const patchedSource = std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    patch -p1 < $patch
+  `
+    .outputScaffold(source)
+    .env({ patch })
+    .toDirectory();
+
   return cargoBuild({
-    source,
+    source: patchedSource,
     runnable: "bin/joshuto",
   });
 };

--- a/packages/miniserve/miniserve-v0.27.1.patch
+++ b/packages/miniserve/miniserve-v0.27.1.patch
@@ -1,0 +1,627 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 2c1cbe0..b37e58e 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -8,7 +8,7 @@ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "bytes",
+  "futures-core",
+  "futures-sink",
+@@ -29,7 +29,7 @@ dependencies = [
+  "actix-service",
+  "actix-utils",
+  "actix-web",
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "bytes",
+  "derive_more",
+  "futures-core",
+@@ -55,7 +55,7 @@ dependencies = [
+  "actix-utils",
+  "ahash",
+  "base64",
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "brotli",
+  "bytes",
+  "bytestring",
+@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+ dependencies = [
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -127,7 +127,7 @@ dependencies = [
+  "parse-size",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -259,7 +259,7 @@ dependencies = [
+  "actix-router",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -313,9 +313,9 @@ dependencies = [
+
+ [[package]]
+ name = "aho-corasick"
+-version = "1.1.2"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
++checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+ dependencies = [
+  "memchr",
+ ]
+@@ -406,9 +406,9 @@ dependencies = [
+
+ [[package]]
+ name = "anyhow"
+-version = "1.0.81"
++version = "1.0.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
++checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+ [[package]]
+ name = "assert_cmd"
+@@ -442,15 +442,15 @@ dependencies = [
+
+ [[package]]
+ name = "autocfg"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
++checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+ [[package]]
+ name = "backtrace"
+-version = "0.3.69"
++version = "0.3.71"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
++checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+ dependencies = [
+  "addr2line",
+  "cc",
+@@ -490,9 +490,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+ [[package]]
+ name = "bitflags"
+-version = "2.4.2"
++version = "2.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
++checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+ [[package]]
+ name = "block-buffer"
+@@ -505,9 +505,9 @@ dependencies = [
+
+ [[package]]
+ name = "brotli"
+-version = "3.4.0"
++version = "3.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
++checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+ dependencies = [
+  "alloc-no-stdlib",
+  "alloc-stdlib",
+@@ -537,9 +537,9 @@ dependencies = [
+
+ [[package]]
+ name = "bumpalo"
+-version = "3.15.4"
++version = "3.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
++checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+ [[package]]
+ name = "byteorder"
+@@ -549,9 +549,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+ [[package]]
+ name = "bytes"
+-version = "1.5.0"
++version = "1.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
++checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+ [[package]]
+ name = "bytesize"
+@@ -570,9 +570,9 @@ dependencies = [
+
+ [[package]]
+ name = "cc"
+-version = "1.0.90"
++version = "1.0.92"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
++checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+ dependencies = [
+  "jobserver",
+  "libc",
+@@ -586,9 +586,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+ [[package]]
+ name = "chrono"
+-version = "0.4.35"
++version = "0.4.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
++checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+ dependencies = [
+  "android-tzdata",
+  "iana-time-zone",
+@@ -609,9 +609,9 @@ dependencies = [
+
+ [[package]]
+ name = "clap"
+-version = "4.5.3"
++version = "4.5.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
++checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -626,29 +626,29 @@ dependencies = [
+  "anstream",
+  "anstyle",
+  "clap_lex",
+- "strsim 0.11.0",
++ "strsim 0.11.1",
+  "terminal_size",
+ ]
+
+ [[package]]
+ name = "clap_complete"
+-version = "4.5.1"
++version = "4.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
++checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+ dependencies = [
+  "clap",
+ ]
+
+ [[package]]
+ name = "clap_derive"
+-version = "4.5.3"
++version = "4.5.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
++checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+ dependencies = [
+  "heck 0.5.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -834,7 +834,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "strsim 0.10.0",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -856,7 +856,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+ dependencies = [
+  "darling_core 0.20.8",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -954,9 +954,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+ [[package]]
+ name = "encoding_rs"
+-version = "0.8.33"
++version = "0.8.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
++checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+ dependencies = [
+  "cfg-if",
+ ]
+@@ -997,9 +997,9 @@ checksum = "e3251e51cec6f8085d67b30363e51f35f40dde45e25507815559a9321ed4c251"
+
+ [[package]]
+ name = "fastrand"
+-version = "2.0.1"
++version = "2.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
++checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+ [[package]]
+ name = "filetime"
+@@ -1113,7 +1113,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -1164,9 +1164,9 @@ dependencies = [
+
+ [[package]]
+ name = "getrandom"
+-version = "0.2.12"
++version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
++checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+ dependencies = [
+  "cfg-if",
+  "libc",
+@@ -1204,7 +1204,7 @@ version = "0.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "ignore",
+  "walkdir",
+ ]
+@@ -1236,9 +1236,9 @@ dependencies = [
+
+ [[package]]
+ name = "h2"
+-version = "0.3.25"
++version = "0.3.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
++checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+ dependencies = [
+  "bytes",
+  "fnv",
+@@ -1457,14 +1457,14 @@ checksum = "560994ab35375da9b5338535c24e11b39cf3246918d755a04252d4405c98cb8d"
+ dependencies = [
+  "grass_compiler",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+ name = "indexmap"
+-version = "2.2.5"
++version = "2.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
++checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+ dependencies = [
+  "equivalent",
+  "hashbrown 0.14.3",
+@@ -1478,15 +1478,15 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+ [[package]]
+ name = "itoa"
+-version = "1.0.10"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
++checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+ [[package]]
+ name = "jobserver"
+-version = "0.1.28"
++version = "0.1.29"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
++checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+ dependencies = [
+  "libc",
+ ]
+@@ -1646,9 +1646,9 @@ dependencies = [
+
+ [[package]]
+ name = "memchr"
+-version = "2.7.1"
++version = "2.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
++checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+ [[package]]
+ name = "mime"
+@@ -1902,7 +1902,7 @@ dependencies = [
+  "phf_shared 0.11.2",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -1925,9 +1925,9 @@ dependencies = [
+
+ [[package]]
+ name = "pin-project-lite"
+-version = "0.2.13"
++version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
++checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+ [[package]]
+ name = "pin-utils"
+@@ -2040,9 +2040,9 @@ dependencies = [
+
+ [[package]]
+ name = "quote"
+-version = "1.0.35"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -2088,9 +2088,9 @@ dependencies = [
+
+ [[package]]
+ name = "regex"
+-version = "1.10.3"
++version = "1.10.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
++checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -2111,9 +2111,9 @@ dependencies = [
+
+ [[package]]
+ name = "regex-syntax"
+-version = "0.8.2"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
++checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+ [[package]]
+ name = "relative-path"
+@@ -2123,9 +2123,9 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+ [[package]]
+ name = "reqwest"
+-version = "0.11.26"
++version = "0.11.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
++checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+ dependencies = [
+  "base64",
+  "bytes",
+@@ -2230,7 +2230,7 @@ dependencies = [
+  "regex",
+  "relative-path",
+  "rustc_version",
+- "syn 2.0.52",
++ "syn 2.0.58",
+  "unicode-ident",
+ ]
+
+@@ -2251,11 +2251,11 @@ dependencies = [
+
+ [[package]]
+ name = "rustix"
+-version = "0.38.31"
++version = "0.38.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
++checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+ dependencies = [
+- "bitflags 2.4.2",
++ "bitflags 2.5.0",
+  "errno",
+  "libc",
+  "linux-raw-sys",
+@@ -2307,9 +2307,9 @@ dependencies = [
+
+ [[package]]
+ name = "rustversion"
+-version = "1.0.14"
++version = "1.0.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
++checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+ [[package]]
+ name = "ryu"
+@@ -2376,14 +2376,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+ name = "serde_json"
+-version = "1.0.114"
++version = "1.0.115"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
++checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+ dependencies = [
+  "itoa",
+  "ryu",
+@@ -2480,9 +2480,9 @@ dependencies = [
+
+ [[package]]
+ name = "smallvec"
+-version = "1.13.1"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
++checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+ [[package]]
+ name = "socket2"
+@@ -2540,9 +2540,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+ [[package]]
+ name = "strsim"
+-version = "0.11.0"
++version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
++checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+ [[package]]
+ name = "strum"
+@@ -2563,7 +2563,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "rustversion",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -2579,9 +2579,9 @@ dependencies = [
+
+ [[package]]
+ name = "syn"
+-version = "2.0.52"
++version = "2.0.58"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
++checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2691,14 +2691,14 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -2719,9 +2719,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",
+@@ -2744,9 +2744,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+ [[package]]
+ name = "tokio"
+-version = "1.36.0"
++version = "1.37.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
++checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+ dependencies = [
+  "backtrace",
+  "bytes",
+@@ -2976,7 +2976,7 @@ dependencies = [
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+  "wasm-bindgen-shared",
+ ]
+
+@@ -3010,7 +3010,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+@@ -3283,7 +3283,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.52",
++ "syn 2.0.58",
+ ]
+
+ [[package]]
+@@ -3299,27 +3299,27 @@ dependencies = [
+
+ [[package]]
+ name = "zstd"
+-version = "0.13.0"
++version = "0.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
++checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+ dependencies = [
+  "zstd-safe",
+ ]
+
+ [[package]]
+ name = "zstd-safe"
+-version = "7.0.0"
++version = "7.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
++checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+ dependencies = [
+  "zstd-sys",
+ ]
+
+ [[package]]
+ name = "zstd-sys"
+-version = "2.0.9+zstd.1.5.5"
++version = "2.0.10+zstd.1.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
++checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+ dependencies = [
+  "cc",
+  "pkg-config",

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -16,9 +16,22 @@ const source = std
   .unarchive("tar", "gzip")
   .peel();
 
+// Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
+// from the `Cargo.lock` from this commit in miniserve:
+// https://github.com/svenstaro/miniserve/commit/2fbfcbfe17b5c12630ccb03b6ccd31cb4b8316cc
+const patch = Brioche.includeFile("miniserve-v0.27.1.patch");
+
 export default () => {
+  const patchedSource = std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    patch -p1 < $patch
+  `
+    .outputScaffold(source)
+    .env({ patch })
+    .toDirectory();
+
   return cargoBuild({
-    source,
+    source: patchedSource,
     runnable: "bin/miniserve",
   });
 };


### PR DESCRIPTION
This PR adds some patches for the `joshuto` and `miniserve` packages to update their `Cargo.lock` files to fix a conflict between older versions of the `time` crate and Rust 1.80 (see time-rs/time#681 for more context).

Both Joshuto and miniserve have already been updated on their main branches to fix this issue, but neither fix had been in a released version yet. So, to come up with a patch, I bisected between the main branch and the release tag to find the first compiling commit, then made a patch by grabbing just the `Cargo.lock` from that commit. The commits I bisected to are below:

- https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
- https://github.com/svenstaro/miniserve/commit/2fbfcbfe17b5c12630ccb03b6ccd31cb4b8316cc

These patches should go away once each upstream project publishes a new version