### PR TITLE
[Breaking][std] Improve toolchain and env var handling

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -25,8 +25,8 @@ export default (): std.Recipe<std.Directory> => {
     .toDirectory();
 
   return std.setEnv(alsaLib, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
 };

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -24,7 +24,7 @@ export default (): std.Recipe<std.Directory> => {
       }),
     }),
     {
-      SSL_CERT_FILE: { append: [{ path: "etc/ssl/certs/ca-bundle.crt" }] },
+      SSL_CERT_FILE: { fallback: { path: "etc/ssl/certs/ca-bundle.crt" } },
     },
   );
 };

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -24,7 +24,7 @@ export default (): std.Recipe<std.Directory> => {
       }),
     }),
     {
-      SSL_CERT_FILE: { path: "etc/ssl/certs/ca-bundle.crt" },
+      SSL_CERT_FILE: { append: [{ path: "etc/ssl/certs/ca-bundle.crt" }] },
     },
   );
 };

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -32,9 +32,9 @@ export default (): std.Recipe<std.Directory> => {
     .toDirectory();
 
   curl = std.setEnv(curl, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
 
   return std.withRunnableLink(curl, "bin/curl");

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -28,8 +28,8 @@ export default function git(): std.Recipe<std.Directory> {
     .toDirectory();
 
   git = std.setEnv(git, {
-    GIT_EXEC_PATH: { path: "libexec/git-core" },
-    GIT_TEMPLATE_DIR: { path: "share/git-core/templates" },
+    GIT_EXEC_PATH: { append: [{ path: "libexec/git-core" }] },
+    GIT_TEMPLATE_DIR: { append: [{ path: "share/git-core/templates" }] },
   });
   git = std.withRunnableLink(git, "bin/git");
 

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -28,8 +28,8 @@ export default function git(): std.Recipe<std.Directory> {
     .toDirectory();
 
   git = std.setEnv(git, {
-    GIT_EXEC_PATH: { append: [{ path: "libexec/git-core" }] },
-    GIT_TEMPLATE_DIR: { append: [{ path: "share/git-core/templates" }] },
+    GIT_EXEC_PATH: { fallback: { path: "libexec/git-core" } },
+    GIT_TEMPLATE_DIR: { fallback: { path: "share/git-core/templates" } },
   });
   git = std.withRunnableLink(git, "bin/git");
 

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -37,7 +37,7 @@ export function go(): std.Recipe<std.Directory> {
     }),
   });
   go = std.setEnv(go, {
-    GOROOT: { append: [{ path: "go" }] },
+    GOROOT: { fallback: { path: "go" } },
   });
   go = std.withRunnableLink(go, "go/bin/go");
 

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -37,7 +37,7 @@ export function go(): std.Recipe<std.Directory> {
     }),
   });
   go = std.setEnv(go, {
-    GOROOT: { path: "go" },
+    GOROOT: { append: [{ path: "go" }] },
   });
   go = std.withRunnableLink(go, "go/bin/go");
 

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -25,24 +25,6 @@ export default function (): std.Recipe<std.Directory> {
   `
     .workDir(source)
     .dependencies(std.toolchain())
-    .env(autotoolsEnv())
     .toDirectory();
   return std.withRunnableLink(jq, "bin/jq");
-}
-
-// HACK: This should be removed once `std.toolchain()` properly sets
-// these variables for autotools
-function autotoolsEnv(): Record<string, std.ProcessTemplateLike> {
-  return {
-    M4: std.tpl`${std.toolchain()}/bin/m4`,
-    AUTOM4TE: std.tpl`${std.toolchain()}/bin/autom4te`,
-    trailer_m4: std.tpl`${std.toolchain()}/share/autoconf/autoconf/trailer.m4`,
-    PERL5LIB: std.tpl`${std.toolchain()}/share/autoconf:${std.toolchain()}/share/automake-1.16`,
-    autom4te_perllibdir: std.tpl`${std.toolchain()}/share/autoconf`,
-    AC_MACRODIR: std.tpl`${std.toolchain()}/share/autoconf`,
-    ACLOCAL_AUTOMAKE_DIR: std.tpl`${std.toolchain()}/share/aclocal-1.16`,
-    AUTOMAKE_UNINSTALLED: "1",
-    AUTOCONF: std.tpl`${std.toolchain()}/bin/autoconf`,
-    AUTOMAKE_LIBDIR: std.tpl`${std.toolchain()}/share/automake-1.16`,
-  };
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -43,9 +43,9 @@ export default function (): std.Recipe<std.Directory> {
     .toDirectory();
 
   oniguruma = std.setEnv(oniguruma, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
 
   return std.withRunnableLink(oniguruma, "bin/onig-config");

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -29,9 +29,9 @@ export default function openssl(): std.Recipe<std.Directory> {
     .toDirectory();
 
   openssl = std.setEnv(openssl, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
 
   return std.withRunnableLink(openssl, "bin/openssl");

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -50,9 +50,9 @@ export default function (): std.Recipe<std.Directory> {
     .toDirectory();
 
   return std.setEnv(pcre2, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
 }
 

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -97,7 +97,7 @@ async function rust(): Promise<std.Recipe<std.Directory>> {
     .flatMap((name) => (name != null ? [name] : []));
 
   result = std.setEnv(result, {
-    LIBRARY_PATH: { path: "lib" },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
   });
 
   result = std.autopack(result, {

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -17,7 +17,11 @@ export function autopack(
   recipe: std.AsyncRecipe<std.Directory>,
   options: AutopackOptions,
 ): std.Recipe<std.Directory> {
-  const { config, variables } = buildConfig(options);
+  const { config, variables } = buildAutopackConfig({
+    options,
+    defaultLinkDependencies: [toolchain()],
+    runtimeUtils: runtimeUtils(),
+  });
 
   const variableArgs: std.ProcessTemplateLike[] = Object.entries(
     variables,
@@ -179,7 +183,16 @@ type EnvValueConfig =
 
 type EnvValue = std.ProcessTemplateLike | { relativePath: string };
 
-function buildConfig(options: AutopackOptions): AutopackConfigResult {
+interface BuildConfigOptions {
+  options: AutopackOptions;
+  defaultLinkDependencies: std.AsyncRecipe[];
+  runtimeUtils: std.Recipe<std.Directory>;
+}
+
+export function buildAutopackConfig(
+  buildConfigOptions: BuildConfigOptions,
+): AutopackConfigResult {
+  const { options, defaultLinkDependencies, runtimeUtils } = buildConfigOptions;
   const variables: Record<string, AutopackConfigVariable> = {};
 
   let variableIndex = 0;
@@ -226,11 +239,11 @@ function buildConfig(options: AutopackOptions): AutopackConfigResult {
 
   const dynamicBinaryPackedExecutable = addVar({
     name: "dynamicBinaryPackedExecutable",
-    value: runtimeUtils().get("bin/brioche-packed-exec"),
+    value: runtimeUtils.get("bin/brioche-packed-exec"),
   });
   const scriptPackedExecutable = addVar({
     name: "scriptPackedExecutable",
-    value: runtimeUtils().get("bin/brioche-packed-plain-exec"),
+    value: runtimeUtils.get("bin/brioche-packed-plain-exec"),
   });
 
   const dynamicBinary =
@@ -299,7 +312,7 @@ function buildConfig(options: AutopackOptions): AutopackConfigResult {
 
   const linkDependencies = [
     ...(options.linkDependencies ?? []),
-    toolchain(),
+    ...defaultLinkDependencies,
   ].map((dep) => addVar({ value: dep }));
 
   const config = {

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -61,6 +61,12 @@ export interface AutopackOptions {
   globs?: string[];
 
   /**
+   * A list of glob patterns to exclude when autopacking. Can only be set
+   * when `globs` is set
+   */
+  excludeGlobs?: string[];
+
+  /**
    * A list of dependencies to search when linking. These will be used to find
    * dynamic libraries, the dynamic linker, script interpreters, and any other
    * dependencies needed to pack a file. A dependency will not be used if
@@ -117,6 +123,12 @@ interface SharedLibraryConfig extends DynamicLinkingConfig {
    * Whether to pack shared libraries. Defaults to `true`
    */
   enabled?: boolean;
+
+  /**
+   * Whether to pack a shared library even if it has no dependencies. Defaults
+   * to `false`
+   */
+  allowEmpty?: boolean;
 }
 
 interface ScriptConfig {
@@ -335,6 +347,7 @@ export function buildAutopackConfig(
   const config = {
     paths: options.paths,
     globs: options.globs,
+    excludeGlobs: options.excludeGlobs,
     linkDependencies,
     selfDependency: options.selfDependency,
     dynamicBinary,
@@ -353,6 +366,7 @@ interface AutopackConfigResult {
 interface AutopackConfigTemplate {
   paths?: TemplatePath[];
   globs?: string[];
+  excludeGlobs?: string[];
   quiet?: boolean;
   linkDependencies?: TemplatePath[];
   selfDependency?: boolean;

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -181,7 +181,10 @@ type EnvValueConfig =
   | { type: "prepend"; value: EnvValue; separator: string }
   | { type: "append"; value: EnvValue; separator: string };
 
-type EnvValue = std.ProcessTemplateLike | { relativePath: string };
+type EnvValue =
+  | std.ProcessTemplateLike
+  | { relativePath: string }
+  | { relativePaths: string[]; separator: string };
 
 interface BuildConfigOptions {
   options: AutopackOptions;
@@ -212,6 +215,20 @@ export function buildAutopackConfig(
         components: [
           { type: "relative_path", path: std.bstring(value.relativePath) },
         ],
+      };
+    } else if (typeof value === "object" && "relativePaths" in value) {
+      return {
+        components: value.relativePaths.flatMap((path, i) => [
+          ...(i === 0
+            ? []
+            : [
+                {
+                  type: "literal",
+                  value: std.bstring(value.separator),
+                } satisfies EnvValueTemplateValueComponent,
+              ]),
+          { type: "relative_path", path: std.bstring(path) },
+        ]),
       };
     } else {
       const processTemplate = std.processTemplate(value);

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -1,4 +1,4 @@
-export * from "./autopack.bri";
+export { autopack, type AutopackOptions } from "./autopack.bri";
 export * from "./oci_container_image.bri";
 export * from "./run_bash.bri";
 export * from "./bash_runnable.bri";

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -53,14 +53,20 @@ export function setEnv(
         );
       }
     } else if ("fallback" in value && "path" in value.fallback) {
-      // TODO: Throw error if not Brioche >= 0.1.2
+      std.assert(
+        std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.2"),
+        "fallback env vars require Brioche v0.1.2 or later",
+      );
 
       result = result.insert(
         `brioche-env.d/env/${key}`,
         std.symlink({ target: `../../${value.fallback.path}` }),
       );
     } else if ("fallback" in value && "value" in value.fallback) {
-      // TODO: Throw error if not Brioche >= 0.1.2
+      std.assert(
+        std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.2"),
+        "fallback env vars require Brioche v0.1.2 or later",
+      );
 
       result = result.insert(
         `brioche-env.d/env/${key}`,

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -1,13 +1,20 @@
 import * as std from "/core";
 
-export type EnvValues = Record<string, EnvValue | EnvValue[]>;
+export type EnvValues = Record<string, EnvValue>;
 
-export type EnvValue = { path: string };
+export type EnvValue =
+  | { append: { path: string }[] }
+  | { fallback: { path: string } }
+  | { fallback: { value: string } };
 
 /**
  * Returns a new recipe with some environment variables. These environment
  * variables will be set when the recipe is included as a dependency for a
- * procss recipe.
+ * process recipe.
+ *
+ * Each environment variable can be set to either append one or more paths
+ * (relative to the root of the recipe), or set a fallback path / value
+ * if the environment variable is empty.
  *
  * ## Example
  *
@@ -17,10 +24,15 @@ export type EnvValue = { path: string };
  *   # ... build a library ...
  * `;
  *
- * // When myLibrary gets included as a dependency, `$LIBRARY_PATH`
- * // will get set to the absolute path of the `lib` directory
+ * // When myLibrary gets included as a dependency, the following
+ * // environment variables will be set:
+ * // - `$LIBRARY_PATH` will be appended with the absolute path to `lib`
+ * // - `$CC` will be set to the path to `cc-wrapper.sh` if not set
+ * // - `$DEBUG` will be set to `1` if not set
  * myLibrary = std.setEnv(myLibrary, {
- *   LIBRARY_PATH: { path: "lib" },
+ *   LIBRARY_PATH: { append: [{ path: "lib"}] },
+ *   CC: { fallback: { path: "cc-wrapper.sh" } },
+ *   DEBUG: { fallback: { value: "1" } },
  * });
  * ```
  */
@@ -30,14 +42,33 @@ export function setEnv(
 ): std.Recipe<std.Directory> {
   let result = std.recipe(recipe);
   for (const [key, value] of Object.entries(env)) {
-    const values = Array.isArray(value) ? value : [value];
-    for (const value of values) {
-      const escapedPath = value.path
-        .replaceAll("_", "__")
-        .replaceAll(/[\/\.]/g, "_");
+    if ("append" in value) {
+      for (const append of value.append) {
+        const escapedPath = append.path
+          .replaceAll("_", "__")
+          .replaceAll(/[\/\.]/g, "_");
+        result = result.insert(
+          `brioche-env.d/env/${key}/${escapedPath}`,
+          std.symlink({ target: `../../../${append.path}` }),
+        );
+      }
+    } else if ("fallback" in value && "path" in value.fallback) {
+      // TODO: Throw error if not Brioche >= 0.1.2
+
       result = result.insert(
-        `brioche-env.d/env/${key}/${escapedPath}`,
-        std.symlink({ target: `../../../${value.path}` }),
+        `brioche-env.d/env/${key}`,
+        std.symlink({ target: `../../${value.fallback.path}` }),
+      );
+    } else if ("fallback" in value && "value" in value.fallback) {
+      // TODO: Throw error if not Brioche >= 0.1.2
+
+      result = result.insert(
+        `brioche-env.d/env/${key}`,
+        std.file(value.fallback.value),
+      );
+    } else {
+      throw new Error(
+        `Invalid value for environment variable ${JSON.stringify(key)}`,
       );
     }
   }

--- a/packages/std/runnable_tools.bri
+++ b/packages/std/runnable_tools.bri
@@ -3,9 +3,9 @@ import * as std from "/core";
 export function runtimeUtils(): std.Recipe<std.Directory> {
   return std
     .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
+      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/47c4991e9f2d965e5604f8e4a6df93de17db8f77/x86_64-linux/brioche-runtime-utils.tar.zstd",
       hash: std.sha256Hash(
-        "7f1539e866ff937c27008da0f4ca6618d48165548df99edfa7b137abcfb09a30",
+        "a7d95992d56a6fa7e0a138ed54b5855ec4bdead94332eda41d0641d95075c7c7",
       ),
     })
     .unarchive("tar", "zstd");

--- a/packages/std/runnable_tools.bri
+++ b/packages/std/runnable_tools.bri
@@ -3,9 +3,9 @@ import * as std from "/core";
 export function runtimeUtils(): std.Recipe<std.Directory> {
   return std
     .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/47c4991e9f2d965e5604f8e4a6df93de17db8f77/x86_64-linux/brioche-runtime-utils.tar.zstd",
+      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/4815f007ab625a42a0e72820fdd6e154b9d5d1c6/x86_64-linux/brioche-runtime-utils.tar.zstd",
       hash: std.sha256Hash(
-        "a7d95992d56a6fa7e0a138ed54b5855ec4bdead94332eda41d0641d95075c7c7",
+        "87b43c798f294772810801697333fb82611a35fb3934354fe0b3c37fba8bb196",
       ),
     })
     .unarchive("tar", "zstd");

--- a/packages/std/toolchain/index.bri
+++ b/packages/std/toolchain/index.bri
@@ -10,20 +10,7 @@
  * can be found in `LICENSE-LFS.md`.
  */
 
-import * as std from "/core";
-import nativeToolchain from "./native";
-
 export { default as stage0 } from "./stage0";
 export { default as stage1 } from "./stage1";
 export { default as stage2 } from "./stage2";
-export { default as native, bash, tools } from "./native";
-
-/**
- * A recipe containing a full C toolchain, including a C compiler, linker,
- * libc, Make, and other common utilities. The toolchain also contains
- * everything from `std.tools()`, including a shell and common Unix-style
- * utilities.
- */
-export function toolchain(): std.Recipe<std.Directory> {
-  return nativeToolchain();
-}
+export { bash, tools, toolchain } from "./native";

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -1,6 +1,7 @@
 import * as std from "/core";
-import { setEnv } from "/extra";
-import stage2 from "/toolchain/stage2";
+import { setEnv } from "/extra/set_env.bri";
+import { buildAutopackConfig, AutopackOptions } from "/extra/autopack.bri";
+import { runtimeUtils } from "/toolchain/utils.bri";
 import linuxHeaders from "./linux_headers.bri";
 import glibc from "./glibc.bri";
 import zlib from "./zlib.bri";
@@ -59,32 +60,75 @@ import patchelf from "./patchelf.bri";
 
 export { bash };
 
+const toolPackages = [
+  zlib(),
+  bzip2(),
+  xz(),
+  zstd(),
+  file(),
+  bc(),
+  binutils(),
+  sed(),
+  grep(),
+  bash(),
+  coreutils(),
+  diffutils(),
+  gawk(),
+  findutils(),
+  gzip(),
+  make(),
+  patch(),
+  tar(),
+  which(),
+];
+
+const toolchainOnlyPackages = [
+  linuxHeaders(),
+  glibc(),
+  readline(),
+  m4(),
+  flex(),
+  gmp(),
+  mpfr(),
+  mpc(),
+  attr(),
+  acl(),
+  libxcrypt(),
+  gcc(),
+  pkgconf(),
+  ncurses(),
+  psmisc(),
+  gettext(),
+  bison(),
+  libtool(),
+  gdbm(),
+  gperf(),
+  expat(),
+  inetutils(),
+  less(),
+  perl(),
+  perlXmlParser(),
+  intltool(),
+  autoconf(),
+  automake(),
+  libelf(),
+  groff(),
+  libpipeline(),
+  texinfo(),
+  manDb(),
+  procpsNg(),
+  utilLinux(),
+  patchelf(),
+];
+
 /**
  * Returns a set of common Unix-style utilities
  */
 export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  let tools = std.merge(
-    zlib(),
-    bzip2(),
-    xz(),
-    zstd(),
-    file(),
-    bc(),
-    binutils(),
-    sed(),
-    grep(),
-    bash(),
-    coreutils(),
-    diffutils(),
-    gawk(),
-    findutils(),
-    gzip(),
-    make(),
-    patch(),
-    tar(),
-    which(),
-  );
-  tools = fixShebangs(tools);
+  let tools = std.merge(...toolPackages);
+
+  // Set env vars when used as a dependency. These are also used
+  // when autopacking
   tools = setEnv(tools, {
     CPATH: { path: "include" },
     LIBRARY_PATH: { path: "lib" },
@@ -92,103 +136,211 @@ export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
     MAGIC: { path: "share/misc/magic.mgc" },
   });
 
+  // Pack binaries and scripts
+  tools = autopack(tools, {
+    globs: ["bin/**"],
+    selfDependency: true,
+    linkDependencies: [toolchain()],
+    dynamicBinaryConfig: {
+      enabled: true,
+    },
+    sharedLibraryConfig: {
+      enabled: false,
+    },
+    scriptConfig: {
+      enabled: true,
+    },
+    repackConfig: {
+      enabled: true,
+    },
+  });
+
   return std.sync(tools);
 });
 
-export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
-  let toolchainOnly = std.merge(
-    linuxHeaders(),
-    glibc(),
-    readline(),
-    m4(),
-    flex(),
-    gmp(),
-    mpfr(),
-    mpc(),
-    attr(),
-    acl(),
-    libxcrypt(),
-    gcc(),
-    pkgconf(),
-    ncurses(),
-    psmisc(),
-    gettext(),
-    bison(),
-    libtool(),
-    gdbm(),
-    gperf(),
-    expat(),
-    inetutils(),
-    less(),
-    perl(),
-    perlXmlParser(),
-    intltool(),
-    autoconf(),
-    automake(),
-    libelf(),
-    groff(),
-    libpipeline(),
-    texinfo(),
-    manDb(),
-    procpsNg(),
-    utilLinux(),
-    patchelf(),
-  );
-  toolchainOnly = fixShebangs(toolchainOnly);
-  toolchainOnly = toolchainOnly.insert(
-    "bin/cc",
-    std.symlink({ target: "gcc" }),
-  );
-  toolchainOnly = std.sync(toolchainOnly);
+/**
+ * Returns a complete toolchain, including a C compiler and common libraries.
+ * Includes all tools from `tools`.
+ */
+export const toolchain = std.memo(
+  async (): Promise<std.Recipe<std.Directory>> => {
+    // Merge all the packages
+    const unpackedToolchain = std.merge(
+      ...toolchainOnlyPackages,
+      ...toolPackages,
+    );
 
-  return std.merge(tools(), toolchainOnly);
-});
+    let toolchain = unpackedToolchain;
 
-function fixShebangs(
+    // Add a symlink for the C compiler
+    toolchain = toolchain.insert("bin/cc", std.symlink({ target: "gcc" }));
+
+    // Set env vars when used as a dependency. These are also used
+    // when autopacking
+    toolchain = setEnv(toolchain, {
+      CPATH: { path: "include" },
+      LIBRARY_PATH: [
+        { path: "lib" },
+        { path: "lib/man-db" },
+        { path: "lib/gconv" },
+      ],
+      PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
+      MAGIC: { path: "share/misc/magic.mgc" },
+    });
+
+    // Pack scripts from autoconf
+    toolchain = autopack(toolchain, {
+      paths: [
+        "bin/autoconf",
+        "bin/autoheader",
+        "bin/autom4te",
+        "bin/autom4te-orig",
+        "bin/autoreconf",
+        "bin/autoscan",
+        "bin/autoupdate",
+        "bin/autoupdate-orig",
+        "bin/ifnames",
+      ],
+      selfDependency: true,
+      scriptConfig: {
+        env: {
+          AUTOCONF: {
+            type: "fallback",
+            value: { relativePath: "bin/autoconf" },
+          },
+          AUTOHEADER: {
+            type: "fallback",
+            value: { relativePath: "bin/autoheader" },
+          },
+          AUTOM4TE: {
+            type: "fallback",
+            value: { relativePath: "bin/autom4te" },
+          },
+          M4: { type: "fallback", value: { relativePath: "bin/m4" } },
+          autom4te_perllibdir: {
+            type: "fallback",
+            value: { relativePath: "share/autoconf" },
+          },
+          AC_MACRODIR: {
+            type: "fallback",
+            value: { relativePath: "share/autoconf" },
+          },
+        },
+      },
+    });
+
+    // Pack scripts from automake
+    toolchain = autopack(toolchain, {
+      globs: ["bin/automake", "bin/automake-*", "bin/aclocal", "bin/aclocal-*"],
+      selfDependency: true,
+      scriptConfig: {
+        env: {
+          AUTOMAKE_UNINSTALLED: { type: "fallback", value: "1" },
+          AUTOM4TE: {
+            type: "fallback",
+            value: { relativePath: "bin/autom4te" },
+          },
+          trailer_m4: {
+            type: "set",
+            value: { relativePath: "share/autoconf/autoconf/trailer.m4" },
+          },
+          ACLOCAL_PATH: {
+            type: "append",
+            value: { relativePath: "share/aclocal" },
+            separator: ":",
+          },
+          ACLOCAL_AUTOMAKE_DIR: {
+            type: "fallback",
+            value: { relativePath: "share/aclocal-1.16" },
+          },
+        },
+      },
+    });
+
+    // Pack all other scripts
+    toolchain = autopack(toolchain, {
+      globs: ["bin/**"],
+      selfDependency: true,
+      dynamicBinaryConfig: {
+        enabled: false,
+      },
+      sharedLibraryConfig: {
+        enabled: false,
+      },
+      scriptConfig: {
+        enabled: true,
+      },
+    });
+
+    // Re-pack all dynamic binaries. This is done so they reference libraries
+    // from the toolchain itself. Note that libraries are not packed, mainly
+    // since libc specifically should not be packed.
+    toolchain = autopack(toolchain, {
+      globs: ["bin/**"],
+      selfDependency: true,
+      dynamicBinaryConfig: {
+        enabled: true,
+      },
+      sharedLibraryConfig: {
+        enabled: false,
+      },
+      scriptConfig: {
+        enabled: false,
+      },
+      repackConfig: {
+        enabled: true,
+      },
+    });
+
+    // Keep the unpacked version of several wrapper scripts
+    const keepUnpackedPaths = [
+      "bin/x86_64-pc-linux-gnu-c++",
+      "bin/x86_64-pc-linux-gnu-g++",
+      "bin/x86_64-pc-linux-gnu-gcc",
+      "bin/x86_64-pc-linux-gnu-gcc-13.2.0",
+      "bin/c++",
+      "bin/g++",
+      "bin/gcc",
+    ];
+    for (const path of keepUnpackedPaths) {
+      toolchain = toolchain.insert(path, unpackedToolchain.get(path));
+    }
+
+    toolchain = std.sync(toolchain);
+
+    return toolchain;
+  },
+);
+
+function autopack(
   recipe: std.AsyncRecipe<std.Directory>,
+  options: AutopackOptions,
 ): std.Recipe<std.Directory> {
-  // TODO: Handle shebangs with wrapper scripts instead of just using
-  // `/usr/bin/env`. This currently duplicates the fix from stage 2
+  const { config, variables } = buildAutopackConfig({
+    options,
+    defaultLinkDependencies: [],
+    runtimeUtils: runtimeUtils(),
+  });
+
+  const variableArgs: std.ProcessTemplateLike[] = Object.entries(
+    variables,
+  ).flatMap(([name, value]) => {
+    switch (value.type) {
+      case "path":
+        return ["--var", std.tpl`${name}=path:${value.value}`];
+    }
+  });
+
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${runtimeUtils()}/bin/brioche-packer`,
       args: [
-        "-c",
-        std.indoc`
-          set -euo pipefail
-
-          find "$BRIOCHE_OUTPUT"/bin -type f -executable -print0 \
-            | while IFS= read -r -d $'\\0' file; do
-              if [ "$(head -c 2 "$file")" == "#!" ]; then
-                awk '
-                  {
-                    if (NR == 1 && $0 ~ /^#!/) {
-                      shebangInvocation = $0
-                      gsub(/^#! */, "", shebangInvocation)
-                      numShebangWords = split(shebangInvocation, shebangWords, / +/)
-                      if (numShebangWords == 1) {
-                        shebangCommand = shebangWords[1]
-                        numComponents = split(shebangCommand, shebangCommandComponents, "/")
-                        targetCommand = shebangCommandComponents[numComponents]
-                        gsub(" ", "", targetCommand)
-                        print "#!/usr/bin/env " targetCommand
-                      } else {
-                        print $0
-                      }
-                    } else {
-                      print $0
-                    }
-                  }
-                ' "$file" > temp
-                chmod +x temp
-                mv temp "$file"
-              fi
-            done
-        `,
+        "autopack",
+        std.outputPath,
+        "--config",
+        JSON.stringify(config),
+        ...variableArgs,
       ],
-      env: {
-        PATH: std.tpl`${stage2()}/bin`,
-      },
       outputScaffold: recipe,
     })
     .toDirectory();

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -205,17 +205,16 @@ export const toolchain = std.memo(
       AUTOMAKE_UNINSTALLED: { fallback: { value: "1" } },
     });
 
