### PR TITLE
Add `libarchive` package

### DIFF
--- a/packages/libarchive/brioche.lock
+++ b/packages/libarchive/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.libarchive.org/downloads/libarchive-3.7.7.tar.xz": {
+      "type": "sha256",
+      "value": "879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee"
+    }
+  }
+}

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+
+export const project = {
+  name: "libarchive",
+  version: "3.7.7",
+};
+
+const source = Brioche.download(
+  `https://www.libarchive.org/downloads/libarchive-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  let libarchive = std.runBash`
+    ./configure --prefix="$BRIOCHE_OUTPUT"
+    make
+    make install
+  `
+    .workDir(source)
+    .dependencies(toolchain())
+    .toDirectory();
+
+  libarchive = std.setEnv(libarchive, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+
+  return libarchive;
+}
+
+// HACK: Quick patch to toolchain to replace absolute libtool
+// path in `libacl.la` with `-l` argument
+function toolchain(): std.Recipe<std.Directory> {
+  let toolchain = std.toolchain();
+
+  const patched = std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    sed -i 's|//lib/lib\\([^\\s]*\\).la|-l\\1|g' lib/*.la
+  `
+    .outputScaffold(std.glob(toolchain, ["lib/libacl.la"]))
+    .toDirectory();
+
+  toolchain = std.merge(toolchain, patched);
+  return toolchain;
+}


### PR DESCRIPTION
This PR adds a package for [libarchive](https://www.libarchive.org/), a C library that supports multiple archive and compression formats

As part of the implementation, I finally got bit by an absolute path in a libtool (`.la`) file. Basically, the file `lib/libacl.la` from `std.toolchain()` references `//lib/libattr.la` by absolute path, and the libarchive build eventually tries to read this absolute path, which won't exist in the sandbox. As a workaround, I manually patched the toolchain as part of this build to replace the absolute path with a normal `-l` flag (i.e. replacing `//lib/libattr.la` with `-lattr`). This patch is localized to the libarchive build (and also only touches `libacl.la`), so we'll likely want to generalize this and apply it to the entirety of `std.toolchain()`