### PR TITLE
Clean up packages

### DIFF
--- a/packages/alsa_lib/brioche.lock
+++ b/packages/alsa_lib/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.12.tar.bz2": {
+      "type": "sha256",
+      "value": "4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2"
+    }
+  }
 }

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -11,7 +11,7 @@ const source = Brioche.download(
   .unarchive("tar", "bzip2")
   .peel();
 
-export default (): std.Recipe<std.Directory> => {
+export default function (): std.Recipe<std.Directory> {
   const alsaLib = std.runBash`
     ./configure --prefix=/
     make install DESTDIR="$BRIOCHE_OUTPUT"
@@ -25,4 +25,4 @@ export default (): std.Recipe<std.Directory> => {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
-};
+}

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "1.2.12",
 };
 
-const source = std
-  .download({
-    url: `https://www.alsa-project.org/files/pub/lib/alsa-lib-${project.version}.tar.bz2`,
-    hash: std.sha256Hash(
-      "4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2",
-    ),
-  })
+const source = Brioche.download(
+  `https://www.alsa-project.org/files/pub/lib/alsa-lib-${project.version}.tar.bz2`,
+)
   .unarchive("tar", "bzip2")
   .peel();
 

--- a/packages/bat/brioche.lock
+++ b/packages/bat/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/sharkdp/bat/archive/refs/tags/v0.24.0.tar.gz": {
+      "type": "sha256",
+      "value": "907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb"
+    }
+  }
 }

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.24.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/sharkdp/bat/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/sharkdp/bat/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/broot/brioche.lock
+++ b/packages/broot/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/Canop/broot/archive/refs/tags/v1.42.0.tar.gz": {
+      "type": "sha256",
+      "value": "f8a206d44b55287f47cdb63e2f19c9022d55d49f9399e5461f7797ccbe0264ba"
+    }
+  }
 }

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "1.42.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/Canop/broot/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "f8a206d44b55287f47cdb63e2f19c9022d55d49f9399e5461f7797ccbe0264ba",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/Canop/broot/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/broot",
   });
-};
+}

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -5,7 +5,7 @@ export const project = {
   version: "2024-07-02",
 };
 
-export default (): std.Recipe<std.Directory> => {
+export default function (): std.Recipe<std.Directory> {
   const cacert = Brioche.download(
     `https://curl.se/ca/cacert-${project.version}.pem`,
   );
@@ -24,4 +24,4 @@ export default (): std.Recipe<std.Directory> => {
       SSL_CERT_FILE: { fallback: { path: "etc/ssl/certs/ca-bundle.crt" } },
     },
   );
-};
+}

--- a/packages/carapace/brioche.lock
+++ b/packages/carapace/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v1.0.5.tar.gz": {
+      "type": "sha256",
+      "value": "25555206b1b5350cba3567463cb2c5b87c43fad20d4e8200ab78d49371c0b4db"
+    }
+  }
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "1.0.5",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "25555206b1b5350cba3567463cb2c5b87c43fad20d4e8200ab78d49371c0b4db",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return goBuild({
     source,
     buildParams: {
@@ -22,4 +22,4 @@ export default () => {
     path: "./cmd/carapace",
     runnable: "bin/carapace",
   });
-};
+}

