### PR TITLE
[std] Add `std.attachResources()` recipe

### DIFF
--- a/packages/std/core/recipes/attach_resources.bri
+++ b/packages/std/core/recipes/attach_resources.bri
@@ -1,0 +1,28 @@
+import { BRIOCHE_VERSION } from "../runtime.bri";
+import { semverMatches } from "../semver.bri";
+import { assert } from "../utils.bri";
+import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import type { Directory } from "./directory.bri";
+
+/**
+ * Attach resources to the files within a recipe by searching within
+ * directories named `brioche-resources.d`. This is useful when unarchiving
+ * a recipe that was archived using `collectReferences`.
+ */
+export function attachResources(
+  recipe: AsyncRecipe<Directory>,
+): Recipe<Directory> {
+  return createRecipe(["directory"], {
+    sourceDepth: 1,
+    briocheSerialize: async (meta) => {
+      assert(semverMatches(BRIOCHE_VERSION, ">=0.1.4"));
+
+      const serializedRecipe = await (await recipe).briocheSerialize();
+      return {
+        meta,
+        type: "attach_resources",
+        recipe: serializedRecipe,
+      };
+    },
+  });
+}

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -21,6 +21,7 @@ export { memo, createProxy } from "./proxy.bri";
 export { symlink, type SymlinkOptions, Symlink } from "./symlink.bri";
 export { sync } from "./sync.bri";
 export { collectReferences } from "./collect_references.bri";
+export { attachResources } from "./attach_resources.bri";
 export { glob } from "./glob.bri";
 export {
   type AsyncRecipe,

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -48,6 +48,7 @@ export type RecipeSerialization<T extends Artifact> = runtime.WithMeta &
           | runtime.InsertRecipe
           | runtime.GlobRecipe
           | runtime.CollectReferencesRecipe
+          | runtime.AttachResourcesRecipe
           | runtime.ProxyRecipe
           | runtime.SyncRecipe
       : T extends Symlink

--- a/packages/std/core/runtime.bri
+++ b/packages/std/core/runtime.bri
@@ -107,6 +107,7 @@ export type Recipe =
   | GlobRecipe
   | SetPermissionsRecipe
   | CollectReferencesRecipe
+  | AttachResourcesRecipe
   | ProxyRecipe
   | SyncRecipe;
 
@@ -192,6 +193,11 @@ export type SetPermissionsRecipe = WithMeta & {
 
 export type CollectReferencesRecipe = WithMeta & {
   type: "collect_references";
+  recipe: Recipe;
+};
+
+export type AttachResourcesRecipe = WithMeta & {
+  type: "attach_resources";
   recipe: Recipe;
 };
 


### PR DESCRIPTION
Companion to brioche-dev/brioche#149

This PR adds a new `std.attachResources()` function. This returns a recipe corresponding to the new upstream `attach_resources` recipe type.