### PR TITLE
Add `pstack` package

### DIFF
--- a/packages/pstack/brioche.lock
+++ b/packages/pstack/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/peadar/pstack.git": {
+      "v2.8.3": "a83d4b95e6bc2c62fae97ca9f9785fc7133a9fdb"
+    }
+  }
+}

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -15,36 +15,15 @@ const gitRef = Brioche.gitRef({
 const source = gitCheckout(gitRef);
 
 export default async function pstack(): Promise<std.Recipe<std.Directory>> {
-  let pstack = cmakeBuild({
+  return cmakeBuild({
     source,
     config: "RelWithDebInfo",
     dependencies: [std.toolchain()],
     set: {
       VERSION_TAG: (await gitRef).commit,
     },
+    runnable: "bin/pstack",
   });
-  pstack = std.withRunnableLink(pstack, "bin/pstack");
-  return pstack;
-  // return std.runBash`
-  //   export LIB="$LIBRARY_PATH"
-
-  //   mkdir build
-  //   cd build
-  //   cmake \\
-  //     -DCMAKE_INSTALL_PREFIX="$BRIOCHE_OUTPUT" \\
-  //     -DCMAKE_BUILD_TYPE=RelWithDebInfo \\
-  //     --debug-find \\
-  //     ..
-  //   make -j4
-  //   make install
-
-  //   if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
-  //     ln -s lib64 "$BRIOCHE_OUTPUT/lib"
-  //   fi
-  // `
-  //   .workDir(source)
-  //   .dependencies(std.toolchain(), cmake(), git())
-  //   .toDirectory();
 }
 
 export function test() {

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "pstack",
+  version: "2.8.3",
+};
+
+const gitRef = Brioche.gitRef({
+  repository: "https://github.com/peadar/pstack.git",
+  ref: `v${project.version}`,
+});
+
+const source = gitCheckout(gitRef);
+
+export default async function pstack(): Promise<std.Recipe<std.Directory>> {
+  let pstack = cmakeBuild({
+    source,
+    config: "RelWithDebInfo",
+    dependencies: [std.toolchain()],
+    set: {
+      VERSION_TAG: (await gitRef).commit,
+    },
+  });
+  pstack = std.withRunnableLink(pstack, "bin/pstack");
+  return pstack;
+  // return std.runBash`
+  //   export LIB="$LIBRARY_PATH"
+
+  //   mkdir build
+  //   cd build
+  //   cmake \\
+  //     -DCMAKE_INSTALL_PREFIX="$BRIOCHE_OUTPUT" \\
+  //     -DCMAKE_BUILD_TYPE=RelWithDebInfo \\
+  //     --debug-find \\
+  //     ..
+  //   make -j4
+  //   make install
+
+  //   if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
+  //     ln -s lib64 "$BRIOCHE_OUTPUT/lib"
+  //   fi
+  // `
+  //   .workDir(source)
+  //   .dependencies(std.toolchain(), cmake(), git())
+  //   .toDirectory();
+}
+
+export function test() {
+  return std.runBash`
+    pstack --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(pstack());
+}


### PR DESCRIPTION
This PR adds a new `pstack` package.

`pstack` is a small utility that dumps a stack trace for a running process. As far as I can tell, there are two implementations that share a name: the [robotux](https://code.lm7.fr/robotux/pstack) version and the [peadar](https://github.com/peadar/pstack) version. The robotux version is the "original" as best as I can tell, but hasn't been updated in 8 years and has limited platform support; the peadar version is a new, actively maintained rewrite that supports more platforms.

Debian's `pstack` package still uses the robotux version, but I decided to use the peader version. Neither Nixpkgs nor Homebrew have a `pstack` package in their main repositories, although I did find one in Arch's AUR, which also uses the peader implementation.