--- a/packages/curl/brioche.lock
+++ b/packages/curl/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://curl.se/download/curl-8.9.1.tar.gz": {
+      "type": "sha256",
+      "value": "291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5"
+    }
+  }
 }

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default (): std.Recipe<std.Directory> => {
+export default function (): std.Recipe<std.Directory> {
   let curl = std.runBash`
     ./configure \\
       --prefix=/ \\
@@ -34,4 +34,4 @@ export default (): std.Recipe<std.Directory> => {
   });
 
   return std.withRunnableLink(curl, "bin/curl");
-};
+}

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "8.9.1",
 };
 
-const source = std
-  .download({
-    url: `https://curl.se/download/curl-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5",
-    ),
-  })
+const source = Brioche.download(
+  `https://curl.se/download/curl-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/dust/brioche.lock
+++ b/packages/dust/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/bootandy/dust/archive/refs/tags/v1.1.1.tar.gz": {
+      "type": "sha256",
+      "value": "98cae3e4b32514e51fcc1ed07fdbe6929d4b80942925348cc6e57b308d9c4cb0"
+    }
+  }
 }

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/dust",
   });
-};
+}

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "1.1.1",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/bootandy/dust/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "98cae3e4b32514e51fcc1ed07fdbe6929d4b80942925348cc6e57b308d9c4cb0",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/bootandy/dust/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -6,19 +6,9 @@ export const project = {
   version: "0.19.2",
 };
 
-// HACK: Workaround for issue unarchiving this tarfile. See:
-// https://github.com/brioche-dev/brioche/issues/103
-const sourceTar = Brioche.download(
+const source = Brioche.download(
   `https://github.com/eza-community/eza/archive/refs/tags/v${project.version}.tar.gz`,
-);
-const source = std
-  .process({
-    command: "tar",
-    args: ["-xf", sourceTar, "--strip-components=1", "-C", std.outputPath],
-    outputScaffold: std.directory(),
-    dependencies: [std.tools()],
-  })
-  .toDirectory();
+).unarchive("tar", "gzip");
 
 export default () => {
   return cargoBuild({

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -10,9 +10,9 @@ const source = Brioche.download(
   `https://github.com/eza-community/eza/archive/refs/tags/v${project.version}.tar.gz`,
 ).unarchive("tar", "gzip");
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/eza",
   });
-};
+}

--- a/packages/git/brioche.lock
+++ b/packages/git/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/git/git/archive/refs/tags/v2.46.0.tar.gz": {
+      "type": "sha256",
+      "value": "d9a72f1648406806d2cb3049b4a73f357e2dc8df5d2962ce6d24220f3861a221"
+    }
+  }
 }

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -8,13 +8,9 @@ export const project = {
   version: "2.46.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/git/git/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "d9a72f1648406806d2cb3049b4a73f357e2dc8df5d2962ce6d24220f3861a221",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/git/git/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -1,3 +1,4 @@
+import * as std from "std";
 import git, { gitCheckout } from "git";
 import { cargoBuild } from "rust";
 

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -13,7 +13,7 @@ const source = gitCheckout(
   }),
 );
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     dependencies: [git()],
@@ -22,4 +22,4 @@ export default () => {
     },
     runnable: "bin/gitui",
   });
-};
+}

--- a/packages/go/brioche.lock
+++ b/packages/go/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://go.dev/dl/go1.23.0.linux-amd64.tar.gz": {
+    "https://go.dev/dl/go1.23.1.linux-amd64.tar.gz": {
       "type": "sha256",
-      "value": "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3"
+      "value": "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd"
     }
   }
 }

--- a/packages/hello_world/project.bri
+++ b/packages/hello_world/project.bri
@@ -11,5 +11,6 @@ export default function (): std.Recipe<std.Directory> {
     ln -s bin/hello-world "$BRIOCHE_OUTPUT/brioche-run"
   `
     .workDir(Brioche.glob("src"))
-    .dependencies(std.toolchain());
+    .dependencies(std.toolchain())
+    .toDirectory();
 }

--- a/packages/hello_world/project.bri
+++ b/packages/hello_world/project.bri
@@ -4,7 +4,7 @@ export const project = {
   name: "hello_world",
 };
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return std.runBash`
     mkdir -p "$BRIOCHE_OUTPUT/bin"
     gcc src/main.c -o "$BRIOCHE_OUTPUT/bin/hello-world"
@@ -12,4 +12,4 @@ export default () => {
   `
     .workDir(Brioche.glob("src"))
     .dependencies(std.toolchain());
-};
+}

--- a/packages/joshuto/brioche.lock
+++ b/packages/joshuto/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/kamiyaa/joshuto/archive/refs/tags/v0.9.8.tar.gz": {
+      "type": "sha256",
+      "value": "877d841b2e26d26d0f0f2e6f1dab3ea2fdda38c345abcd25085a3f659c24e013"
+    }
+  }
 }

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.9.8",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/kamiyaa/joshuto/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "877d841b2e26d26d0f0f2e6f1dab3ea2fdda38c345abcd25085a3f659c24e013",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/kamiyaa/joshuto/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 // https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
 const patch = Brioche.includeFile("joshuto-v0.9.8.patch");
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   const patchedSource = std.runBash`
     cd "$BRIOCHE_OUTPUT"
     patch -p1 < $patch
@@ -30,4 +30,4 @@ export default () => {
     source: patchedSource,
     runnable: "bin/joshuto",
   });
-};
+}

