### PR TITLE
Update all packages to use `Brioche.download` where possible

### DIFF
--- a/packages/ca_certificates/brioche.lock
+++ b/packages/ca_certificates/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://curl.se/ca/cacert-2024-07-02.pem": {
+      "type": "sha256",
+      "value": "1bf458412568e134a4514f5e170a328d11091e071c7110955c9884ed87972ac9"
+    }
+  }
 }

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -6,12 +6,9 @@ export const project = {
 };
 
 export default (): std.Recipe<std.Directory> => {
-  const cacert = std.download({
-    url: `https://curl.se/ca/cacert-${project.version}.pem`,
-    hash: std.sha256Hash(
-      "1bf458412568e134a4514f5e170a328d11091e071c7110955c9884ed87972ac9",
-    ),
-  });
+  const cacert = Brioche.download(
+    `https://curl.se/ca/cacert-${project.version}.pem`,
+  );
 
   return std.setEnv(
     std.directory({

--- a/packages/jq/brioche.lock
+++ b/packages/jq/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-1.7.1.tar.gz": {
+      "type": "sha256",
+      "value": "478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2"
+    }
+  }
 }

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "1.7.1",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/jqlang/jq/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/jqlang/jq/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
+      "type": "sha256",
+      "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
+    }
+  }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -241,12 +241,9 @@ export function createSkeletonCrate(
 }
 
 function cargoChef(): std.Recipe<std.Directory> {
-  const pkg = std.download({
-    url: "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
-    hash: std.sha256Hash(
-      "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc",
-    ),
-  });
+  const pkg = Brioche.download(
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
+  );
 
   return std.directory({
     bin: pkg.unarchive("tar", "gzip"),

--- a/packages/std/brioche.lock
+++ b/packages/std/brioche.lock
@@ -5,6 +5,30 @@
       "type": "sha256",
       "value": "f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
     },
+    "https://development-content.brioche.dev/github.com/brioche-dev/brioche-bootstrap/99ab9787d5ee27eb613227131e23d2c651de318a/brioche-bootstrap.tar.zstd": {
+      "type": "sha256",
+      "value": "0cabcd0a074e08ac132281f711f884777b47def17fbeff2a82ba011836b83d11"
+    },
+    "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd": {
+      "type": "sha256",
+      "value": "7f1539e866ff937c27008da0f4ca6618d48165548df99edfa7b137abcfb09a30"
+    },
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/busybox_amd64_linux.tar.xz": {
+      "type": "sha256",
+      "value": "e2e9ae181e115e155158cb9031687d943b0847d8058a4c28454194d835478be6"
+    },
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/make_static_linux_amd64.tar.xz": {
+      "type": "sha256",
+      "value": "f8a75f171c2c753bc86a331473812ddc24837d5e91b0b1c7af89d6a2aa6e8986"
+    },
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/toolchain_amd64_linux.tar.zstd": {
+      "type": "sha256",
+      "value": "27416708f7ee8cd0c5d408010192705b40c914647fd0d80f00c2194795828cd6"
+    },
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/utils_amd64_linux.tar.zstd": {
+      "type": "sha256",
+      "value": "eb29ea059fcd9ca457841f5c79151721a74761a31610d694bce61a62f4de6d33"
+    },
     "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/Python-3.11.4.tar.xz": {
       "type": "sha256",
       "value": "2f0e409df2ab57aa9fc4cbddfb976af44e4e55bf6f619eee6bc5c2297264a7f6"

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -82,6 +82,19 @@ declare global {
      * ```
      */
     function glob(...patterns: string[]): Recipe<Directory>;
+
+    /**
+     * Download a file from a URL. Unlike `std.download`, this function does
+     * not take a hash, and it **must** be called with a constant string URL.
+     * The hash of the downloaded file will be saved in the lockfile.
+     *
+     * ## Example
+     *
+     * ```typescript
+     * const file = Brioche.download("http://example.com/");
+     * ```
+     */
+    function download(url: string): Recipe<File>;
   }
 }
 
@@ -150,6 +163,27 @@ declare global {
         {
           type: "glob",
           patterns,
+        },
+      );
+    },
+  });
+};
+(globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to download ${url}`);
+  }
+
+  const sourceFile = sourceFrame.fileName;
+
+  return createRecipe(["file"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "download",
+          url,
         },
       );
     },

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -88,6 +88,8 @@ declare global {
      * not take a hash, and it **must** be called with a constant string URL.
      * The hash of the downloaded file will be saved in the lockfile.
      *
+     * See also `std.download`, which can be used even if URL is not constant.
+     *
      * ## Example
      *
      * ```typescript

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -9,7 +9,7 @@ export interface DownloadOptions {
 
 /**
  * Returns a recipe that will download a URL, and return
- * a file of its results. A has must be provided, and will
+ * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
  * ## Example

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -12,6 +12,9 @@ export interface DownloadOptions {
  * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
+ * See also `Brioche.download`, which does not require specifying
+ * a hash, but only works with a constant URL.
+ *
  * ## Example
  *
  * std.download({

--- a/packages/std/runnable_tools.bri
+++ b/packages/std/runnable_tools.bri
@@ -1,14 +1,9 @@
 import * as std from "/core";
 
 export function runtimeUtils(): std.Recipe<std.Directory> {
-  return std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
-      hash: std.sha256Hash(
-        "7f1539e866ff937c27008da0f4ca6618d48165548df99edfa7b137abcfb09a30",
-      ),
-    })
-    .unarchive("tar", "zstd");
+  return Brioche.download(
+    "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
+  ).unarchive("tar", "zstd");
 }
 
 interface RunnableData {

--- a/packages/std/toolchain/native/acl.bri
+++ b/packages/std/toolchain/native/acl.bri
@@ -3,12 +3,9 @@ import stage2 from "/toolchain/stage2";
 import attr from "./attr.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/acl-2.3.1.tar.xz",
-    hash: std.sha256Hash(
-      "c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/acl-2.3.1.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/attr.bri
+++ b/packages/std/toolchain/native/attr.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/attr-2.5.1.tar.gz",
-    hash: std.sha256Hash(
-      "bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/attr-2.5.1.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/autoconf.bri
+++ b/packages/std/toolchain/native/autoconf.bri
@@ -3,12 +3,9 @@ import { wrapWithScript } from "../utils.bri";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/autoconf-2.71.tar.xz",
-    hash: std.sha256Hash(
-      "f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/autoconf-2.71.tar.xz",
+  );
 
   let autoconf = std
     .process({

--- a/packages/std/toolchain/native/automake.bri
+++ b/packages/std/toolchain/native/automake.bri
@@ -4,12 +4,9 @@ import m4 from "./m4.bri";
 import autoconf from "./autoconf.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/automake-1.16.5.tar.xz",
-    hash: std.sha256Hash(
-      "f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/automake-1.16.5.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/bash.bri
+++ b/packages/std/toolchain/native/bash.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bash-5.2.15.tar.gz",
-    hash: std.sha256Hash(
-      "13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bash-5.2.15.tar.gz",
+  );
 
   let bash = std
     .process({

--- a/packages/std/toolchain/native/bc.bri
+++ b/packages/std/toolchain/native/bc.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bc-6.6.0.tar.xz",
-    hash: std.sha256Hash(
-      "309ef0faebf149376aa69446a496fac13c3ff483a100a51d9c67cea1a73b2906",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bc-6.6.0.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/binutils.bri
+++ b/packages/std/toolchain/native/binutils.bri
@@ -5,12 +5,9 @@ import flex from "./flex.bri";
 import zlib from "./zlib.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
-    hash: std.sha256Hash(
-      "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
+  );
 
   let binutils = std
     .process({

--- a/packages/std/toolchain/native/bison.bri
+++ b/packages/std/toolchain/native/bison.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bison-3.8.2.tar.xz",
-    hash: std.sha256Hash(
-      "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bison-3.8.2.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/bzip2.bri
+++ b/packages/std/toolchain/native/bzip2.bri
@@ -2,18 +2,12 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bzip2-1.0.8.tar.gz",
-    hash: std.sha256Hash(
-      "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
-    ),
-  });
-  const sourcePatch = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/bzip2-1.0.8-install_docs-1.patch",
-    hash: std.sha256Hash(
-      "35e3bbd9642af51fef2a8a83afba040d272da42d7e3a251d8e43255a7b496702",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bzip2-1.0.8.tar.gz",
+  );
+  const sourcePatch = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/bzip2-1.0.8-install_docs-1.patch",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/coreutils.bri
+++ b/packages/std/toolchain/native/coreutils.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/coreutils-9.3.tar.xz",
-    hash: std.sha256Hash(
-      "adbcfcfe899235b71e8768dcf07cd532520b7f54f9a8064843f8d199a904bbaa",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/coreutils-9.3.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/diffutils.bri
+++ b/packages/std/toolchain/native/diffutils.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/diffutils-3.10.tar.xz",
-    hash: std.sha256Hash(
-      "90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/diffutils-3.10.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/expat.bri
+++ b/packages/std/toolchain/native/expat.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/expat-2.5.0.tar.xz",
-    hash: std.sha256Hash(
-      "ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/expat-2.5.0.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/file.bri
+++ b/packages/std/toolchain/native/file.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/file-5.45.tar.gz",
-    hash: std.sha256Hash(
-      "fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/file-5.45.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/findutils.bri
+++ b/packages/std/toolchain/native/findutils.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/findutils-4.9.0.tar.xz",
-    hash: std.sha256Hash(
-      "a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/findutils-4.9.0.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/flex.bri
+++ b/packages/std/toolchain/native/flex.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/flex-2.6.4.tar.gz",
-    hash: std.sha256Hash(
-      "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/flex-2.6.4.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/gawk.bri
+++ b/packages/std/toolchain/native/gawk.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gawk-5.2.2.tar.xz",
-    hash: std.sha256Hash(
-      "3c1fce1446b4cbee1cd273bd7ec64bc87d89f61537471cd3e05e33a965a250e9",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gawk-5.2.2.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/gcc.bri
+++ b/packages/std/toolchain/native/gcc.bri
@@ -11,12 +11,9 @@ import mpc from "./mpc.bri";
 import libxcrypt from "./libxcrypt.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
+  );
 
   const buildSysroot = std.merge(
     linuxHeaders(),

--- a/packages/std/toolchain/native/gdbm.bri
+++ b/packages/std/toolchain/native/gdbm.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gdbm-1.23.tar.gz",
-    hash: std.sha256Hash(
-      "74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gdbm-1.23.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/gettext.bri
+++ b/packages/std/toolchain/native/gettext.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gettext-0.22.tar.xz",
-    hash: std.sha256Hash(
-      "0e60393a47061567b46875b249b7d2788b092d6457d656145bb0e7e6a3e26d93",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gettext-0.22.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/glibc.bri
+++ b/packages/std/toolchain/native/glibc.bri
@@ -2,24 +2,15 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/glibc-2.38.tar.xz",
-    hash: std.sha256Hash(
-      "fb82998998b2b29965467bc1b69d152e9c307d2cf301c9eafb4555b770ef3fd2",
-    ),
-  });
-  const sourcePatchFhs = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-fhs-1.patch",
-    hash: std.sha256Hash(
-      "643552db030e2f2d7ffde4f558e0f5f83d3fabf34a2e0e56ebdb49750ac27b0d",
-    ),
-  });
-  const sourcePatchMemalign = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-memalign_fix-1.patch",
-    hash: std.sha256Hash(
-      "3e4b4b15485c9767501151ccf1b33cf5ee912298fda899cd809277ece27e859c",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/glibc-2.38.tar.xz",
+  );
+  const sourcePatchFhs = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-fhs-1.patch",
+  );
+  const sourcePatchMemalign = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-memalign_fix-1.patch",
+  );
 
   let glibc = std
     .process({

--- a/packages/std/toolchain/native/gmp.bri
+++ b/packages/std/toolchain/native/gmp.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
-    hash: std.sha256Hash(
-      "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/gperf.bri
+++ b/packages/std/toolchain/native/gperf.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gperf-3.1.tar.gz",
-    hash: std.sha256Hash(
-      "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gperf-3.1.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/grep.bri
+++ b/packages/std/toolchain/native/grep.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/grep-3.11.tar.xz",
-    hash: std.sha256Hash(
-      "1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/grep-3.11.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/groff.bri
+++ b/packages/std/toolchain/native/groff.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/groff-1.23.0.tar.gz",
-    hash: std.sha256Hash(
-      "6b9757f592b7518b4902eb6af7e54570bdccba37a871fddb2d30ae3863511c13",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/groff-1.23.0.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/gzip.bri
+++ b/packages/std/toolchain/native/gzip.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gzip-1.12.tar.xz",
-    hash: std.sha256Hash(
-      "ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gzip-1.12.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/inetutils.bri
+++ b/packages/std/toolchain/native/inetutils.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/inetutils-2.4.tar.xz",
-    hash: std.sha256Hash(
-      "1789d6b1b1a57dfe2a7ab7b533ee9f5dfd9cbf5b59bb1bb3c2612ed08d0f68b2",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/inetutils-2.4.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/intltool.bri
+++ b/packages/std/toolchain/native/intltool.bri
@@ -5,12 +5,9 @@ import perlXmlParser from "./perl_xml_parser.bri";
 import expat from "./expat.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/intltool-0.51.0.tar.gz",
-    hash: std.sha256Hash(
-      "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/intltool-0.51.0.tar.gz",
+  );
 
   const perlDep = std.merge(perl(), perlXmlParser());
 

--- a/packages/std/toolchain/native/less.bri
+++ b/packages/std/toolchain/native/less.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/less-643.tar.gz",
-    hash: std.sha256Hash(
-      "c28dea82484a605590aa3dc0a173ab0a218a1293048ca4b42844bf10f1027eb5",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/less-643.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/libelf.bri
+++ b/packages/std/toolchain/native/libelf.bri
@@ -10,12 +10,9 @@ import zlib from "./zlib.bri";
 export default std.memo((): std.Recipe<std.Directory> => {
   const toolchain = std.merge(glibc(), binutils(), gcc(), linuxHeaders());
 
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/elfutils-0.189.tar.bz2",
-    hash: std.sha256Hash(
-      "39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/elfutils-0.189.tar.bz2",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/libpipeline.bri
+++ b/packages/std/toolchain/native/libpipeline.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libpipeline-1.5.7.tar.gz",
-    hash: std.sha256Hash(
-      "b8b45194989022a79ec1317f64a2a75b1551b2a55bea06f67704cb2a2e4690b0",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libpipeline-1.5.7.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/libtool.bri
+++ b/packages/std/toolchain/native/libtool.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libtool-2.4.7.tar.xz",
-    hash: std.sha256Hash(
-      "4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libtool-2.4.7.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/libxcrypt.bri
+++ b/packages/std/toolchain/native/libxcrypt.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libxcrypt-4.4.36.tar.xz",
-    hash: std.sha256Hash(
-      "e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/libxcrypt-4.4.36.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/linux_headers.bri
+++ b/packages/std/toolchain/native/linux_headers.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/linux-6.4.12.tar.xz",
-    hash: std.sha256Hash(
-      "cca91be956fe081f8f6da72034cded96fe35a50be4bfb7e103e354aa2159a674",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/linux-6.4.12.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/m4.bri
+++ b/packages/std/toolchain/native/m4.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/m4-1.4.19.tar.xz",
-    hash: std.sha256Hash(
-      "63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/m4-1.4.19.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/make.bri
+++ b/packages/std/toolchain/native/make.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/make-4.4.1.tar.gz",
-    hash: std.sha256Hash(
-      "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/make-4.4.1.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/man_db.bri
+++ b/packages/std/toolchain/native/man_db.bri
@@ -5,12 +5,9 @@ import libpipeline from "./libpipeline.bri";
 import groff from "./groff.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/man-db-2.11.2.tar.xz",
-    hash: std.sha256Hash(
-      "cffa1ee4e974be78646c46508e6dd2f37e7c589aaab2938cc1064f058fef9f8d",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/man-db-2.11.2.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/mpc.bri
+++ b/packages/std/toolchain/native/mpc.bri
@@ -4,12 +4,9 @@ import gmp from "./gmp.bri";
 import mpfr from "./mpfr.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
-    hash: std.sha256Hash(
-      "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/mpfr.bri
+++ b/packages/std/toolchain/native/mpfr.bri
@@ -3,12 +3,9 @@ import stage2 from "/toolchain/stage2";
 import gmp from "./gmp.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
+  );
 
   let mpfr = std
     .process({

--- a/packages/std/toolchain/native/ncurses.bri
+++ b/packages/std/toolchain/native/ncurses.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/ncurses-6.4.tar.gz",
-    hash: std.sha256Hash(
-      "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/ncurses-6.4.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/patch.bri
+++ b/packages/std/toolchain/native/patch.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/patch-2.7.6.tar.xz",
-    hash: std.sha256Hash(
-      "ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/patch-2.7.6.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/patchelf.bri
+++ b/packages/std/toolchain/native/patchelf.bri
@@ -5,12 +5,9 @@ import autoconf from "./autoconf.bri";
 import automake from "./automake.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://github.com/NixOS/patchelf/archive/refs/tags/0.18.0.tar.gz",
-    hash: std.sha256Hash(
-      "1451d01ee3a21100340aed867d0b799f46f0b1749680028d38c3f5d0128fb8a7",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://github.com/NixOS/patchelf/archive/refs/tags/0.18.0.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/perl.bri
+++ b/packages/std/toolchain/native/perl.bri
@@ -4,12 +4,9 @@ import zlib from "./zlib.bri";
 import bzip2 from "./bzip2.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/perl-5.38.0.tar.xz",
-    hash: std.sha256Hash(
-      "eca551caec3bc549a4e590c0015003790bdd1a604ffe19cc78ee631d51f7072e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/perl-5.38.0.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/perl_xml_parser.bri
+++ b/packages/std/toolchain/native/perl_xml_parser.bri
@@ -4,12 +4,9 @@ import perl from "./perl.bri";
 import expat from "./expat.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/XML-Parser-2.46.tar.gz",
-    hash: std.sha256Hash(
-      "d331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/XML-Parser-2.46.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/pkgconf.bri
+++ b/packages/std/toolchain/native/pkgconf.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/pkgconf-2.0.1.tar.xz",
-    hash: std.sha256Hash(
-      "3238af7473740844e5159dd8fb6540603e3fbcebf60beb3c8a426cdca2e29c51",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/pkgconf-2.0.1.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/procps_ng.bri
+++ b/packages/std/toolchain/native/procps_ng.bri
@@ -4,12 +4,9 @@ import pkgconf from "./pkgconf.bri";
 import ncurses from "./ncurses.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/procps-ng-4.0.3.tar.xz",
-    hash: std.sha256Hash(
-      "303c8ec4f96ae18d8eaef86c2bd0986938764a45dc505fe0a0af868c674dba92",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/procps-ng-4.0.3.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/psmisc.bri
+++ b/packages/std/toolchain/native/psmisc.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/psmisc-23.6.tar.xz",
-    hash: std.sha256Hash(
-      "257dde06159a4c49223d06f1cccbeb68933a4514fc8f1d77c64b54f0d108822a",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/psmisc-23.6.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/readline.bri
+++ b/packages/std/toolchain/native/readline.bri
@@ -2,18 +2,12 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/readline-8.2.tar.gz",
-    hash: std.sha256Hash(
-      "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35",
-    ),
-  });
-  const sourcePatch = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/readline-8.2-upstream_fix-1.patch",
-    hash: std.sha256Hash(
-      "2d6478185dcce0d8fe6ac02e7872fba8b91429f41627ddfc2e322e5338e36a53",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/readline-8.2.tar.gz",
+  );
+  const sourcePatch = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/readline-8.2-upstream_fix-1.patch",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/sed.bri
+++ b/packages/std/toolchain/native/sed.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/sed-4.9.tar.xz",
-    hash: std.sha256Hash(
-      "6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/sed-4.9.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/tar.bri
+++ b/packages/std/toolchain/native/tar.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/tar-1.35.tar.xz",
-    hash: std.sha256Hash(
-      "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/tar-1.35.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/texinfo.bri
+++ b/packages/std/toolchain/native/texinfo.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/texinfo-7.0.3.tar.xz",
-    hash: std.sha256Hash(
-      "74b420d09d7f528e84f97aa330f0dd69a98a6053e7a4e01767eed115038807bf",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/texinfo-7.0.3.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/util_linux.bri
+++ b/packages/std/toolchain/native/util_linux.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/util-linux-2.39.1.tar.xz",
-    hash: std.sha256Hash(
-      "890ae8ff810247bd19e274df76e8371d202cda01ad277681b0ea88eeaa00286b",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/util-linux-2.39.1.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/which.bri
+++ b/packages/std/toolchain/native/which.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/ftp.gnu.org/gnu/which/which-2.21.tar.gz",
-    hash: std.sha256Hash(
-      "f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/ftp.gnu.org/gnu/which/which-2.21.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/xz.bri
+++ b/packages/std/toolchain/native/xz.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/xz-5.4.4.tar.xz",
-    hash: std.sha256Hash(
-      "705d0d96e94e1840e64dec75fc8d5832d34f6649833bec1ced9c3e08cf88132e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/xz-5.4.4.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/zlib.bri
+++ b/packages/std/toolchain/native/zlib.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/zlib-1.2.13.tar.xz",
-    hash: std.sha256Hash(
-      "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/zlib-1.2.13.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/native/zstd.bri
+++ b/packages/std/toolchain/native/zstd.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import stage2 from "/toolchain/stage2";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/zstd-1.5.5.tar.gz",
-    hash: std.sha256Hash(
-      "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/zstd-1.5.5.tar.gz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/stage0/index.bri
+++ b/packages/std/toolchain/stage0/index.bri
@@ -9,23 +9,13 @@ interface BootstrapRunOptions {
 export function bootstrapRun(
   options: BootstrapRunOptions,
 ): std.Recipe<std.Directory> {
-  const bootstrapRootfs = std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-bootstrap/99ab9787d5ee27eb613227131e23d2c651de318a/brioche-bootstrap.tar.zstd",
-      hash: std.sha256Hash(
-        "0cabcd0a074e08ac132281f711f884777b47def17fbeff2a82ba011836b83d11",
-      ),
-    })
-    .unarchive("tar", "zstd");
+  const bootstrapRootfs = Brioche.download(
+    "https://development-content.brioche.dev/github.com/brioche-dev/brioche-bootstrap/99ab9787d5ee27eb613227131e23d2c651de318a/brioche-bootstrap.tar.zstd",
+  ).unarchive("tar", "zstd");
 
-  const busybox = std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/busybox_amd64_linux.tar.xz",
-      hash: std.sha256Hash(
-        "e2e9ae181e115e155158cb9031687d943b0847d8058a4c28454194d835478be6",
-      ),
-    })
-    .unarchive("tar", "xz");
+  const busybox = Brioche.download(
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/busybox_amd64_linux.tar.xz",
+  ).unarchive("tar", "xz");
 
   const briocheLd = runtimeUtils().get("bin/brioche-ld");
   const briochePacked = runtimeUtils().get("bin/brioche-packed-exec");
@@ -97,32 +87,17 @@ export function bootstrapRun(
 }
 
 export default async (): Promise<std.Recipe> => {
-  const utils = std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/utils_amd64_linux.tar.zstd",
-      hash: std.sha256Hash(
-        "eb29ea059fcd9ca457841f5c79151721a74761a31610d694bce61a62f4de6d33",
-      ),
-    })
-    .unarchive("tar", "zstd");
+  const utils = Brioche.download(
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/utils_amd64_linux.tar.zstd",
+  ).unarchive("tar", "zstd");
 
-  const toolchain = std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/toolchain_amd64_linux.tar.zstd",
-      hash: std.sha256Hash(
-        "27416708f7ee8cd0c5d408010192705b40c914647fd0d80f00c2194795828cd6",
-      ),
-    })
-    .unarchive("tar", "zstd");
+  const toolchain = Brioche.download(
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/toolchain_amd64_linux.tar.zstd",
+  ).unarchive("tar", "zstd");
 
-  const make = std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/make_static_linux_amd64.tar.xz",
-      hash: std.sha256Hash(
-        "f8a75f171c2c753bc86a331473812ddc24837d5e91b0b1c7af89d6a2aa6e8986",
-      ),
-    })
-    .unarchive("tar", "xz");
+  const make = Brioche.download(
+    "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2022-10-31/make_static_linux_amd64.tar.xz",
+  ).unarchive("tar", "xz");
 
   const briocheLd = runtimeUtils().get("bin/brioche-ld");
   const briochePacked = runtimeUtils().get("bin/brioche-packed-exec");

--- a/packages/std/toolchain/stage1/1_01_binutils.bri
+++ b/packages/std/toolchain/stage1/1_01_binutils.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import { bootstrapRun } from "/toolchain/stage0";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
-    hash: std.sha256Hash(
-      "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage1/1_02_gcc.bri
+++ b/packages/std/toolchain/stage1/1_02_gcc.bri
@@ -3,30 +3,18 @@ import { bootstrapRun } from "/toolchain/stage0";
 import binutils from "./1_01_binutils.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da",
-    ),
-  });
-  const mpfrArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993",
-    ),
-  });
-  const gmpArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
-    hash: std.sha256Hash(
-      "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898",
-    ),
-  });
-  const mpcArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
-    hash: std.sha256Hash(
-      "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
+  );
+  const mpfrArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
+  );
+  const gmpArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
+  );
+  const mpcArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
+  );
 
   const stage1 = binutils();
 

--- a/packages/std/toolchain/stage1/1_03_linux_headers.bri
+++ b/packages/std/toolchain/stage1/1_03_linux_headers.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import { bootstrapRun } from "/toolchain/stage0";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/linux-6.4.12.tar.xz",
-    hash: std.sha256Hash(
-      "cca91be956fe081f8f6da72034cded96fe35a50be4bfb7e103e354aa2159a674",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/linux-6.4.12.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage1/1_04_glibc.bri
+++ b/packages/std/toolchain/stage1/1_04_glibc.bri
@@ -6,18 +6,12 @@ import gcc from "./1_02_gcc.bri";
 import linuxHeaders from "./1_03_linux_headers.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/glibc-2.38.tar.xz",
-    hash: std.sha256Hash(
-      "fb82998998b2b29965467bc1b69d152e9c307d2cf301c9eafb4555b770ef3fd2",
-    ),
-  });
-  const sourcePatch = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-fhs-1.patch",
-    hash: std.sha256Hash(
-      "643552db030e2f2d7ffde4f558e0f5f83d3fabf34a2e0e56ebdb49750ac27b0d",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/glibc-2.38.tar.xz",
+  );
+  const sourcePatch = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/patches/glibc-2.38-fhs-1.patch",
+  );
 
   const briochePacked = runtimeUtils().get("bin/brioche-packed-exec");
   const briochePacker = runtimeUtils().get("bin/brioche-packer");

--- a/packages/std/toolchain/stage1/1_05_libstdcpp.bri
+++ b/packages/std/toolchain/stage1/1_05_libstdcpp.bri
@@ -7,12 +7,9 @@ import glibc from "./1_04_glibc.bri";
 import { wrapWithScript, useBriocheLd } from "../utils.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
+  );
 
   let stage1 = std.merge(binutils(), gcc(), linuxHeaders(), glibc());
 

--- a/packages/std/toolchain/stage2/2_01_m4.bri
+++ b/packages/std/toolchain/stage2/2_01_m4.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/m4-1.4.19.tar.xz",
-    hash: std.sha256Hash(
-      "63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/m4-1.4.19.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_02_ncurses.bri
+++ b/packages/std/toolchain/stage2/2_02_ncurses.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/ncurses-6.4.tar.gz",
-    hash: std.sha256Hash(
-      "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/ncurses-6.4.tar.gz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_03_bash.bri
+++ b/packages/std/toolchain/stage2/2_03_bash.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bash-5.2.15.tar.gz",
-    hash: std.sha256Hash(
-      "13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bash-5.2.15.tar.gz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_04_coreutils.bri
+++ b/packages/std/toolchain/stage2/2_04_coreutils.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/coreutils-9.3.tar.xz",
-    hash: std.sha256Hash(
-      "adbcfcfe899235b71e8768dcf07cd532520b7f54f9a8064843f8d199a904bbaa",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/coreutils-9.3.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_05_diffutils.bri
+++ b/packages/std/toolchain/stage2/2_05_diffutils.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/diffutils-3.10.tar.xz",
-    hash: std.sha256Hash(
-      "90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/diffutils-3.10.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_06_file.bri
+++ b/packages/std/toolchain/stage2/2_06_file.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/file-5.45.tar.gz",
-    hash: std.sha256Hash(
-      "fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/file-5.45.tar.gz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_07_findutils.bri
+++ b/packages/std/toolchain/stage2/2_07_findutils.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/findutils-4.9.0.tar.xz",
-    hash: std.sha256Hash(
-      "a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/findutils-4.9.0.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_08_gawk.bri
+++ b/packages/std/toolchain/stage2/2_08_gawk.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gawk-5.2.2.tar.xz",
-    hash: std.sha256Hash(
-      "3c1fce1446b4cbee1cd273bd7ec64bc87d89f61537471cd3e05e33a965a250e9",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gawk-5.2.2.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_09_grep.bri
+++ b/packages/std/toolchain/stage2/2_09_grep.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/grep-3.11.tar.xz",
-    hash: std.sha256Hash(
-      "1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/grep-3.11.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_10_gzip.bri
+++ b/packages/std/toolchain/stage2/2_10_gzip.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gzip-1.12.tar.xz",
-    hash: std.sha256Hash(
-      "ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gzip-1.12.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_11_make.bri
+++ b/packages/std/toolchain/stage2/2_11_make.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/make-4.4.1.tar.gz",
-    hash: std.sha256Hash(
-      "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/make-4.4.1.tar.gz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_12_patch.bri
+++ b/packages/std/toolchain/stage2/2_12_patch.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/patch-2.7.6.tar.xz",
-    hash: std.sha256Hash(
-      "ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/patch-2.7.6.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_13_sed.bri
+++ b/packages/std/toolchain/stage2/2_13_sed.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/sed-4.9.tar.xz",
-    hash: std.sha256Hash(
-      "6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/sed-4.9.tar.xz",
+  );
 
   return bootstrapRun({
     script: `

--- a/packages/std/toolchain/stage2/2_14_tar.bri
+++ b/packages/std/toolchain/stage2/2_14_tar.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/tar-1.35.tar.xz",
-    hash: std.sha256Hash(
-      "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/tar-1.35.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_15_xz.bri
+++ b/packages/std/toolchain/stage2/2_15_xz.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/xz-5.4.4.tar.xz",
-    hash: std.sha256Hash(
-      "705d0d96e94e1840e64dec75fc8d5832d34f6649833bec1ced9c3e08cf88132e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/xz-5.4.4.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_16_binutils.bri
+++ b/packages/std/toolchain/stage2/2_16_binutils.bri
@@ -3,12 +3,9 @@ import { bootstrapRun } from "../stage0";
 import stage1 from "../stage1";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
-    hash: std.sha256Hash(
-      "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/binutils-2.41.tar.xz",
+  );
 
   return bootstrapRun({
     script: std.indoc`

--- a/packages/std/toolchain/stage2/2_17_gcc.bri
+++ b/packages/std/toolchain/stage2/2_17_gcc.bri
@@ -20,30 +20,18 @@ import xz from "./2_15_xz.bri";
 import binutils from "./2_16_binutils.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da",
-    ),
-  });
-  const mpfrArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
-    hash: std.sha256Hash(
-      "06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993",
-    ),
-  });
-  const gmpArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
-    hash: std.sha256Hash(
-      "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898",
-    ),
-  });
-  const mpcArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
-    hash: std.sha256Hash(
-      "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gcc-13.2.0.tar.xz",
+  );
+  const mpfrArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpfr-4.2.0.tar.xz",
+  );
+  const gmpArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gmp-6.3.0.tar.xz",
+  );
+  const mpcArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/mpc-1.3.1.tar.gz",
+  );
 
   let stage2 = std.merge(
     stage1(),

--- a/packages/std/toolchain/stage2/2_19_gettext.bri
+++ b/packages/std/toolchain/stage2/2_19_gettext.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import toolchain from "./2_18_toolchain.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gettext-0.22.tar.xz",
-    hash: std.sha256Hash(
-      "0e60393a47061567b46875b249b7d2788b092d6457d656145bb0e7e6a3e26d93",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/gettext-0.22.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/stage2/2_20_bison.bri
+++ b/packages/std/toolchain/stage2/2_20_bison.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import toolchain from "./2_18_toolchain.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bison-3.8.2.tar.xz",
-    hash: std.sha256Hash(
-      "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/bison-3.8.2.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/stage2/2_21_perl.bri
+++ b/packages/std/toolchain/stage2/2_21_perl.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import toolchain from "./2_18_toolchain.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/perl-5.38.0.tar.xz",
-    hash: std.sha256Hash(
-      "eca551caec3bc549a4e590c0015003790bdd1a604ffe19cc78ee631d51f7072e",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/perl-5.38.0.tar.xz",
+  );
 
   let perl = std
     .process({

--- a/packages/std/toolchain/stage2/2_22_python.bri
+++ b/packages/std/toolchain/stage2/2_22_python.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import toolchain from "./2_18_toolchain.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/Python-3.11.4.tar.xz",
-    hash: std.sha256Hash(
-      "2f0e409df2ab57aa9fc4cbddfb976af44e4e55bf6f619eee6bc5c2297264a7f6",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/Python-3.11.4.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/stage2/2_23_texinfo.bri
+++ b/packages/std/toolchain/stage2/2_23_texinfo.bri
@@ -3,12 +3,9 @@ import toolchain from "./2_18_toolchain.bri";
 import perl from "./2_21_perl.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/texinfo-7.0.3.tar.xz",
-    hash: std.sha256Hash(
-      "74b420d09d7f528e84f97aa330f0dd69a98a6053e7a4e01767eed115038807bf",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/texinfo-7.0.3.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/stage2/2_24_util_linux.bri
+++ b/packages/std/toolchain/stage2/2_24_util_linux.bri
@@ -2,12 +2,9 @@ import * as std from "/core";
 import toolchain from "./2_18_toolchain.bri";
 
 export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  const sourceArchive = std.download({
-    url: "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/util-linux-2.39.1.tar.xz",
-    hash: std.sha256Hash(
-      "890ae8ff810247bd19e274df76e8371d202cda01ad277681b0ea88eeaa00286b",
-    ),
-  });
+  const sourceArchive = Brioche.download(
+    "https://development-content.brioche.dev/linuxfromscratch.org/v12.0/packages/util-linux-2.39.1.tar.xz",
+  );
 
   return std
     .process({

--- a/packages/std/toolchain/utils.bri
+++ b/packages/std/toolchain/utils.bri
@@ -4,14 +4,9 @@ import * as std from "/core";
 // it's pinned to a specific version. It should only be updated if the
 // tools used for building the toolchain should be upgraded
 export function runtimeUtils(): std.Recipe<std.Directory> {
-  return std
-    .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
-      hash: std.sha256Hash(
-        "7f1539e866ff937c27008da0f4ca6618d48165548df99edfa7b137abcfb09a30",
-      ),
-    })
-    .unarchive("tar", "zstd");
+  return Brioche.download(
+    "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
+  ).unarchive("tar", "zstd");
 }
 
 interface UseBriocheLdOptions {


### PR DESCRIPTION
This is a followup to #75, which updates all existing packages to use `Brioche.download` when applicable. Effectively, this moves all URL hashes into `brioche.lock` lockfiles, which means that the only manual change to update most normal packages is to simply bump the version number