### PR TITLE
Add `python` pacakge

### DIFF
--- a/packages/python/brioche.lock
+++ b/packages/python/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.python.org/ftp/python/3.12.7/Python-3.12.7.tar.xz": {
+      "type": "sha256",
+      "value": "24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550"
+    }
+  }
+}

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -68,6 +68,10 @@ export default async function python() {
     },
   });
 
+  // Some binaries under `/bin` are shebang scripts. These need to be wrapped
+  // to avoid issues with absolute paths
+  python = std.recipe(wrapShebangs(python));
+
   python = python.insert("bin/python", std.symlink({ target: "python3" }));
   python = python.insert(
     "bin/python-config",
@@ -83,4 +87,35 @@ export function test() {
     python --version | tee -a "$BRIOCHE_OUTPUT"
     pip --version | tee -a "$BRIOCHE_OUTPUT"
   `.dependencies(python());
+}
+
+async function wrapShebangs(
+  recipe: std.Recipe<std.Directory>,
+): Promise<std.Recipe<std.Directory>> {
+  // Get all the files under `/bin` that are shebang scripts
+  const shebangPathList = await std.runBash`
+    cd "$recipe"
+    find bin -type f -executable \\
+    | while read file; do
+      if [[ "$(head -c 2 "$file")" == '#!' ]]; then
+        echo "$file" >> "$BRIOCHE_OUTPUT"
+      fi
+    done
+  `
+    .env({ recipe })
+    .toFile()
+    .read();
+  const shebangPaths = shebangPathList
+    .split("\n")
+    .filter((line) => line !== "");
+
+  // Wrap each script using `std.addRunnable()`
+  const wrappedShebangs = shebangPaths.map((path) => {
+    return std.addRunnable(std.directory(), path, {
+      command: { relativePath: "bin/python" },
+      args: [[std.glob(recipe, [path]), `/${path}`]],
+    });
+  });
+
+  return std.merge(recipe, ...wrappedShebangs);
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -1,0 +1,86 @@
+import * as std from "std";
+import openssl from "openssl";
+
+export const project = {
+  name: "python",
+  version: "3.12.7",
+};
+
+const source = Brioche.download(
+  `https://www.python.org/ftp/python/${project.version}/Python-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default async function python() {
+  let python = std.runBash`
+    export LD_LIBRARY_PATH="$LIBRARY_PATH"
+    export PATH="$BRIOCHE_OUTPUT/bin\${PATH:+:$PATH}"
+
+    ./configure \\
+      --prefix=/ \\
+      --without-ensurepip
+    make -j8
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+
+    python3 -m ensurepip --default-pip
+  `
+    .workDir(source)
+    .dependencies(std.toolchain(), openssl())
+    .toDirectory();
+
+  // Get all the native Python modules
+  const nativeModuleList = await std.runBash`
+    find "$python"/lib/python*/lib-dynload \\
+       -name "*.so" \\
+       -exec basename {} \\; \\
+       > "$BRIOCHE_OUTPUT"
+  `
+    .env({ python })
+    .toFile()
+    .read();
+  const nativeModules = nativeModuleList
+    .split("\n")
+    .filter((mod) => mod !== "");
+
+  // Repack Python with all the dynamic libraries needed for all the native
+  // modules. It isn't linked against the native modules directly, just their
+  // transitive dependencies
+  python = std.autopack(python, {
+    globs: ["bin/python*"],
+    excludeGlobs: ["bin/python*-config"],
+    linkDependencies: [std.toolchain()],
+    dynamicBinaryConfig: {
+      // Listing the modules both under `extraLibraries` and `skipLibraries`
+      // forces Python to be linked with the modules' transitive dependencies
+      extraLibraries: nativeModules,
+      skipLibraries: nativeModules,
+      libraryPaths: [std.glob(python, ["lib/python*/lib-dynload"]).peel(3)],
+    },
+    sharedLibraryConfig: {
+      enabled: false,
+    },
+    scriptConfig: {
+      enabled: false,
+    },
+    repackConfig: {
+      enabled: true,
+    },
+  });
+
+  python = python.insert("bin/python", std.symlink({ target: "python3" }));
+  python = python.insert(
+    "bin/python-config",
+    std.symlink({ target: "python3-config" }),
+  );
+  python = python.insert("bin/pydoc", std.symlink({ target: "pydoc3" }));
+
+  return python;
+}
+
+export function test() {
+  return std.runBash`
+    python --version | tee -a "$BRIOCHE_OUTPUT"
+    pip --version | tee -a "$BRIOCHE_OUTPUT"
+  `.dependencies(python());
+}


### PR DESCRIPTION
This PR adds a new package for Python, which includes both CPython and the bundled version of pip.

Packaging Python definitely posed some unique challenges:

- Compiling Python compiles several native `.so` modules that link against other native libraries, like zlib for example. When this happens, the `.so` module references zlib during the build, but the Python interpreter itself doesn't, which means Python itself couldn't load zlib (which means Python wouldn't be able to load the module at all). So, we have a step in the build to rewrap the Python interpreter to make sure it references the native libraries used by all native modules (with a... kinda weird use of `std.autopack()`)
- We use `--without-ensurepip`, then manually run `ensurepip` at the end. This is because `ensurepip` during the build ends up at a weird path, probably because we use `DESTDIR` when running `make install`. Running `ensurepip` _after_ installation puts everything in the right place
- Python writes several shebang scripts under `bin/`, but does so with [a unique structure](https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_vendor/distlib/scripts.py#L154) to account for very long paths (like those seen in the Brioche sandbox). So, we wrap scripts in a custom way just for the Python shebangs by using `std.addRunnable()`

There's definitely more work for better Python support, such as handling venvs, supporting some of the modern Python package managers, and figuring out how to properly support wheels.

Also, this Python build doesn't currently include sqlite support, so that would be a nice add-on once sqlite is packaged in Brioche.