-    // Re-pack all dynamic binaries. This is done so they reference libraries
-    // from the toolchain itself. Note that libraries are not packed, mainly
-    // since libc specifically should not be packed.
+    // Re-pack all dynamic binaries and shared libraries
     toolchain = autopack(toolchain, {
-      globs: ["bin/**"],
+      globs: ["**"],
+      excludeGlobs: ["lib/libc.so*"],
       selfDependency: true,
       dynamicBinaryConfig: {
         enabled: true,
       },
       sharedLibraryConfig: {
-        enabled: false,
+        enabled: true,
       },
       scriptConfig: {
         enabled: false,

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -193,8 +193,8 @@ export const toolchain = std.memo(
       },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
       MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
-      AUTOCONF: { append: [{ path: "bin/autoconf" }] },
-      AUTOHEADER: { append: [{ path: "bin/autoheader" }] },
+      AUTOCONF: { fallback: { path: "bin/autoconf" } },
+      AUTOHEADER: { fallback: { path: "bin/autoheader" } },
     });
 
     // Pack scripts from autoconf

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -1,5 +1,6 @@
 import * as std from "/core";
 import { setEnv } from "/extra/set_env.bri";
+import stage2 from "/toolchain/stage2";
 import { buildAutopackConfig, AutopackOptions } from "/extra/autopack.bri";
 import { runtimeUtils } from "/toolchain/utils.bri";
 import linuxHeaders from "./linux_headers.bri";
@@ -224,6 +225,8 @@ export const toolchain = std.memo(
       },
     });
 
