### PR TITLE
Use quieter output for GH Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,18 @@ jobs:
         run: |
           for project in packages/*; do
             echo "::group::$project"
-            brioche build -p "$project" --check --sync --locked
+            brioche build -p "$project" --check --sync --locked --display plain-reduced
             echo "::endgroup::"
           done
         env:
           BRIOCHE_REGISTRY_PASSWORD: ${{ secrets.BRIOCHE_REGISTRY_PASSWORD }}
+      - name: Save failed processes
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: process-events
+          path: ~/.local/share/brioche/process-temp/*/events.bin.zst
+          compression-level: 0
 
   publish:
     name: Publish packages


### PR DESCRIPTION
This PR uses the new `--display plain-reduced` output format for Brioche introduced in brioche-dev/brioche#141. During the build, process outputs aren't written. Instead, on failure, all process outputs (that weren't deleted) are uploaded as artifacts in the Brioche "process events" format.

Seeing the output in GitHub Actions was nice, but generally a large build had so much output that it was genuinely hard to view... since it would very frequently crash my browser tab.