### PR TITLE
[std] Add more functions for creating runnables

### DIFF
--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -1,4 +1,4 @@
-import { Awaitable, mixin } from "../utils.bri";
+import { Awaitable, mixin, unreachable } from "../utils.bri";
 import * as runtime from "../runtime.bri";
 import type { File } from "./file.bri";
 import { type Directory, directory } from "./directory.bri";
@@ -245,11 +245,25 @@ export function tpl(
 // This is a branded type for one of the symbol type of process template
 // components. Note that we avoid true symbol/branded types so the types can
 // be structurally equivalent across different versions of `std`.
-type ProcessTemplateSymbol<K extends string> = {
-  componentType: K;
+type ProcessTemplateSymbol<
+  K extends ProcessTemplateSymbolKind = ProcessTemplateSymbolKind,
+> = {
+  componentType: "symbol";
+  symbol: K;
 } & {
-  [key in K]: never;
-};
+  [key in K]?: never;
+} & { __processTemplateSymbol: never };
+
+const PROCESS_TEMPLATE_SYMBOL_KINDS = [
+  "outputPath",
+  "resourceDir",
+  "inputResourceDirs",
+  "homeDir",
+  "workDir",
+  "tempDir",
+] as const;
+
+type ProcessTemplateSymbolKind = (typeof PROCESS_TEMPLATE_SYMBOL_KINDS)[number];
 
 /**
  * Expands to the path where the process should write its output. Equivalent
@@ -257,7 +271,8 @@ type ProcessTemplateSymbol<K extends string> = {
  */
 // eslint-disable-next-line
 export const outputPath = {
-  componentType: "outputPath",
+  componentType: "symbol",
+  symbol: "outputPath",
 } as OutputPath;
 type OutputPath = ProcessTemplateSymbol<"outputPath">;
 
@@ -268,7 +283,8 @@ type OutputPath = ProcessTemplateSymbol<"outputPath">;
  */
 // eslint-disable-next-line
 export const resourceDir = {
-  componentType: "resourceDir",
+  componentType: "symbol",
+  symbol: "resourceDir",
 } as ResourceDir;
 type ResourceDir = ProcessTemplateSymbol<"resourceDir">;
 
@@ -279,7 +295,8 @@ type ResourceDir = ProcessTemplateSymbol<"resourceDir">;
  */
 // eslint-disable-next-line
 export const inputResourceDirs = {
-  componentType: "inputResourceDirs",
+  componentType: "symbol",
+  symbol: "inputResourceDirs",
 } as InputResourceDirs;
 type InputResourceDirs = ProcessTemplateSymbol<"inputResourceDirs">;
 
@@ -289,7 +306,8 @@ type InputResourceDirs = ProcessTemplateSymbol<"inputResourceDirs">;
  */
 // eslint-disable-next-line
 export const homeDir = {
-  componentType: "homeDir",
+  componentType: "symbol",
+  symbol: "homeDir",
 } as HomeDir;
 type HomeDir = ProcessTemplateSymbol<"homeDir">;
 
@@ -299,7 +317,8 @@ type HomeDir = ProcessTemplateSymbol<"homeDir">;
  */
 // eslint-disable-next-line
 export const workDir = {
-  componentType: "workDir",
+  componentType: "symbol",
+  symbol: "workDir",
 } as WorkDir;
 type WorkDir = ProcessTemplateSymbol<"workDir">;
 
@@ -309,19 +328,22 @@ type WorkDir = ProcessTemplateSymbol<"workDir">;
  */
 // eslint-disable-next-line
 export const tempDir = {
-  componentType: "tempDir",
+  componentType: "symbol",
+  symbol: "tempDir",
 } as TempDir;
 type TempDir = ProcessTemplateSymbol<"tempDir">;
 
-function isProcessTemplateSymbol<K extends string>(
+function isProcessTemplateSymbol(
   value: unknown,
-  componentType: K,
-): value is ProcessTemplateSymbol<K> {
+): value is ProcessTemplateSymbol {
   return (
     typeof value === "object" &&
     value != null &&
     "componentType" in value &&
-    value["componentType"] === componentType
+    value["componentType"] === "symbol" &&
+    "symbol" in value &&
+    typeof value.symbol === "string" &&
+    (PROCESS_TEMPLATE_SYMBOL_KINDS as readonly string[]).includes(value.symbol)
   );
 }
 
@@ -331,12 +353,7 @@ export type ProcessTemplateComponent =
   | string
   | ProcessTemplate
   | Recipe
-  | typeof outputPath
-  | typeof resourceDir
-  | typeof inputResourceDirs
-  | typeof homeDir
-  | typeof workDir
-  | typeof tempDir
+  | ProcessTemplateSymbol
   | undefined;
 
 export class ProcessTemplate {
@@ -357,18 +374,23 @@ export class ProcessTemplate {
             return [];
           } else if (typeof component === "string") {
             return [{ type: "literal", value: runtime.bstring(component) }];
-          } else if (isProcessTemplateSymbol(component, "outputPath")) {
-            return [{ type: "output_path" }];
-          } else if (isProcessTemplateSymbol(component, "resourceDir")) {
-            return [{ type: "resource_dir" }];
-          } else if (isProcessTemplateSymbol(component, "inputResourceDirs")) {
-            return [{ type: "input_resource_dirs" }];
-          } else if (isProcessTemplateSymbol(component, "homeDir")) {
-            return [{ type: "home_dir" }];
-          } else if (isProcessTemplateSymbol(component, "workDir")) {
-            return [{ type: "work_dir" }];
-          } else if (isProcessTemplateSymbol(component, "tempDir")) {
-            return [{ type: "temp_dir" }];
+          } else if (isProcessTemplateSymbol(component)) {
+            switch (component.symbol) {
+              case "outputPath":
+                return [{ type: "output_path" }];
+              case "resourceDir":
+                return [{ type: "resource_dir" }];
+              case "inputResourceDirs":
+                return [{ type: "input_resource_dirs" }];
+              case "homeDir":
+                return [{ type: "home_dir" }];
+              case "workDir":
+                return [{ type: "work_dir" }];
+              case "tempDir":
+                return [{ type: "temp_dir" }];
+              default:
+                return unreachable(component.symbol);
+            }
           } else if (isProcessTemplateInstance(component)) {
             const serialized = await component.briocheSerialize();
             return serialized.components;

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -1,9 +1,6 @@
 import * as std from "/core";
 import { tools } from "/toolchain";
-import {
-  type RunnableTemplate,
-  makeRunnableExecutable,
-} from "/runnable_tools.bri";
+import { withRunnable, type RunnableTemplateValue } from "./runnable.bri";
 
 export type BashRunnable = std.Recipe<std.Directory> & BashRunnableUtils;
 
@@ -75,60 +72,12 @@ interface BashRunnableOptions {
 }
 
 function makeBashRunnable(options: BashRunnableOptions): BashRunnable {
-  let recipe = options.root;
-  let n = 0;
-  let command: RunnableTemplate = { components: [] };
-  [command, recipe, n] = buildTemplate([tools().get("bin/bash")], recipe, n);
-
-  const argTemplates: RunnableTemplateValue = [
-    "-e",
-    "-u",
-    "-o",
-    "pipefail",
-    "-c",
-    options.script,
-    "--",
-  ];
-  const args: RunnableTemplate[] = [];
-  for (const arg of argTemplates) {
-    let argTemplate: RunnableTemplate;
-    [argTemplate, recipe, n] = buildTemplate(arg, recipe, n);
-    args.push(argTemplate);
-  }
-
-  const env: Record<string, RunnableTemplate> = {};
-  for (const [key, value] of Object.entries(options.env)) {
-    let valueTemplate: RunnableTemplate;
-    [valueTemplate, recipe, n] = buildTemplate(value, recipe, n);
-    env[key] = valueTemplate;
-  }
-
-  const path = env["PATH"] ?? { components: [] };
-  for (const dep of options.dependencies) {
-    let depTemplate: RunnableTemplate;
-    [depTemplate, recipe, n] = buildTemplate([dep, "/bin"], recipe, n);
-
-    if (path.components.length > 0) {
-      path.components.push(
-        { type: "literal", value: std.bstring(":") },
-        ...depTemplate.components,
-      );
-    } else {
-      path.components.push(...depTemplate.components);
-    }
-  }
-
-  if (path.components.length > 0) {
-    env["PATH"] = path;
-  }
-
-  const runnable = makeRunnableExecutable({
-    command,
-    args,
-    env,
+  const recipe = withRunnable(options.root, {
+    command: tools().get("bin/bash"),
+    args: ["-e", "-u", "-o", "pipefail", "-c", options.script, "--"],
+    env: options.env,
+    dependencies: options.dependencies,
   });
-
-  recipe = recipe.insert("brioche-run", runnable);
 
   return std.mixin(recipe, {
     env(values: Record<string, RunnableTemplateValue>): BashRunnable {
@@ -154,63 +103,4 @@ function makeBashRunnable(options: BashRunnableOptions): BashRunnable {
       });
     },
   });
-}
-
-type RunnableTemplateValue =
-  | string
-  | undefined
-  | { relativePath: string }
-  | std.AsyncRecipe
-  | RunnableTemplateValue[];
-
-function buildTemplate(
-  template: RunnableTemplateValue,
-  recipe: std.AsyncRecipe<std.Directory>,
-  n: number,
-): [RunnableTemplate, std.Recipe<std.Directory>, number] {
-  let recipeValue = std.recipe(recipe);
-
-  if (template == null || template === "") {
-    return [{ components: [] }, recipeValue, n];
-  } else if (typeof template === "string") {
-    return [
-      { components: [{ type: "literal", value: std.bstring(template) }] },
-      recipeValue,
-      n,
-    ];
-  } else if (Array.isArray(template)) {
-    const resultComponents = [];
-    for (const component of template) {
-      let result: RunnableTemplate;
-      [result, recipeValue, n] = buildTemplate(component, recipeValue, n);
-
-      resultComponents.push(...result.components);
-    }
-
-    return [{ components: resultComponents }, recipeValue, n];
-  } else if ("relativePath" in template) {
-    return [
-      {
-        components: [
-          { type: "relative_path", path: std.bstring(template.relativePath) },
-        ],
-      },
-      recipeValue,
-      n,
-    ];
-  } else {
-    recipeValue = recipeValue.insert(`brioche-run.d/recipe-${n}`, template);
-    return [
-      {
-        components: [
-          {
-            type: "relative_path",
-            path: std.bstring(`brioche-run.d/recipe-${n}`),
-          },
-        ],
-      },
-      recipeValue,
-      n + 1,
-    ];
-  }
 }

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -1,6 +1,7 @@
 export { autopack, type AutopackOptions } from "./autopack.bri";
 export * from "./oci_container_image.bri";
 export * from "./run_bash.bri";
+export * from "./runnable.bri";
 export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -221,10 +221,14 @@ function buildTemplate(
 
     return [{ components: resultComponents }, recipeValue, n];
   } else if ("relativePath" in template) {
+    const relativePath = [pathToRecipeRoot, template.relativePath]
+      .filter((path) => path != null && path !== "")
+      .join("/");
+
     return [
       {
         components: [
-          { type: "relative_path", path: std.bstring(template.relativePath) },
+          { type: "relative_path", path: std.bstring(relativePath) },
         ],
       },
       recipeValue,

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -19,7 +19,7 @@ export interface WithRunnableUtils {
   dependencies(...dependencies: std.AsyncRecipe<std.Directory>[]): WithRunnable;
 }
 
-export interface WithRunnableOptions {
+export interface RunnableOptions {
   command: RunnableTemplateValue;
   args?: RunnableTemplateValue[];
   env?: Record<string, RunnableTemplateValue>;
@@ -52,52 +52,9 @@ export interface WithRunnableOptions {
  */
 export function withRunnable(
   recipe: std.AsyncRecipe<std.Directory>,
-  options: WithRunnableOptions,
+  options: RunnableOptions,
 ): WithRunnable {
-  let n = 0;
-  let command: RunnableTemplate;
-  [command, recipe, n] = buildTemplate(options.command, recipe, n);
-
-  const args: RunnableTemplate[] = [];
-  for (const arg of options.args ?? []) {
-    let argTemplate: RunnableTemplate;
-    [argTemplate, recipe, n] = buildTemplate(arg, recipe, n);
-    args.push(argTemplate);
-  }
-
-  const env: Record<string, RunnableTemplate> = {};
-  for (const [key, value] of Object.entries(options.env ?? {})) {
-    let valueTemplate: RunnableTemplate;
-    [valueTemplate, recipe, n] = buildTemplate(value, recipe, n);
-    env[key] = valueTemplate;
-  }
-
-  const path = env["PATH"] ?? { components: [] };
-  for (const dep of options.dependencies ?? []) {
-    let depTemplate: RunnableTemplate;
-    [depTemplate, recipe, n] = buildTemplate([dep, "/bin"], recipe, n);
-
-    if (path.components.length > 0) {
-      path.components.push(
-        { type: "literal", value: std.bstring(":") },
-        ...depTemplate.components,
-      );
-    } else {
-      path.components.push(...depTemplate.components);
-    }
-  }
-
-  if (path.components.length > 0) {
-    env["PATH"] = path;
-  }
-
-  const runnable = makeRunnableExecutable({
-    command,
-    args,
-    env,
-  });
-
-  recipe = recipe.insert("brioche-run", runnable);
+  recipe = addRunnable(recipe, "brioche-run", options);
 
   return std.mixin(recipe, {
     env(values: Record<string, RunnableTemplateValue>): WithRunnable {
@@ -118,6 +75,113 @@ export function withRunnable(
   });
 }
 
+/**
+ * Return a new recipe with an executable at `path` that runs the specified
+ * command. This wraps the command so it can be run outside Brioche.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ *
+ * // Running `brioche run -c bin/hello` will print "Hello, world!"
+ * export default function () {
+ *   return std.addRunnable(std.directory(), "bin/hello", {
+ *     command: "echo",
+ *     args: ["Hello, world!"],
+ *     dependencies: [std.tools()],
+ *   });
+ * }
+ * ```
+ */
+export function addRunnable(
+  recipe: std.AsyncRecipe<std.Directory>,
+  path: string,
+  options: RunnableOptions,
+): std.Recipe<std.Directory> {
+  // Compute the path to get from the runnable path (`path`) to the
+  // recipe root
+  const pathComponentsToRecipeRoot = [];
+  const dirComponents = path.split("/").slice(0, -1);
+  for (const component of dirComponents) {
+    if (component === "..") {
+      if (pathComponentsToRecipeRoot.length === 0) {
+        throw new Error(`path escapes recipe root: ${path}`);
+      }
+
+      // Remove one traversal when going up a directory
+      pathComponentsToRecipeRoot.pop();
+    } else if (component === "." || component === "") {
+      // Skip current dir and empty components
+    } else {
+      // For a normal path, we need to go up one more directory to get back
+      // to the root
+      pathComponentsToRecipeRoot.push("..");
+    }
+  }
+  const pathToRecipeRoot = pathComponentsToRecipeRoot.join("/");
+
+  let n = 0;
+  let command: RunnableTemplate;
+  [command, recipe, n] = buildTemplate(
+    options.command,
+    recipe,
+    pathToRecipeRoot,
+    n,
+  );
+
+  const args: RunnableTemplate[] = [];
+  for (const arg of options.args ?? []) {
+    let argTemplate: RunnableTemplate;
+    [argTemplate, recipe, n] = buildTemplate(arg, recipe, pathToRecipeRoot, n);
+    args.push(argTemplate);
+  }
+
+  const env: Record<string, RunnableTemplate> = {};
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    let valueTemplate: RunnableTemplate;
+    [valueTemplate, recipe, n] = buildTemplate(
+      value,
+      recipe,
+      pathToRecipeRoot,
+      n,
+    );
+    env[key] = valueTemplate;
+  }
+
+  const pathEnv = env["PATH"] ?? { components: [] };
+  for (const dep of options.dependencies ?? []) {
+    let depTemplate: RunnableTemplate;
+    [depTemplate, recipe, n] = buildTemplate(
+      [dep, "/bin"],
+      recipe,
+      pathToRecipeRoot,
+      n,
+    );
+
+    if (pathEnv.components.length > 0) {
+      pathEnv.components.push(
+        { type: "literal", value: std.bstring(":") },
+        ...depTemplate.components,
+      );
+    } else {
+      pathEnv.components.push(...depTemplate.components);
+    }
+  }
+
+  if (pathEnv.components.length > 0) {
+    env["PATH"] = pathEnv;
+  }
+
+  const runnable = makeRunnableExecutable({
+    command,
+    args,
+    env,
+  });
+
+  return recipe.insert(path, runnable);
+}
+
 export type RunnableTemplateValue =
   | string
   | undefined
@@ -128,6 +192,7 @@ export type RunnableTemplateValue =
 function buildTemplate(
   template: RunnableTemplateValue,
   recipe: std.AsyncRecipe<std.Directory>,
+  pathToRecipeRoot: string | undefined,
   n: number,
 ): [RunnableTemplate, std.Recipe<std.Directory>, number] {
   let recipeValue = std.recipe(recipe);
@@ -144,7 +209,12 @@ function buildTemplate(
     const resultComponents = [];
     for (const component of template) {
       let result: RunnableTemplate;
-      [result, recipeValue, n] = buildTemplate(component, recipeValue, n);
+      [result, recipeValue, n] = buildTemplate(
+        component,
+        recipeValue,
+        pathToRecipeRoot,
+        n,
+      );
 
       resultComponents.push(...result.components);
     }
@@ -161,13 +231,17 @@ function buildTemplate(
       n,
     ];
   } else {
+    const pathToBriocheRunDir = [pathToRecipeRoot, "brioche-run.d"]
+      .filter((path) => path != null && path !== "")
+      .join("/");
+
     recipeValue = recipeValue.insert(`brioche-run.d/recipe-${n}`, template);
     return [
       {
         components: [
           {
             type: "relative_path",
-            path: std.bstring(`brioche-run.d/recipe-${n}`),
+            path: std.bstring(`${pathToBriocheRunDir}/recipe-${n}`),
           },
         ],
       },

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -1,0 +1,178 @@
+import * as std from "/core";
+import {
+  type RunnableTemplate,
+  makeRunnableExecutable,
+} from "/runnable_tools.bri";
+
+export type WithRunnable = std.Recipe<std.Directory> & WithRunnableUtils;
+
+export interface WithRunnableUtils {
+  /**
+   * Set environment variables when the command is run.
+   */
+  env(values: Record<string, RunnableTemplateValue>): WithRunnable;
+
+  /**
+   * Include additonal dependencies when the command is run. This
+   * will set the `$PATH` environment variable.
+   */
+  dependencies(...dependencies: std.AsyncRecipe<std.Directory>[]): WithRunnable;
+}
+
+export interface WithRunnableOptions {
+  command: RunnableTemplateValue;
+  args?: RunnableTemplateValue[];
+  env?: Record<string, RunnableTemplateValue>;
+  dependencies?: std.AsyncRecipe<std.Directory>[];
+}
+
+/**
+ * Return a runnable recipe, where `brioche-run` is an executable that
+ * runs the specified command. This wraps the command so it can be run outside
+ * Brioche, such as by calling `brioche run` or by putting it into an OCI
+ * container image.
+ *
+ * See also `std.bashRunnable`, which allows running a full Bash script instead
+ * of a single command.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * import * as std from "std";
+ *
+ * // Running `brioche run` will print "Hello, world!"
+ * export default function () {
+ *   return std.withRunnable(std.directory(), {
+ *     command: "echo",
+ *     args: ["Hello, world!"],
+ *     dependencies: [std.tools()],
+ *   });
+ * }
+ * ```
+ */
+export function withRunnable(
+  recipe: std.AsyncRecipe<std.Directory>,
+  options: WithRunnableOptions,
+): WithRunnable {
+  let n = 0;
+  let command: RunnableTemplate;
+  [command, recipe, n] = buildTemplate(options.command, recipe, n);
+
+  const args: RunnableTemplate[] = [];
+  for (const arg of options.args ?? []) {
+    let argTemplate: RunnableTemplate;
+    [argTemplate, recipe, n] = buildTemplate(arg, recipe, n);
+    args.push(argTemplate);
+  }
+
+  const env: Record<string, RunnableTemplate> = {};
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    let valueTemplate: RunnableTemplate;
+    [valueTemplate, recipe, n] = buildTemplate(value, recipe, n);
+    env[key] = valueTemplate;
+  }
+
+  const path = env["PATH"] ?? { components: [] };
+  for (const dep of options.dependencies ?? []) {
+    let depTemplate: RunnableTemplate;
+    [depTemplate, recipe, n] = buildTemplate([dep, "/bin"], recipe, n);
+
+    if (path.components.length > 0) {
+      path.components.push(
+        { type: "literal", value: std.bstring(":") },
+        ...depTemplate.components,
+      );
+    } else {
+      path.components.push(...depTemplate.components);
+    }
+  }
+
+  if (path.components.length > 0) {
+    env["PATH"] = path;
+  }
+
+  const runnable = makeRunnableExecutable({
+    command,
+    args,
+    env,
+  });
+
+  recipe = recipe.insert("brioche-run", runnable);
+
+  return std.mixin(recipe, {
+    env(values: Record<string, RunnableTemplateValue>): WithRunnable {
+      return withRunnable(recipe, {
+        ...options,
+        env: { ...options.env, ...values },
+      });
+    },
+
+    dependencies(
+      ...dependencies: std.AsyncRecipe<std.Directory>[]
+    ): WithRunnable {
+      return withRunnable(recipe, {
+        ...options,
+        dependencies: [...(options.dependencies ?? []), ...dependencies],
+      });
+    },
+  });
+}
+
+export type RunnableTemplateValue =
+  | string
+  | undefined
+  | { relativePath: string }
+  | std.AsyncRecipe
+  | RunnableTemplateValue[];
+
+function buildTemplate(
+  template: RunnableTemplateValue,
+  recipe: std.AsyncRecipe<std.Directory>,
+  n: number,
+): [RunnableTemplate, std.Recipe<std.Directory>, number] {
+  let recipeValue = std.recipe(recipe);
+
+  if (template == null || template === "") {
+    return [{ components: [] }, recipeValue, n];
+  } else if (typeof template === "string") {
+    return [
+      { components: [{ type: "literal", value: std.bstring(template) }] },
+      recipeValue,
+      n,
+    ];
+  } else if (Array.isArray(template)) {
+    const resultComponents = [];
+    for (const component of template) {
+      let result: RunnableTemplate;
+      [result, recipeValue, n] = buildTemplate(component, recipeValue, n);
+
+      resultComponents.push(...result.components);
+    }
+
+    return [{ components: resultComponents }, recipeValue, n];
+  } else if ("relativePath" in template) {
+    return [
+      {
+        components: [
+          { type: "relative_path", path: std.bstring(template.relativePath) },
+        ],
+      },
+      recipeValue,
+      n,
+    ];
+  } else {
+    recipeValue = recipeValue.insert(`brioche-run.d/recipe-${n}`, template);
+    return [
+      {
+        components: [
+          {
+            type: "relative_path",
+            path: std.bstring(`brioche-run.d/recipe-${n}`),
+          },
+        ],
+      },
+      recipeValue,
+      n + 1,
+    ];
+  }
+}


### PR DESCRIPTION
This PR adds a few new functions to `std` used for creating [runnables](https://brioche.dev/docs/core-concepts/runnables/):

- `std.withRunnable(recipe, options)`: Add a new binary in the recipe at the path `brioche-run`. The options include the command, args, and envs to run.
- `std.addRunnable(recipe, path, options)`: Add a new binary in the recipe at the path specified by `path`. Same options as `std.withRunnable`, just with a custom path instead of always using `brioche-run`.

These new functions are meant to be a middle-ground between `std.withRunnableLink()` (where you can only directly run another executable) and `std.bashRunnable` (where you get a lot more flexibility, but need to include Bash as a dependency). By comparison, the new functions allows minimal templating for the command, args, and envs, but not the full capabilities of a whole shell.

Internally, `std.bashRunnable` now uses `std.withRunnable()` to actually build the runnable, which in turn uses `std.addRunnable()`.