### PR TITLE
[std] Update `std.toolchain()` to set env var to fix Bison

### DIFF
--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -210,6 +210,9 @@ export const toolchain = std.memo(
       // pkg-config search paths
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
 
+      // Bison data dir
+      BISON_PKGDATADIR: { fallback: { path: "share/bison" } },
+
       // Magic patterns used by `file`
       MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
 


### PR DESCRIPTION
Closes #79 

This PR updates `std.toolchain()` to set `$BISON_PKGDATADIR`, which fixes issues where Bison couldn't find some files (like `share/bison/m4sugar/m4sugar.m4`)