### PR TITLE
[std] Implement `std.glob()` function

### DIFF
--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -1,4 +1,6 @@
 import * as runtime from "../runtime.bri";
+import { assert } from "../utils.bri";
+import { semverMatches } from "../semver.bri";
 import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
@@ -27,6 +29,11 @@ export function glob(
   return createRecipe<Directory>(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
+      assert(
+        semverMatches(runtime.BRIOCHE_VERSION, ">=0.1.2"),
+        "std.glob requires Brioche v0.1.2 or later",
+      );
+
       const serializedDirectory = await (await recipe).briocheSerialize();
       return {
         meta,

--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -1,0 +1,39 @@
+import * as runtime from "../runtime.bri";
+import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import type { Directory } from "./directory.bri";
+
+/**
+ * Returns a directory recipe containing only files that match one of the
+ * specified glob patterns.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ *
+ * const dir = std.directory({
+ *   "file.txt": std.file("Hello, world!"),
+ *   "script.sh": std.file("echo 'Hello, world!'"),
+ * });
+ *
+ * // Get only the text files from the directory
+ * const textFiles = std.glob(dir, ["*.txt"]);
+ * ```
+ */
+export function glob(
+  recipe: AsyncRecipe<Directory>,
+  patterns: string[],
+): Recipe<Directory> {
+  return createRecipe<Directory>(["directory"], {
+    sourceDepth: 1,
+    briocheSerialize: async (meta) => {
+      const serializedDirectory = await (await recipe).briocheSerialize();
+      return {
+        meta,
+        type: "glob",
+        directory: serializedDirectory,
+        patterns: patterns.map((pattern) => runtime.bstring(pattern)),
+      };
+    },
+  });
+}

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -20,6 +20,7 @@ export { memo, createProxy } from "./proxy.bri";
 export { symlink, type SymlinkOptions, Symlink } from "./symlink.bri";
 export { sync } from "./sync.bri";
 export { collectReferences } from "./collect_references.bri";
+export { glob } from "./glob.bri";
 export {
   type AsyncRecipe,
   type Recipe,

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -46,6 +46,7 @@ export type RecipeSerialization<T extends Artifact> = runtime.WithMeta &
           | runtime.PeelRecipe
           | runtime.GetRecipe
           | runtime.InsertRecipe
+          | runtime.GlobRecipe
           | runtime.CollectReferencesRecipe
           | runtime.ProxyRecipe
           | runtime.SyncRecipe

--- a/packages/std/core/runtime.bri
+++ b/packages/std/core/runtime.bri
@@ -104,6 +104,7 @@ export type Recipe =
   | PeelRecipe
   | GetRecipe
   | InsertRecipe
+  | GlobRecipe
   | SetPermissionsRecipe
   | CollectReferencesRecipe
   | ProxyRecipe
@@ -175,6 +176,12 @@ export type InsertRecipe = WithMeta & {
   directory: Recipe;
   path: BString;
   recipe?: Recipe | null | undefined;
+};
+
+export type GlobRecipe = WithMeta & {
+  type: "glob";
+  directory: Recipe;
+  patterns: BString[];
 };
 
 export type SetPermissionsRecipe = WithMeta & {


### PR DESCRIPTION
This PR adds the new `std.glob()` function. This uses the new `glob` recipe type introduced by brioche-dev/brioche#119. Here's a little example inspired by #62:

```typescript
// Get only the `go.mod` and `go.sum` files from a Go module
std.glob(goModule, ["**/go.mod", "**/go.sum"]);
```