### PR TITLE
Add `sqlite` package

### DIFF
--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -1,5 +1,6 @@
 import * as std from "std";
 import openssl from "openssl";
+import sqlite from "sqlite";
 
 export const project = {
   name: "python",
@@ -26,7 +27,7 @@ export default async function python() {
     python3 -m ensurepip --default-pip
   `
     .workDir(source)
-    .dependencies(std.toolchain(), openssl())
+    .dependencies(std.toolchain(), openssl(), sqlite())
     .toDirectory();
 
   // Get all the native Python modules

--- a/packages/sqlite/brioche.lock
+++ b/packages/sqlite/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.sqlite.org/2024/sqlite-autoconf-3460100.tar.gz": {
+      "type": "sha256",
+      "value": "67d3fe6d268e6eaddcae3727fce58fcc8e9c53869bdd07a0c61e38ddf2965071"
+    }
+  }
+}

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -26,7 +26,7 @@ const source = Brioche.download(
   .peel();
 
 export default function (): std.Recipe<std.Directory> {
-  return std.runBash`
+  let sqlite = std.runBash`
     ./configure \\
       --prefix=/ \\
       --enable-readline
@@ -36,6 +36,10 @@ export default function (): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain())
     .toDirectory();
+
+  sqlite = makePkgConfigPathsRelative(sqlite);
+
+  return sqlite;
 }
 
 /**
@@ -71,4 +75,21 @@ function encodeVersionNumber(version: string): string {
   );
 
   return `${major}${xx}${yy}${zz}`;
+}
+
+// TODO: This is duplicated from the `std.toolchain()` build, we should
+// figure out how to generalize this
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std.runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
 }

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -29,7 +29,9 @@ export default function (): std.Recipe<std.Directory> {
   let sqlite = std.runBash`
     ./configure \\
       --prefix=/ \\
-      --enable-readline
+      --enable-readline \\
+      --enable-fts3 \\
+      --enable-session
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+
+export const project = {
+  name: "sqlite",
+  version: "3.46.1",
+  extra: {
+    // The version number as encoded in SQLite build product names
+    filenameEncodedVersion: "3460100",
+  },
+};
+
+// Ensure the version number matches the encoded version used for the download
+std.assert(
+  encodeVersionNumber(project.version) === project.extra.filenameEncodedVersion,
+  `sqlite version number ${encodeVersionNumber(
+    project.version,
+  )} does not match encoded version number ${
+    project.extra.filenameEncodedVersion
+  }`,
+);
+
+const source = Brioche.download(
+  `https://www.sqlite.org/2024/sqlite-autoconf-${project.extra.filenameEncodedVersion}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-readline
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+}
+
+/**
+ * Encode a sqlite version number used in filenames and URLs. See this page
+ * for more details:
+ *
+ * https://www.sqlite.org/download.html
+ */
+function encodeVersionNumber(version: string): string {
+  const [major, x, y, z, ...rest] = version.split(".");
+
+  std.assert(
+    major === "3",
+    `expected sqlite major version to be 3 in ${version}`,
+  );
+  std.assert(
+    x != null && x !== "",
+    `sqlite version string ${version} is missing minor version`,
+  );
+  std.assert(
+    y != null && y !== "",
+    `sqlite version string ${version} is missing patch version`,
+  );
+  std.assert(rest.length === 0, `invalid sqlite version ${version}`);
+
+  const xx = x.padStart(2, "0");
+  const yy = y.padStart(2, "0");
+  const zz = (z ?? "").padStart(2, "0");
+
+  std.assert(
+    xx.length === 2 && yy.length === 2 && zz.length === 2,
+    `unable to parse sqlite version ${version}`,
+  );
+
+  return `${major}${xx}${yy}${zz}`;
+}

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -38,6 +38,12 @@ export default function (): std.Recipe<std.Directory> {
     .toDirectory();
 
   sqlite = makePkgConfigPathsRelative(sqlite);
+  sqlite = std.setEnv(sqlite, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+  sqlite = std.withRunnableLink(sqlite, "bin/sqlite3");
 
   return sqlite;
 }


### PR DESCRIPTION
This PR adds the new `sqlite` package, which includes the `sqlite3` CLI tool and `libsqlite3.so`

I also updated Python to include sqlite as a dependency, which made it so the configure script picked up sqlite and compiled the native `sqlite3` module.

I copied the function introduced in #118 that patches pkg-config files to use portable paths. This is probably a sign that we should add a general utility for this.