### PR TITLE
Update python to 3.13

### DIFF
--- a/packages/python/brioche.lock
+++ b/packages/python/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://www.python.org/ftp/python/3.12.7/Python-3.12.7.tar.xz": {
+    "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz": {
       "type": "sha256",
-      "value": "24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550"
+      "value": "086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d"
     }
   }
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -3,7 +3,7 @@ import openssl from "openssl";
 
 export const project = {
   name: "python",
-  version: "3.12.7",
+  version: "3.13.0",
 };
 
 const source = Brioche.download(
@@ -79,7 +79,7 @@ export default async function python() {
   );
   python = python.insert("bin/pydoc", std.symlink({ target: "pydoc3" }));
 
-  return python;
+  return std.withRunnableLink(python, "bin/python");
 }
 
 export function test() {


### PR DESCRIPTION
Also updated the existing python `project.bri` file to default the runnable link for `bin/python` to support the `brioche run` default