### PR TITLE
[std] Sync `toolchain()` and `tools()` as tarballs

### DIFF
--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -161,7 +161,9 @@ export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
     MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
   });
 
-  return std.sync(tools);
+  tools = syncTarball(tools);
+
+  return tools;
 });
 
 /**
@@ -312,7 +314,7 @@ export const toolchain = std.memo(
 
     toolchain = makePkgConfigPathsRelative(toolchain);
 
-    toolchain = std.sync(toolchain);
+    toolchain = syncTarball(toolchain);
 
     return toolchain;
   },
@@ -427,4 +429,37 @@ function makePkgConfigPathsRelative(
       outputScaffold: recipe,
     })
     .toDirectory();
+}
+
+/**
+ * Sync a recipe by creating an archive of it, then unarchiving it. When
+ * fetched from the registry, the recipe will be downloaded as a single
+ * compressed tarball, which may be faster than syncing lots of individual
+ * files.
+ */
+function syncTarball(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  recipe = std.collectReferences(std.directory({ recipe }));
+
+  const tarredRecipe = std
+    .process({
+      command: "tar",
+      args: [
+        "--zstd",
+        "-cf",
+        std.outputPath,
+        "--hard-dereference",
+        "-C",
+        recipe,
+        ".",
+      ],
+      dependencies: [tar(), zstd()],
+    })
+    .toFile();
+
+  let untarredRecipe = tarredRecipe.unarchive("tar", "zstd");
+  untarredRecipe = std.attachResources(untarredRecipe);
+
+  return std.castToDirectory(untarredRecipe.get("recipe"));
 }


### PR DESCRIPTION
Depends on #146 

Part of brioche-dev/brioche#147

This PR updates the `std.toolchain()` and `std.tools()` recipes by wrapping them with a new function called `syncTarball`. Internally, this function just tars then untars each recipe, which is effectively a no-op. But the _tarred_ version of the recipe is what would get synced from the registry, meaning this should ensure both `std.toolchain()` and `std.tools()` would get synced as a single tar download, rather than thousands of individual file downloads.