+    toolchain = fixShebangs(toolchain);
+
     toolchain = std.sync(toolchain);
 
     return toolchain;
@@ -259,6 +262,56 @@ function autopack(
         JSON.stringify(config),
         ...variableArgs,
       ],
+      outputScaffold: recipe,
+    })
+    .toDirectory();
+}
+
+function fixShebangs(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // TODO: Handle shebangs with wrapper scripts instead of just using
+  // `/usr/bin/env`. This currently duplicates the fix from stage 2
+  return std
+    .process({
+      command: std.tpl`${stage2()}/bin/bash`,
+      args: [
+        "-c",
+        std.indoc`
+          set -euo pipefail
+
+          find "$BRIOCHE_OUTPUT"/bin -type f -executable -print0 \
+            | while IFS= read -r -d $'\\0' file; do
+              if [ "$(head -c 2 "$file")" == "#!" ]; then
+                awk '
+                  {
+                    if (NR == 1 && $0 ~ /^#!/) {
+                      shebangInvocation = $0
+                      gsub(/^#! */, "", shebangInvocation)
+                      numShebangWords = split(shebangInvocation, shebangWords, / +/)
+                      if (numShebangWords == 1) {
+                        shebangCommand = shebangWords[1]
+                        numComponents = split(shebangCommand, shebangCommandComponents, "/")
+                        targetCommand = shebangCommandComponents[numComponents]
+                        gsub(" ", "", targetCommand)
+                        print "#!/usr/bin/env " targetCommand
+                      } else {
+                        print $0
+                      }
+                    } else {
+                      print $0
+                    }
+                  }
+                ' "$file" > temp
+                chmod +x temp
+                mv temp "$file"
+              fi
+            done
+        `,
+      ],
+      env: {
+        PATH: std.tpl`${stage2()}/bin`,
+      },
       outputScaffold: recipe,
     })
     .toDirectory();

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -157,7 +157,7 @@ export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
 
   // Set `$MAGIC` env var for `file` when used as a dependency
   tools = setEnv(tools, {
-    MAGIC: { path: "share/misc/magic.mgc" },
+    MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
   });
 
   return std.sync(tools);
@@ -183,14 +183,18 @@ export const toolchain = std.memo(
     // Set env vars when used as a dependency. These are also used
     // when autopacking
     toolchain = setEnv(toolchain, {
-      CPATH: { path: "include" },
-      LIBRARY_PATH: [
-        { path: "lib" },
-        { path: "lib/man-db" },
-        { path: "lib/gconv" },
-      ],
-      PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
-      MAGIC: { path: "share/misc/magic.mgc" },
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: {
+        append: [
+          { path: "lib" },
+          { path: "lib/man-db" },
+          { path: "lib/gconv" },
+        ],
+      },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
+      AUTOCONF: { append: [{ path: "bin/autoconf" }] },
+      AUTOHEADER: { append: [{ path: "bin/autoheader" }] },
     });
 
     // Pack scripts from autoconf

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -67,7 +67,6 @@ const toolPackages = [
   zstd(),
   file(),
   bc(),
-  binutils(),
   sed(),
   grep(),
   bash(),
@@ -88,6 +87,7 @@ const toolchainOnlyPackages = [
   readline(),
   m4(),
   flex(),
+  binutils(),
   gmp(),
   mpfr(),
   mpc(),
@@ -127,19 +127,9 @@ const toolchainOnlyPackages = [
 export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
   let tools = std.merge(...toolPackages);
 
-  // Set env vars when used as a dependency. These are also used
-  // when autopacking
-  tools = setEnv(tools, {
-    CPATH: { path: "include" },
-    LIBRARY_PATH: { path: "lib" },
-    PKG_CONFIG_PATH: { path: "lib/pkgconfig" },
-    MAGIC: { path: "share/misc/magic.mgc" },
-  });
-
   // Pack binaries and scripts
   tools = autopack(tools, {
     globs: ["bin/**"],
-    selfDependency: true,
     linkDependencies: [toolchain()],
     dynamicBinaryConfig: {
       enabled: true,
@@ -153,6 +143,21 @@ export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
     repackConfig: {
       enabled: true,
     },
+  });
+
+  // Only take the binaries (plus the magic file)
+  tools = std.directory({
+    bin: tools.get("bin"),
+    share: std.directory({
+      misc: std.directory({
+        "magic.mgc": tools.get("share/misc/magic.mgc"),
+      }),
+    }),
+  });
+
+  // Set `$MAGIC` env var for `file` when used as a dependency
+  tools = setEnv(tools, {
+    MAGIC: { path: "share/misc/magic.mgc" },
   });
 
   return std.sync(tools);

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -263,6 +263,7 @@ export const toolchain = std.memo(
     });
 
     // Pack all other scripts
+    // TODO: Use globs for Perl 5 paths
     toolchain = autopack(toolchain, {
       globs: ["bin/**"],
       selfDependency: true,
@@ -274,6 +275,21 @@ export const toolchain = std.memo(
       },
       scriptConfig: {
         enabled: true,
+        env: {
+          PERL5LIB: {
+            type: "append",
+            value: {
+              relativePaths: [
+                "lib/perl5/site_perl/5.38.0/x86_64-linux-thread-multi",
+                "lib/perl5/site_perl/5.38.0",
+                "lib/perl5/5.38.0/x86_64-linux-thread-multi",
+                "lib/perl5/5.38.0",
+              ],
+              separator: ":",
+            },
+            separator: ":",
+          },
+        },
       },
     });
 

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -195,106 +195,14 @@ export const toolchain = std.memo(
       MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
       AUTOCONF: { fallback: { path: "bin/autoconf" } },
       AUTOHEADER: { fallback: { path: "bin/autoheader" } },
-    });
-
-    // Pack scripts from autoconf
-    toolchain = autopack(toolchain, {
-      paths: [
-        "bin/autoconf",
-        "bin/autoheader",
-        "bin/autom4te",
-        "bin/autom4te-orig",
-        "bin/autoreconf",
-        "bin/autoscan",
-        "bin/autoupdate",
-        "bin/autoupdate-orig",
-        "bin/ifnames",
-      ],
-      selfDependency: true,
-      scriptConfig: {
-        env: {
-          AUTOCONF: {
-            type: "fallback",
-            value: { relativePath: "bin/autoconf" },
-          },
-          AUTOHEADER: {
-            type: "fallback",
-            value: { relativePath: "bin/autoheader" },
-          },
-          AUTOM4TE: {
-            type: "fallback",
-            value: { relativePath: "bin/autom4te" },
-          },
-          M4: { type: "fallback", value: { relativePath: "bin/m4" } },
-          autom4te_perllibdir: {
-            type: "fallback",
-            value: { relativePath: "share/autoconf" },
-          },
-          AC_MACRODIR: {
-            type: "fallback",
-            value: { relativePath: "share/autoconf" },
-          },
-        },
-      },
-    });
-
-    // Pack scripts from automake
-    toolchain = autopack(toolchain, {
-      globs: ["bin/automake", "bin/automake-*", "bin/aclocal", "bin/aclocal-*"],
-      selfDependency: true,
-      scriptConfig: {
-        env: {
-          AUTOMAKE_UNINSTALLED: { type: "fallback", value: "1" },
-          AUTOM4TE: {
-            type: "fallback",
-            value: { relativePath: "bin/autom4te" },
-          },
-          trailer_m4: {
-            type: "set",
-            value: { relativePath: "share/autoconf/autoconf/trailer.m4" },
-          },
-          ACLOCAL_PATH: {
-            type: "append",
-            value: { relativePath: "share/aclocal" },
-            separator: ":",
-          },
-          ACLOCAL_AUTOMAKE_DIR: {
-            type: "fallback",
-            value: { relativePath: "share/aclocal-1.16" },
-          },
-        },
-      },
-    });
-
-    // Pack all other scripts
-    // TODO: Use globs for Perl 5 paths
-    toolchain = autopack(toolchain, {
-      globs: ["bin/**"],
-      selfDependency: true,
-      dynamicBinaryConfig: {
-        enabled: false,
-      },
-      sharedLibraryConfig: {
-        enabled: false,
-      },
-      scriptConfig: {
-        enabled: true,
-        env: {
-          PERL5LIB: {
-            type: "append",
-            value: {
-              relativePaths: [
-                "lib/perl5/site_perl/5.38.0/x86_64-linux-thread-multi",
-                "lib/perl5/site_perl/5.38.0",
-                "lib/perl5/5.38.0/x86_64-linux-thread-multi",
-                "lib/perl5/5.38.0",
-              ],
-              separator: ":",
-            },
-            separator: ":",
-          },
-        },
-      },
+      AUTOM4TE: { fallback: { path: "bin/autom4te" } },
+      M4: { fallback: { path: "bin/m4" } },
+      autom4te_perllibdir: { fallback: { path: "share/autoconf" } },
+      AC_MACRODIR: { fallback: { path: "share/autoconf" } },
+      trailer_m4: { fallback: { path: "share/autoconf/autoconf/trailer.m4" } },
+      ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+      ACLOCAL_AUTOMAKE_DIR: { fallback: { path: "share/aclocal-1.16" } },
+      AUTOMAKE_UNINSTALLED: { fallback: { value: "1" } },
     });
 
     // Re-pack all dynamic binaries. This is done so they reference libraries
@@ -316,20 +224,6 @@ export const toolchain = std.memo(
         enabled: true,
       },
     });
-
-    // Keep the unpacked version of several wrapper scripts
-    const keepUnpackedPaths = [
-      "bin/x86_64-pc-linux-gnu-c++",
-      "bin/x86_64-pc-linux-gnu-g++",
-      "bin/x86_64-pc-linux-gnu-gcc",
-      "bin/x86_64-pc-linux-gnu-gcc-13.2.0",
-      "bin/c++",
-      "bin/g++",
-      "bin/gcc",
-    ];
-    for (const path of keepUnpackedPaths) {
-      toolchain = toolchain.insert(path, unpackedToolchain.get(path));
-    }
 
     toolchain = std.sync(toolchain);
 

--- a/packages/std/toolchain/utils.bri
+++ b/packages/std/toolchain/utils.bri
@@ -6,9 +6,9 @@ import * as std from "/core";
 export function runtimeUtils(): std.Recipe<std.Directory> {
   return std
     .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/47c4991e9f2d965e5604f8e4a6df93de17db8f77/x86_64-linux/brioche-runtime-utils.tar.zstd",
+      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/4815f007ab625a42a0e72820fdd6e154b9d5d1c6/x86_64-linux/brioche-runtime-utils.tar.zstd",
       hash: std.sha256Hash(
-        "a7d95992d56a6fa7e0a138ed54b5855ec4bdead94332eda41d0641d95075c7c7",
+        "87b43c798f294772810801697333fb82611a35fb3934354fe0b3c37fba8bb196",
       ),
     })
     .unarchive("tar", "zstd");

--- a/packages/std/toolchain/utils.bri
+++ b/packages/std/toolchain/utils.bri
@@ -6,9 +6,9 @@ import * as std from "/core";
 export function runtimeUtils(): std.Recipe<std.Directory> {
   return std
     .download({
-      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/fad8671ca1ea5c14ebcbc31f373bbc443a9b5719/x86_64-linux/brioche-runtime-utils.tar.zstd",
+      url: "https://development-content.brioche.dev/github.com/brioche-dev/brioche-runtime-utils/commits/47c4991e9f2d965e5604f8e4a6df93de17db8f77/x86_64-linux/brioche-runtime-utils.tar.zstd",
       hash: std.sha256Hash(
-        "7f1539e866ff937c27008da0f4ca6618d48165548df99edfa7b137abcfb09a30",
+        "a7d95992d56a6fa7e0a138ed54b5855ec4bdead94332eda41d0641d95075c7c7",
       ),
     })
     .unarchive("tar", "zstd");


### PR DESCRIPTION
This PR makes a few changes to `std`:

- Update `std.setEnv()` to support setting fallback env vars, instead of just appended paths
- Update `std.toolchain()` to set env vars for automake/autoconf, which cleans up downstream builds
- Re-wrap `std.toolchain()` and `std.tools()`. This ensures the final built version of each library gets used for all executables, and additionally shrinks the total size of both artifacts

The `std.setEnv()` in particular requires a code change. Here's an example:

```typescript
// Previously
/*
std.setEnv(recipe, {
  FOO: { path: "foo" },
  BAR: [{ path: "bar" }, { path: "baz" }],
});
*/

// Now
std.setEnv(recipe, {
  FOO: { append: [{ path: "foo" }] },
  BAR: { append: [{ path: "bar" }, { path: "baz" }] },
});
```

Additionally, there's now `fallback` values for env vars, which allow falling back to either a path or to a literal value. Unlike with `append` paths, this will either set it to a single path/value, or will leave it unchanged if it was already set

```typescript
std.setEnv(recipe, {
  // Append a path to $LIBRARY_PATH
  LIBRARY_PATH: { append: [{ path: "lib" }] },

  // Set $MAKE if not already set
  MAKE: { fallback: { path: "bin/make" } },

  // Set $DEBUG to 1 if not already set
  DEBUG: { fallback: { value: "1" } },
});
```