### PR TITLE
[rust] Add `unsafe` option for `rust.cargoBuild()`

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -117,6 +117,7 @@ export interface CargoBuildOptions {
   runnable?: string;
   dependencies?: std.AsyncRecipe<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
+  unsafe?: std.ProcessUnsafeOptions;
   buildParams?: CargoBuildParameters;
 }
 
@@ -133,6 +134,10 @@ export interface CargoBuildOptions {
  *   by default (e.g. `bin/foo`).
  * - `dependencies`: Optionally add additional dependencies to the build.
  * - `env`: Optionally set environment variables for the build.
+ * - `unsafe`: Optional unsafe options to enable when building. For example,
+ *   passing `{ networking: true }` will allow a `build.rs` script to
+ *   download files during the build. You must take extra care to ensure
+ *   the build is hermetic when setting these options!
  * - `buildParams`: Optional build parameters:
  *   - `features`: An array of features to enable.
  *
@@ -214,6 +219,7 @@ export function cargoBuild(options: CargoBuildOptions) {
       ...options.env,
     })
     .workDir(crate)
+    .unsafe(options.unsafe)
     .toDirectory();
 
   // Add a runnable link if set in the options


### PR DESCRIPTION
This PR updates the `rust.cargoBuild()` function to take a new `unsafe` option as input. This forwards the unsafe settings to the `std.process()` that does the actual build, which is useful for e.g. Rust projects that use `build.rs` for fetching remote dependencies (of course, we can't guarantee that builds are hermetic in those cases, so the burden is on the package author when enabling this setting).

This builds on the work from #122