### PR TITLE
Add implementation for `Brioche.gitRef()` global function

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -45,35 +45,59 @@ interface GitCheckoutOptions {
  * Checkout a git repository at a specific commit. The specified commit will
  * be cloned without any history.
  *
+ * See also the `Brioche.gitRef` function, which can be used with `gitCheckout`
+ * to get a commit hash from a git ref (such as a branch or tag name), and
+ * then record the commit hash in the lockfile.
+ *
  * ## Options
  *
  * - `repository`: The URL of the git repository to checkout.
  * - `commit`: The full commit hash to checkout.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import { gitCheckout } from "git";
+ *
+ * // Check out the main branch from the Brioche repository. The commit
+ * // hash will be locked when first run, and will not change until the
+ * // lockfile is updated
+ * const source = gitCheckout(
+ *   Brioche.gitRef({
+ *     repository: "https://github.com/brioche-dev/brioche.git",
+ *     ref: "main",
+ *   }),
+ * );
+ * ```
  */
 export function gitCheckout(
-  options: GitCheckoutOptions,
+  options: std.Awaitable<GitCheckoutOptions>,
 ): std.Recipe<std.Directory> {
-  // Validate that the commit is a hash
-  std.assert(
-    /^[0-9a-f]{40}$/.test(options.commit),
-    `Invalid git commit hash: ${options.commit}`,
-  );
+  return std.recipeFn(async () => {
+    const { commit, repository } = await options;
 
-  // Clone and fetch only the specified commit. See this article:
-  // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
-  return std.runBash`
-    cd "$BRIOCHE_OUTPUT"
-    git -c init.defaultBranch=main init
-    git remote add origin "$repository"
-    git fetch --depth 1 origin "$commit"
-    git -c advice.detachedHead=false checkout FETCH_HEAD
-  `
-    .dependencies(git(), caCertificates())
-    .env({
-      repository: options.repository,
-      commit: options.commit,
-    })
-    .outputScaffold(std.directory())
-    .unsafe({ networking: true })
-    .toDirectory();
+    // Validate that the commit is a hash
+    std.assert(
+      /^[0-9a-f]{40}$/.test(commit),
+      `Invalid git commit hash: ${commit}`,
+    );
+
+    // Clone and fetch only the specified commit. See this article:
+    // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
+    return std.runBash`
+      cd "$BRIOCHE_OUTPUT"
+      git -c init.defaultBranch=main init
+      git remote add origin "$repository"
+      git fetch --depth 1 origin "$commit"
+      git -c advice.detachedHead=false checkout FETCH_HEAD
+    `
+      .dependencies(git(), caCertificates())
+      .env({
+        repository,
+        commit,
+      })
+      .outputScaffold(std.directory())
+      .unsafe({ networking: true })
+      .toDirectory();
+  });
 }

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -82,6 +82,19 @@ declare global {
      * ```
      */
     function glob(...patterns: string[]): Recipe<Directory>;
+
+    /**
+     * Download a file from a URL. Unlike `std.download`, this function does
+     * not take a hash, and it **must** be called with a constant string URL.
+     * The hash of the downloaded file will be saved in the lockfile.
+     *
+     * ## Example
+     *
+     * ```typescript
+     * const file = Brioche.download("http://example.com/");
+     * ```
+     */
+    function download(url: string): Recipe<File>;
   }
 }
 