--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/martinvonz/jj/archive/refs/tags/v0.20.0.tar.gz": {
+      "type": "sha256",
+      "value": "b2c898ea224fe45df81c241bf1f0bc8e74c0988b8f549e894b15a38f2f4d6665"
+    }
+  }
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -13,11 +13,11 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/jj",
     path: "cli",
     dependencies: [openssl()],
   });
-};
+}

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -7,13 +7,9 @@ export const project = {
   version: "0.20.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/martinvonz/jj/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "b2c898ea224fe45df81c241bf1f0bc8e74c0988b8f549e894b15a38f2f4d6665",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/martinvonz/jj/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/jwt_cli/brioche.lock
+++ b/packages/jwt_cli/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/mike-engel/jwt-cli/archive/refs/tags/6.1.0.tar.gz": {
+      "type": "sha256",
+      "value": "9bc2232f052f0fcc3171d95a301911b29b8dff12fcb7ea80718c0ef1c993f9b9"
+    }
+  }
 }

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "6.1.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/mike-engel/jwt-cli/archive/refs/tags/${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "9bc2232f052f0fcc3171d95a301911b29b8dff12fcb7ea80718c0ef1c993f9b9",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/mike-engel/jwt-cli/archive/refs/tags/${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default function () {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/jwt",

--- a/packages/k9s/brioche.lock
+++ b/packages/k9s/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/derailed/k9s/archive/refs/tags/v0.32.5.tar.gz": {
-      "type": "sha256",
-      "value": "e011697b3de99d7691119036eaae6e5d4f1a98e284755ab6b15ae6daba08595f"
+  "git_refs": {
+    "https://github.com/derailed/k9s.git": {
+      "v0.32.5": "1440643e8d1a101a38d9be1933131ddf5c863940"
     }
   }
 }

--- a/packages/k9s/brioche.lock
+++ b/packages/k9s/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/derailed/k9s/archive/refs/tags/v0.32.5.tar.gz": {
+      "type": "sha256",
+      "value": "e011697b3de99d7691119036eaae6e5d4f1a98e284755ab6b15ae6daba08595f"
+    }
+  }
 }

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -7,13 +7,9 @@ export const project = {
 };
 const gitCommit = "1440643e8d1a101a38d9be1933131ddf5c863940";
 
-const source = std
-  .download({
-    url: `https://github.com/derailed/k9s/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "e011697b3de99d7691119036eaae6e5d4f1a98e284755ab6b15ae6daba08595f",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/derailed/k9s/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -13,7 +13,7 @@ const gitRef = await Brioche.gitRef({
 });
 const source = gitCheckout(gitRef);
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return goBuild({
     source,
     buildParams: {
@@ -26,4 +26,4 @@ export default () => {
     },
     runnable: "bin/k9s",
   });
-};
+}

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -1,17 +1,17 @@
 import * as std from "std";
+import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
   name: "k9s",
   version: "0.32.5",
 };
-const gitCommit = "1440643e8d1a101a38d9be1933131ddf5c863940";
 
-const source = Brioche.download(
-  `https://github.com/derailed/k9s/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const gitRef = await Brioche.gitRef({
+  repository: "https://github.com/derailed/k9s.git",
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
 
 export default () => {
   return goBuild({
@@ -21,7 +21,7 @@ export default () => {
         "-s",
         "-w",
         `-X github.com/derailed/k9s/cmd.version=${project.version}`,
-        `-X github.com/derailed/k9s/cmd.commit=${gitCommit}`,
+        `-X github.com/derailed/k9s/cmd.commit=${gitRef.commit}`,
       ],
     },
     runnable: "bin/k9s",

--- a/packages/lurk/brioche.lock
+++ b/packages/lurk/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/JakWai01/lurk/archive/refs/tags/v0.3.6.tar.gz": {
+      "type": "sha256",
+      "value": "5e5497fbe0480709619f70223d1724183031e62e28c42e609ceca51951b7081e"
+    }
+  }
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/lurk",
   });
