### PR TITLE
[gitui] Use `Brioche.gitRef` instead of hard-coding commit hash

### DIFF
--- a/packages/gitui/brioche.lock
+++ b/packages/gitui/brioche.lock
@@ -1,3 +1,8 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/extrawurst/gitui.git": {
+      "v0.26.3": "95e1d4d4324bf1eab34f8100afc7f3ae7e435252"
+    }
+  }
 }

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -6,10 +6,12 @@ export const project = {
   version: "0.26.3",
 };
 
-const source = gitCheckout({
-  repository: "https://github.com/extrawurst/gitui.git",
-  commit: "95e1d4d4324bf1eab34f8100afc7f3ae7e435252",
-});
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/extrawurst/gitui.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default () => {
   return cargoBuild({


### PR DESCRIPTION
This PR updates the `gitui` package to use `Brioche.gitRef`, so that the package source uses the git tag instead of hard-coding a commit (the commit is then recorded in the `brioche.lock` lockfile)

(`gitui` is the only package that uses `gitCheckout`, so it was the only one that needed to be updated)