@@ -150,6 +163,27 @@ declare global {
         {
           type: "glob",
           patterns,
+        },
+      );
+    },
+  });
+};
+(globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(`Could not find source file to download ${url}`);
+  }
+
+  const sourceFile = sourceFrame.fileName;
+
+  return createRecipe(["file"], {
+    sourceDepth: 1,
+    briocheSerialize: async () => {
+      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+        sourceFile,
+        {
+          type: "download",
+          url,
         },
       );
     },

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -88,6 +88,8 @@ declare global {
      * not take a hash, and it **must** be called with a constant string URL.
      * The hash of the downloaded file will be saved in the lockfile.
      *
+     * See also `std.download`, which can be used even if URL is not constant.
+     *
      * ## Example
      *
      * ```typescript

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -244,6 +244,11 @@ declare global {
 (globalThis as any).Brioche.gitRef ??= async (
   options: GitRefOptions,
 ): Promise<GitRefResult> => {
+  assert(
+    semverMatches(BRIOCHE_VERSION, ">=0.1.2"),
+    "Brioche.gitRef(...) requires Brioche v0.1.2 or later",
+  );
+
   const sourceFrame = source({ depth: 1 }).at(0);
   if (sourceFrame === undefined) {
     throw new Error(

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -6,6 +6,16 @@ import {
 } from "./recipes";
 import { source } from "./source.bri";
 
+interface GitRefOptions {
+  repository: string;
+  ref: string;
+}
+
+interface GitRefResult {
+  repository: string;
+  commit: string;
+}
+
 declare global {
   // eslint-disable-next-line
   namespace Brioche {
@@ -97,6 +107,38 @@ declare global {
      * ```
      */
     function download(url: string): Recipe<File>;
+
+    /**
+     * Get the commit hash for a git ref in a repository. This function must
+     * be called with constant strings for both the repository and ref. The
+     * commit hash will be saved in the lockfile, so the same commit hash
+     * will be used until the lockfile is updated.
+     *
+     * See also the `gitCheckout` function from the `git` package, which can
+     * checkout a git repo from a commit hash returned from `Brioche.gitRef`.
+     *
+     * ## Options
+     *
+     * - `repository`: A git repository URL.
+     * - `ref`: A git ref, such as a branch or tag name. Example: `main`
+     *
+     * ## Example
+     *
+     * ```typescript
+     * import { gitCheckout } from "git";
+     *
+     * // Check out the main branch from the Brioche repository. The commit
+     * // hash will be locked when first run, and will not change until the
+     * // lockfile is updated
+     * const source = gitCheckout(
+     *   Brioche.gitRef({
+     *     repository: "https://github.com/brioche-dev/brioche.git",
+     *     ref: "main",
+     *   }),
+     * );
+     * ```
+     */
+    function gitRef(options: GitRefOptions): Promise<GitRefResult>;
   }
 }
 
@@ -190,4 +232,33 @@ declare global {
       );
     },
   });
+};
+(globalThis as any).Brioche.gitRef ??= async (
+  options: GitRefOptions,
+): Promise<GitRefResult> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(
+      `Could not find source file to resolve git ref '${options.ref}' from repository '${options.repository}'`,
+    );
+  }
+
+  const result = await (globalThis as any).Deno.core.ops.op_brioche_get_static(
+    sourceFrame.fileName,
+    {
+      type: "git_ref",
+      repository: options.repository,
+      ref: options.ref,
+    },
+  );
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    typeof result.repository !== "string" ||
+    typeof result.commit !== "string"
+  ) {
+    throw new Error("failed to parse git ref result");
+  }
+
+  return { repository: result.repository, commit: result.commit };
 };

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -218,7 +218,7 @@ declare global {
 (globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
   assert(
     semverMatches(BRIOCHE_VERSION, ">=0.1.2"),
-    "Brioche.download(...) requires Brioche v0.1.2 or greater",
+    "Brioche.download(...) requires Brioche v0.1.2 or later",
   );
 
   const sourceFrame = source({ depth: 1 }).at(0);

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -9,7 +9,7 @@ export interface DownloadOptions {
 
 /**
  * Returns a recipe that will download a URL, and return
- * a file of its results. A has must be provided, and will
+ * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
  * ## Example

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -12,6 +12,9 @@ export interface DownloadOptions {
  * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
+ * See also `Brioche.download`, which does not require specifying
+ * a hash, but only works with a constant URL.
+ *
  * ## Example
  *
  * std.download({


### PR DESCRIPTION
Companion PR: brioche-dev/brioche#126

This PR adds an implementation for `Brioche.gitRef()` on the `Brioche` global (basically following in the footsteps of #75).

Additionally, the `gitCheckout` function from the `git` package was updated slightly to compose better with the `Brioche.gitRef()` function: it can now take its options wrapped in a `Promise` (one very minor change is that the validation of the commit hash format doesn't run until the recipe returned by `gitCheckout` is baked or serialized).