-};
+}

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.3.6",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/JakWai01/lurk/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "5e5497fbe0480709619f70223d1724183031e62e28c42e609ceca51951b7081e",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/JakWai01/lurk/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/miniserve/brioche.lock
+++ b/packages/miniserve/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/svenstaro/miniserve/archive/refs/tags/v0.27.1.tar.gz": {
+      "type": "sha256",
+      "value": "b65580574ca624072b1a94d59ebf201ab664eacacb46a5043ef7b81ebb538f80"
+    }
+  }
 }

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 // https://github.com/svenstaro/miniserve/commit/2fbfcbfe17b5c12630ccb03b6ccd31cb4b8316cc
 const patch = Brioche.includeFile("miniserve-v0.27.1.patch");
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   const patchedSource = std.runBash`
     cd "$BRIOCHE_OUTPUT"
     patch -p1 < $patch
@@ -30,4 +30,4 @@ export default () => {
     source: patchedSource,
     runnable: "bin/miniserve",
   });
-};
+}

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.27.1",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/svenstaro/miniserve/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "b65580574ca624072b1a94d59ebf201ab664eacacb46a5043ef7b81ebb538f80",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/svenstaro/miniserve/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/nodejs/brioche.lock
+++ b/packages/nodejs/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://nodejs.org/dist/v20.16.0/node-v20.16.0-linux-x64.tar.xz": {
+      "type": "sha256",
+      "value": "c30af7dfea46de7d8b9b370fa33b8b15440bc93f0a686af8601bbb48b82f16c0"
+    }
+  }
 }

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -44,7 +44,7 @@ interface NpmInstallOptions {
  * import * as std from "std";
  * import nodejs, { npmInstall } from "nodejs";
  *
- * export default () => {
+ * export default function () {
  *   // Get all the files for the NPM package
  *   const source = Brioche.glob("src", "package.lock", "package.json");
  *

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -12,13 +12,9 @@ export const project = {
  * - `bin/npm`
  */
 function nodejs(): std.Recipe<std.Directory> {
-  let node = std
-    .download({
-      url: `https://nodejs.org/dist/v${project.version}/node-v${project.version}-linux-x64.tar.xz`,
-      hash: std.sha256Hash(
-        "c30af7dfea46de7d8b9b370fa33b8b15440bc93f0a686af8601bbb48b82f16c0",
-      ),
-    })
+  let node = Brioche.download(
+    `https://nodejs.org/dist/v${project.version}/node-v${project.version}-linux-x64.tar.xz`,
+  )
     .unarchive("tar", "xz")
     .peel();
 

--- a/packages/nushell/brioche.lock
+++ b/packages/nushell/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/nushell/nushell/archive/refs/tags/0.96.1.tar.gz": {
+      "type": "sha256",
+      "value": "829e2f91d130d7b0063a08b1fadb737bdff616ac744eba43baa5fc42aa8b682b"
+    }
+  }
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -13,10 +13,10 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/nu",
     dependencies: [openssl()],
   });
