### PR TITLE
Add `libxml2` package

### DIFF
--- a/packages/libxml2/brioche.lock
+++ b/packages/libxml2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.9.tar.xz": {
+      "type": "sha256",
+      "value": "58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5"
+    }
+  }
+}

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -1,0 +1,23 @@
+import * as std from "std";
+
+export const project = {
+  name: "libxml2",
+  version: "2.9.9",
+};
+
+export const source = Brioche.download(
+  `https://download.gnome.org/sources/libxml2/2.9/libxml2-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+}


### PR DESCRIPTION
This PR adds a new package for `libxml2`, including both libraries and binaries. This was motivated by moretools, which uses `xmllint` provided by `libxml2` at build time