### PR TITLE
Fix failing package builds

### DIFF
--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -8,7 +8,9 @@ export const project = {
 
 const source = Brioche.download(
   `https://github.com/eza-community/eza/archive/refs/tags/v${project.version}.tar.gz`,
-).unarchive("tar", "gzip");
+)
+  .unarchive("tar", "gzip")
+  .peel();
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -8,7 +8,9 @@ export const project = {
 
 const source = Brioche.download(
   `https://github.com/astral-sh/ruff/archive/refs/tags/${project.version}.tar.gz`,
-).unarchive("tar", "gzip");
+)
+  .unarchive("tar", "gzip")
+  .peel();
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({


### PR DESCRIPTION
This PR is a followup to #112 to fix the failing builds for the `eza` and `ruff` packages. Both of them were just missing a `.peel()` after calling `.unarchive(...)`