-};
+}

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -7,13 +7,9 @@ export const project = {
   version: "0.96.1",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/nushell/nushell/archive/refs/tags/${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "829e2f91d130d7b0063a08b1fadb737bdff616ac744eba43baa5fc42aa8b682b",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/nushell/nushell/archive/refs/tags/${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/oha/brioche.lock
+++ b/packages/oha/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/hatoo/oha/archive/refs/tags/v1.4.6.tar.gz": {
+      "type": "sha256",
+      "value": "8a68d4411ce241d161aeaa87e9f1e778b381398454bf58e58c976d575fcb2c3b"
+    }
+  }
 }

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "1.4.6",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/hatoo/oha/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "8a68d4411ce241d161aeaa87e9f1e778b381398454bf58e58c976d575fcb2c3b",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/hatoo/oha/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/oha",
   });
-};
+}

--- a/packages/oniguruma/brioche.lock
+++ b/packages/oniguruma/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/kkos/oniguruma/archive/refs/tags/v6.9.9.tar.gz": {
+      "type": "sha256",
+      "value": "001aa1202e78448f4c0bf1a48c76e556876b36f16d92ce3207eccfd61d99f2a0"
+    }
+  }
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "6.9.9",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/kkos/oniguruma/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "001aa1202e78448f4c0bf1a48c76e556876b36f16d92ce3207eccfd61d99f2a0",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/kkos/oniguruma/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/openssl/brioche.lock
+++ b/packages/openssl/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz": {
+      "type": "sha256",
+      "value": "777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+    }
+  }
 }

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "3.3.1",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/openssl/openssl/releases/download/openssl-${project.version}/openssl-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/openssl/openssl/releases/download/openssl-${project.version}/openssl-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/opentofu/brioche.lock
+++ b/packages/opentofu/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/opentofu/opentofu/archive/refs/tags/v1.8.0.tar.gz": {
+      "type": "sha256",
+      "value": "9e3f622741a0df00a10fcd42653260742c966936b252d3171d1ad952de6e40e0"
+    }
+  }
 }

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "1.8.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/opentofu/opentofu/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "9e3f622741a0df00a10fcd42653260742c966936b252d3171d1ad952de6e40e0",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/opentofu/opentofu/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return goBuild({
     source,
     path: "./cmd/tofu",
@@ -23,4 +23,4 @@ export default () => {
     },
     runnable: "bin/tofu",
   });
-};
+}

--- a/packages/pcre2/brioche.lock
+++ b/packages/pcre2/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.44.tar.gz": {
+      "type": "sha256",
+      "value": "07a002e8216382a96f722bc4a831f3d77457fe3e9e62a6dff250a2dd0e9c5e6d"
+    }
+  }
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "10.44",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "07a002e8216382a96f722bc4a831f3d77457fe3e9e62a6dff250a2dd0e9c5e6d",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/pv/brioche.lock
+++ b/packages/pv/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://www.ivarch.com/programs/sources/pv-1.8.13.tar.gz": {
+      "type": "sha256",
+      "value": "e2bde058d0d3bfe03e60a6eedef6a179991f5cc698d1bac01b64a86f5a8c17af"
+    }
+  }
 }

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -11,7 +11,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default (): std.Recipe<std.Directory> => {
+export default function (): std.Recipe<std.Directory> {
   const pv = std.runBash`
     ./configure --prefix=/
     make
@@ -22,4 +22,4 @@ export default (): std.Recipe<std.Directory> => {
     .toDirectory();
 
   return std.withRunnableLink(pv, "bin/pv");
-};
+}

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "1.8.13",
 };
 
-const source = std
-  .download({
-    url: `https://www.ivarch.com/programs/sources/pv-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "e2bde058d0d3bfe03e60a6eedef6a179991f5cc698d1bac01b64a86f5a8c17af",
-    ),
-  })
+const source = Brioche.download(
+  `https://www.ivarch.com/programs/sources/pv-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/ripgrep/brioche.lock
+++ b/packages/ripgrep/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.1.0.tar.gz": {
+      "type": "sha256",
+      "value": "33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6"
+    }
+  }
 }

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     buildParams: {
@@ -20,4 +20,4 @@ export default () => {
     },
     runnable: "bin/rg",
   });
-};
+}

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "14.1.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/BurntSushi/ripgrep/archive/refs/tags/${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/BurntSushi/ripgrep/archive/refs/tags/${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -10,10 +10,10 @@ const source = Brioche.download(
   `https://github.com/astral-sh/ruff/archive/refs/tags/${project.version}.tar.gz`,
 ).unarchive("tar", "gzip");
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     path: "crates/ruff",
     runnable: "bin/ruff",
   });
