### PR TITLE
[std] Improve autotools to avoid needing to manually set env vars

### DIFF
--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -13,16 +13,7 @@ const source = Brioche.download(
 
 export default function (): std.Recipe<std.Directory> {
   let oniguruma = std.runBash`
-    # Some of the build scripts hardcode a few paths, so we need to
-    # create symlinks and set _lt_pkgdatadir to point to the correct
-    # location.
-    mkdir -p "$TMPDIR"/pkgdatadir
-    ln -s "$toolchain"/share/libtool/build-aux "$TMPDIR"/pkgdatadir/build-aux
-    ln -s "$toolchain"/share/libtool "$TMPDIR"/pkgdatadir/libltdl
-    ln -s "$toolchain"/share/aclocal "$TMPDIR"/pkgdatadir/m4
-    export _lt_pkgdatadir="$TMPDIR"/pkgdatadir
-
-    autoreconf --install --force --verbose -I "$aclocal_dir"
+    autoreconf --install --force --verbose
     ./configure \\
       --prefix=/ \\
       --enable-posix-api=yes
@@ -31,11 +22,6 @@ export default function (): std.Recipe<std.Directory> {
   `
     .dependencies(std.toolchain())
     .workDir(source)
-    .env({
-      toolchain: std.toolchain(),
-      aclocal_dir: std.tpl`${std.toolchain()}/share/aclocal`,
-      ...autotoolsEnv(),
-    })
     .toDirectory();
 
   oniguruma = std.setEnv(oniguruma, {
@@ -45,22 +31,4 @@ export default function (): std.Recipe<std.Directory> {
   });
 
   return std.withRunnableLink(oniguruma, "bin/onig-config");
-}
-
-// HACK: This should be removed once `std.toolchain()` properly sets
-// these variables for autotools
-function autotoolsEnv(): Record<string, std.ProcessTemplateLike> {
-  return {
-    M4: std.tpl`${std.toolchain()}/bin/m4`,
-    AUTOM4TE: std.tpl`${std.toolchain()}/bin/autom4te`,
-    trailer_m4: std.tpl`${std.toolchain()}/share/autoconf/autoconf/trailer.m4`,
-    PERL5LIB: std.tpl`${std.toolchain()}/share/autoconf:${std.toolchain()}/share/automake-1.16`,
-    autom4te_perllibdir: std.tpl`${std.toolchain()}/share/autoconf`,
-    AC_MACRODIR: std.tpl`${std.toolchain()}/share/autoconf`,
-    ACLOCAL_AUTOMAKE_DIR: std.tpl`${std.toolchain()}/share/aclocal-1.16`,
-    AUTOMAKE_UNINSTALLED: "1",
-    AUTOCONF: std.tpl`${std.toolchain()}/bin/autoconf`,
-    AUTOMAKE_LIBDIR: std.tpl`${std.toolchain()}/share/automake-1.16`,
-    AUTOHEADER: std.tpl`${std.toolchain()}/bin/autoheader`,
-  };
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -13,15 +13,6 @@ const source = Brioche.download(
 
 export default function (): std.Recipe<std.Directory> {
   const pcre2 = std.runBash`
-    # Some of the build scripts hardcode a few paths, so we need to
-    # create symlinks and set _lt_pkgdatadir to point to the correct
-    # location.
-    mkdir -p "$TMPDIR"/pkgdatadir
-    ln -s "$toolchain"/share/libtool/build-aux "$TMPDIR"/pkgdatadir/build-aux
-    ln -s "$toolchain"/share/libtool "$TMPDIR"/pkgdatadir/libltdl
-    ln -s "$toolchain"/share/aclocal "$TMPDIR"/pkgdatadir/m4
-    export _lt_pkgdatadir="$TMPDIR"/pkgdatadir
-
     ./autogen.sh
     ./configure \\
       --prefix=/ \\
@@ -34,15 +25,6 @@ export default function (): std.Recipe<std.Directory> {
   `
     .dependencies(std.toolchain())
     .workDir(source)
-    // `GREP` and `SED` are defined in libtool's scripts, but the values are
-    // hardcoded. Setting them here ensures that the build scripts can properly
-    // find them.
-    .env({
-      toolchain: std.toolchain(),
-      GREP: "grep",
-      SED: "sed",
-      ...autotoolsEnv(),
-    })
     .toDirectory();
 
   return std.setEnv(pcre2, {
@@ -50,21 +32,4 @@ export default function (): std.Recipe<std.Directory> {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
-}
-
-// HACK: This should be removed once `std.toolchain()` properly sets
-// these variables for autotools
-function autotoolsEnv(): Record<string, std.ProcessTemplateLike> {
-  return {
-    M4: std.tpl`${std.toolchain()}/bin/m4`,
-    AUTOM4TE: std.tpl`${std.toolchain()}/bin/autom4te`,
-    trailer_m4: std.tpl`${std.toolchain()}/share/autoconf/autoconf/trailer.m4`,
-    PERL5LIB: std.tpl`${std.toolchain()}/share/autoconf:${std.toolchain()}/share/automake-1.16`,
-    autom4te_perllibdir: std.tpl`${std.toolchain()}/share/autoconf`,
-    AC_MACRODIR: std.tpl`${std.toolchain()}/share/autoconf`,
-    ACLOCAL_AUTOMAKE_DIR: std.tpl`${std.toolchain()}/share/aclocal-1.16`,
-    AUTOMAKE_UNINSTALLED: "1",
-    AUTOCONF: std.tpl`${std.toolchain()}/bin/autoconf`,
-    AUTOMAKE_LIBDIR: std.tpl`${std.toolchain()}/share/automake-1.16`,
-  };
 }

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -181,10 +181,16 @@ export const toolchain = std.memo(
     // Add a symlink for the C compiler
     toolchain = toolchain.insert("bin/cc", std.symlink({ target: "gcc" }));
 
+    // Add a symlink that libtool needs
+    toolchain = toolchain.insert(
+      "share/libtool/m4",
+      std.symlink({ target: "../aclocal" }),
+    );
+
     // Set env vars when used as a dependency. These are also used
     // when autopacking
     toolchain = setEnv(toolchain, {
-      CPATH: { append: [{ path: "include" }] },
+      // Library paths for shared libraries
       LIBRARY_PATH: {
         append: [
           { path: "lib" },
@@ -192,18 +198,43 @@ export const toolchain = std.memo(
           { path: "lib/gconv" },
         ],
       },
+
+      // Include paths
+      CPATH: { append: [{ path: "include" }] },
+
+      // Perl library paths
+      PERL5LIB: {
+        append: [{ path: "share/autconf" }, { path: "share/automake-1.16" }],
+      },
+
+      // pkg-config search paths
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+
+      // Magic patterns used by `file`
       MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
+
+      // Autotools env vars
       AUTOCONF: { fallback: { path: "bin/autoconf" } },
       AUTOHEADER: { fallback: { path: "bin/autoheader" } },
       AUTOM4TE: { fallback: { path: "bin/autom4te" } },
-      M4: { fallback: { path: "bin/m4" } },
       autom4te_perllibdir: { fallback: { path: "share/autoconf" } },
       AC_MACRODIR: { fallback: { path: "share/autoconf" } },
       trailer_m4: { fallback: { path: "share/autoconf/autoconf/trailer.m4" } },
       ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
       ACLOCAL_AUTOMAKE_DIR: { fallback: { path: "share/aclocal-1.16" } },
+      AUTOMAKE_LIBDIR: { fallback: { path: "share/automake-1.16" } },
       AUTOMAKE_UNINSTALLED: { fallback: { value: "1" } },
+      _lt_pkgdatadir: { fallback: { path: "share/libtool" } },
+
+      // Programs that autotools uses. These default to absolute paths,
+      // setting them to just the name will resolve them using `$PATH` instead
+      M4: { fallback: { value: "m4" } },
+      SED: { fallback: { value: "sed" } },
+      GREP: { fallback: { value: "grep" } },
+      EGREP: { fallback: { value: "grep -E" } },
+      FGREP: { fallback: { value: "grep -F" } },
+      NM: { fallback: { value: "nm -B" } },
+      LD: { fallback: { value: "ld" } },
     });
 
     // Re-pack all dynamic binaries and shared libraries


### PR DESCRIPTION
Closes #51

This PR tweaks `std.toolchain()` to set some more env vars for autotools. This makes it so the `pcre2` and `oniguruma` packages no longer need to manually set some env vars to get autotools builds working (which were the last two holdouts even after the changes from #110)