### PR TITLE
Update `libxml2`

### DIFF
--- a/packages/libxml2/brioche.lock
+++ b/packages/libxml2/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.9.tar.xz": {
+    "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.tar.xz": {
       "type": "sha256",
-      "value": "58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5"
+      "value": "65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650"
     }
   }
 }

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -13,12 +13,38 @@ export const source = Brioche.download(
   .peel();
 
 export default function (): std.Recipe<std.Directory> {
-  return std.runBash`
+  let libxml2 = std.runBash`
     ./configure --prefix=/
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
     .dependencies(std.toolchain(), python())
+    .toDirectory();
+
+  libxml2 = makePkgConfigPathsRelative(libxml2);
+
+  libxml2 = std.setEnv(libxml2, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+
+  return libxml2;
+}
+
+// TODO: Figure out where to move this, this is copied from `std`
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std.runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
     .toDirectory();
 }

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -1,12 +1,13 @@
 import * as std from "std";
+import python from "python";
 
 export const project = {
   name: "libxml2",
-  version: "2.9.9",
+  version: "2.13.4",
 };
 
 export const source = Brioche.download(
-  `https://download.gnome.org/sources/libxml2/2.9/libxml2-${project.version}.tar.xz`,
+  `https://download.gnome.org/sources/libxml2/2.13/libxml2-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -18,6 +19,6 @@ export default function (): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain(), python())
     .toDirectory();
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -73,12 +73,21 @@ export default async function python() {
   // to avoid issues with absolute paths
   python = std.recipe(wrapShebangs(python));
 
+  // Fix absolute paths in pkg-config files
+  python = makePkgConfigPathsRelative(python);
+
   python = python.insert("bin/python", std.symlink({ target: "python3" }));
   python = python.insert(
     "bin/python-config",
     std.symlink({ target: "python3-config" }),
   );
   python = python.insert("bin/pydoc", std.symlink({ target: "pydoc3" }));
+
+  python = std.setEnv(python, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
 
   return std.withRunnableLink(python, "bin/python");
 }
@@ -122,4 +131,20 @@ async function wrapShebangs(
   });
 
   return std.merge(recipe, ...wrappedShebangs);
+}
+
+// TODO: Figure out where to move this, this is copied from `std`
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std.runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
 }


### PR DESCRIPTION
This PR updates libxml2 from 2.9.9 to 2.13.4 (this was already released when libxml2 was first added, but I missed it because I was looking at a download list that was lexicographically sorted...)

This PR also patches the `pkg-config` files, effectively copying what we did in #118