-};
+}

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -6,19 +6,9 @@ export const project = {
   version: "0.6.1",
 };
 
-// HACK: Workaround for issue unarchiving this tarfile. See:
-// https://github.com/brioche-dev/brioche/issues/103
-const sourceTar = Brioche.download(
+const source = Brioche.download(
   `https://github.com/astral-sh/ruff/archive/refs/tags/${project.version}.tar.gz`,
-);
-const source = std
-  .process({
-    command: "tar",
-    args: ["-xf", sourceTar, "--strip-components=1", "-C", std.outputPath],
-    outputScaffold: std.directory(),
-    dependencies: [std.tools()],
-  })
-  .toDirectory();
+).unarchive("tar", "gzip");
 
 export default () => {
   return cargoBuild({

--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -4,6 +4,10 @@
     "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
       "type": "sha256",
       "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
+    },
+    "https://static.rust-lang.org/dist/channel-rust-1.80.1.toml": {
+      "type": "sha256",
+      "value": "de354821fe573e7514d4245a4f20223b45c755b265d76312c777ae7135c28ed1"
     }
   }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -142,7 +142,7 @@ export interface CargoBuildOptions {
  * import openssl from "openssl";
  * import { cargoBuild } from "rust";
  *
- * export default () => {
+ * export default function () {
  *   return cargoBuild({
  *     source: Brioche.glob("src", "Cargo.*"),
  *     runnable: "bin/hello",

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -38,14 +38,9 @@ const Manifest = t.object({
  * ...among other binaries.
  */
 async function rust(): Promise<std.Recipe<std.Directory>> {
-  const manifestToml = await std
-    .download({
-      url: `https://static.rust-lang.org/dist/channel-rust-${project.version}.toml`,
-      hash: std.sha256Hash(
-        "de354821fe573e7514d4245a4f20223b45c755b265d76312c777ae7135c28ed1",
-      ),
-    })
-    .read();
+  const manifestToml = await Brioche.download(
+    `https://static.rust-lang.org/dist/channel-rust-${project.version}.toml`,
+  ).read();
   const manifest = t.parse(Manifest, TOML.parse(manifestToml));
 
   // TODO: Support other profiles

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -45,7 +45,7 @@ export interface BashRunnableUtils {
  * import * as std from "std";
  *
  * // Running `brioche run` will print "Hello, world!"
- * export default () => {
+ * export default function () {
  *   return std.bashRunnable`
  *     echo "Hello, world!"
  *   `;

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -21,7 +21,7 @@ import { tools } from "/toolchain";
  * // Running `brioche build -o output` will create a directory `output`
  * // with the file `hello.txt`. The result is cached, so the script won't
  * // re-run unless the script changes or its inputs change.
- * export default () => {
+ * export default function () {
  *   const file = std.file("Hello, world!");
  *
  *   // Return a recipe that will call the script, with `$file` set to

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -13,7 +13,7 @@ import * as std from "/core";
  * ```typescript
  * import * as std from "std";
  *
- * export default () => {
+ * export default function () {
  *   // Build a C program from the `src` directory
  *   let program = std.runBash`
  *     mkdir -p "$BRIOCHE_OUTPUT/bin"

--- a/packages/tcsh/brioche.lock
+++ b/packages/tcsh/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://astron.com/pub/tcsh/tcsh-6.24.13.tar.gz": {
+      "type": "sha256",
+      "value": "1e927d52e9c85d162bf985f24d13c6ccede9beb880d86fec492ed15480a5c71a"
+    }
+  }
 }

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -5,13 +5,9 @@ export const project = {
   version: "6.24.13",
 };
 
-const source = std
-  .download({
-    url: `https://astron.com/pub/tcsh/tcsh-${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "1e927d52e9c85d162bf985f24d13c6ccede9beb880d86fec492ed15480a5c71a",
-    ),
-  })
+const source = Brioche.download(
+  `https://astron.com/pub/tcsh/tcsh-${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/tokei/brioche.lock
+++ b/packages/tokei/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/XAMPPRocky/tokei/archive/refs/tags/v12.1.2.tar.gz": {
+      "type": "sha256",
+      "value": "81ef14ab8eaa70a68249a299f26f26eba22f342fb8e22fca463b08080f436e50"
+    }
+  }
 }

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/tokei",
   });
-};
+}

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "12.1.2",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/XAMPPRocky/tokei/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "81ef14ab8eaa70a68249a299f26f26eba22f342fb8e22fca463b08080f436e50",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/XAMPPRocky/tokei/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/xplr/brioche.lock
+++ b/packages/xplr/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/sayanarijit/xplr/archive/refs/tags/v0.21.9.tar.gz": {
+      "type": "sha256",
+      "value": "345400c2fb7046963b2e0fcca8802b6e523e0fb742d0d893cb7fd42f10072a55"
+    }
+  }
 }

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.21.9",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/sayanarijit/xplr/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "345400c2fb7046963b2e0fcca8802b6e523e0fb742d0d893cb7fd42f10072a55",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/sayanarijit/xplr/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/xplr",
   });
-};
+}

