### PR TITLE
Increase timeout in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     needs: [check]
     if: github.repository == 'brioche-dev/brioche-packages' && github.event_name == 'push' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/build/') )
     runs-on: proxmox-runner-set
+    timeout-minutes: 720
     steps:
       - name: Install system packages
         run: |


### PR DESCRIPTION
This PR increases the timeout for the GitHub Actions workflow from the default value (6 hours) to a more generous value (12 hours). Recently, some builds-- namely, those that require rebuilding `std.toolchain()`-- have either gotten close to the threshold or have hit it and failed.