### PR TITLE
[std] Fix some issues with libraries in `std.toolchain()`

### DIFF
--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -204,7 +204,7 @@ export const toolchain = std.memo(
 
       // Perl library paths
       PERL5LIB: {
-        append: [{ path: "share/autconf" }, { path: "share/automake-1.16" }],
+        append: [{ path: "share/autoconf" }, { path: "share/automake-1.16" }],
       },
 
       // pkg-config search paths

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -181,6 +181,28 @@ export const toolchain = std.memo(
     // Add a symlink for the C compiler
     toolchain = toolchain.insert("bin/cc", std.symlink({ target: "gcc" }));
 
+    // Fix broken library symlinks
+    toolchain = toolchain.insert(
+      "lib/libuuid.so",
+      std.symlink({ target: "libuuid.so.1" }),
+    );
+    toolchain = toolchain.insert(
+      "lib/libblkid.so",
+      std.symlink({ target: "libblk.id.so.1" }),
+    );
+    toolchain = toolchain.insert(
+      "lib/libsmartcols.so",
+      std.symlink({ target: "libsmartcols.so.1" }),
+    );
+    toolchain = toolchain.insert(
+      "lib/libfdisk.so",
+      std.symlink({ target: "libfdisk.so.1" }),
+    );
+    toolchain = toolchain.insert(
+      "lib/libmount.so",
+      std.symlink({ target: "libmount.so.1" }),
+    );
+
     // Add a symlink that libtool needs
     toolchain = toolchain.insert(
       "share/libtool/m4",

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -283,6 +283,8 @@ export const toolchain = std.memo(
 
     toolchain = fixShebangs(toolchain);
 
+    toolchain = makePkgConfigPathsRelative(toolchain);
+
     toolchain = std.sync(toolchain);
 
     return toolchain;
@@ -362,6 +364,33 @@ function fixShebangs(
                 chmod +x temp
                 mv temp "$file"
               fi
+            done
+        `,
+      ],
+      env: {
+        PATH: std.tpl`${stage2()}/bin`,
+      },
+      outputScaffold: recipe,
+    })
+    .toDirectory();
+}
+
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std
+    .process({
+      command: std.tpl`${stage2()}/bin/bash`,
+      args: [
+        "-c",
+        std.indoc`
+          set -euo pipefail
+
+          find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+            | while IFS= read -r -d $'\\0' file; do
+              sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
             done
         `,
       ],


### PR DESCRIPTION
- Fix typo in `$PERL5LIB` in `std.toolchain()`
- Fix broken library symlinks in `std.toolchain()`
- Patch pkg-config files in `std.toolchain()` to use relative paths. This is kind of a hacky process for now (it just looks for the string `=/`, meant to find variables set with an absolute path). This will probably need to be refined in the future, and we'll probably want a utility function that can be applied to other packages too