--- a/packages/xsv/brioche.lock
+++ b/packages/xsv/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/BurntSushi/xsv/archive/refs/tags/0.13.0.tar.gz": {
+      "type": "sha256",
+      "value": "2b75309b764c9f2f3fdc1dd31eeea5a74498f7da21ae757b3ffd6fd537ec5345"
+    }
+  }
 }

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.13.0",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/BurntSushi/xsv/archive/refs/tags/${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "2b75309b764c9f2f3fdc1dd31eeea5a74498f7da21ae757b3ffd6fd537ec5345",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/BurntSushi/xsv/archive/refs/tags/${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/xsv",
   });
-};
+}

--- a/packages/zoxide/brioche.lock
+++ b/packages/zoxide/brioche.lock
@@ -1,3 +1,9 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v0.9.4.tar.gz": {
+      "type": "sha256",
+      "value": "ec002bdca37917130ae34e733eb29d4baa03b130c4b11456d630a01a938e0187"
+    }
+  }
 }

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -12,9 +12,9 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/zoxide",
   });
-};
+}

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -6,13 +6,9 @@ export const project = {
   version: "0.9.4",
 };
 
-const source = std
-  .download({
-    url: `https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v${project.version}.tar.gz`,
-    hash: std.sha256Hash(
-      "ec002bdca37917130ae34e733eb29d4baa03b130c4b11456d630a01a938e0187",
-    ),
-  })
+const source = Brioche.download(
+  `https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v${project.version}.tar.gz`,
+)
   .unarchive("tar", "gzip")
   .peel();
 


### PR DESCRIPTION
This PR includes some general minor cleanup across lots of packages:

- Update `brioche.lock` for `go` package. I missed this before merging #111
- Update all remaining `std.download()` recipes to use `Brioche.download()` where possible (this was supposed to be done in #104 but quite a few packages were missed)
- Switch to using `.unarchive()` in places where a workaround was needed due to brioche-dev/brioche#103
- Update `k9s` package to use `Brioche.gitRef()` + `gitCheckout()`. This ensures that the git commit hash for the build matches the actual source code commit
- Use `export default function () { ... }` instead of `export default () => { ... };` everywhere
  - This isn't a "set in stone" decision, but I'd prefer to stick to one in the packages repo, and I believe `export default function () { ... }` has the edge (namely: you can define a function that is both exported as the default and has a local name, see [this diff from `go`](https://github.com/brioche-dev/brioche-packages/commit/93f3dc798dc3b2f3bc74b8e163ddc25b200540ce#diff-46402b0c47a52cd64b882ee1aa324b43069af03d5aad738b52b5f94e6b20c2aeL21-L46) for an example). Open to bikeshedding on this though!