### PR TITLE
Add `jj` package

### DIFF
--- a/packages/jj/brioche.lock
+++ b/packages/jj/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/jj-vcs/jj.git": {
+      "v0.24.0": "32d2a85539254e9d96f9819072fa5c6ac70dd1e4"
+    }
+  }
+}

--- a/packages/jj/project.bri
+++ b/packages/jj/project.bri
@@ -1,0 +1,31 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { cargoBuild } from "rust";
+import openssl from "openssl";
+
+export const project = {
+  name: "jj",
+  version: "0.24.0",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/jj-vcs/jj.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function jj(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "cli",
+    dependencies: [openssl()],
+    runnable: "bin/jj",
+  });
+}
+
+export function test() {
+  return std.runBash`
+    jj --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(jj());
+}


### PR DESCRIPTION
This PR adds a package for [Jujutsu](https://github.com/jj-vcs/jj), a git-compatible VCS (abbreviated `jj`)

I also used `jj` to make this PR 🙂 