### PR TITLE
Add `tcpdump` and `libpcap` packages

### DIFF
--- a/packages/libpcap/brioche.lock
+++ b/packages/libpcap/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.tcpdump.org/release/libpcap-1.10.5.tar.xz": {
+      "type": "sha256",
+      "value": "84fa89ac6d303028c1c5b754abff77224f45eca0a94eb1a34ff0aa9ceece3925"
+    }
+  }
+}

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -1,0 +1,28 @@
+import * as std from "std";
+
+export const project = {
+  name: "libpcap",
+  version: "1.10.5",
+};
+
+const source = Brioche.download(
+  `https://www.tcpdump.org/release/libpcap-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  const libpcap = std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  return std.setEnv(libpcap, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+}

--- a/packages/tcpdump/brioche.lock
+++ b/packages/tcpdump/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.tcpdump.org/release/tcpdump-4.99.5.tar.xz": {
+      "type": "sha256",
+      "value": "d76395ab82d659d526291b013eee200201380930793531515abfc6e77b4f2ee5"
+    }
+  }
+}

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -1,0 +1,25 @@
+import * as std from "std";
+import libpcap from "libpcap";
+
+export const project = {
+  name: "tcpdump",
+  version: "4.99.5",
+};
+
+const source = Brioche.download(
+  `https://www.tcpdump.org/release/tcpdump-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  const tcpdump = std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain(), libpcap())
+    .toDirectory();
+
+  return std.withRunnableLink(tcpdump, "bin/tcpdump");
+}


### PR DESCRIPTION
This PR adds the new `tcpdump` package, as well as `libpcap` which is a dependency of `tcpdump`. The `libpcap` package is based on the snippet from #79