### PR TITLE
Add `proot` package

### DIFF
--- a/packages/proot/brioche.lock
+++ b/packages/proot/brioche.lock
@@ -1,0 +1,11 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/proot-me/proot.git": {
+      "v5.4.0": "bd5a5f63d72f8210d8cee76195eb9f0749e5bd70"
+    },
+    "https://github.com/troydhanson/uthash.git": {
+      "master": "f69112c04f1b6e059b8071cb391a1fcc83791a00"
+    }
+  }
+}

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import git, { gitCheckout } from "git";
+import talloc from "talloc";
+import libarchive from "libarchive";
+
+export const project = {
+  name: "proot",
+  version: "5.4.0",
+};
+
+export const source = std.recipeFn(() => {
+  const source = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/proot-me/proot.git",
+      ref: `v${project.version}`,
+    }),
+  );
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    sed -i 's|/bin/echo|/usr/bin/env echo|g' src/GNUmakefile
+  `
+    .outputScaffold(source)
+    .toDirectory();
+});
+
+export default function proot(): std.Recipe<std.Directory> {
+  let proot = std.runBash`
+    BRIOCHE_LD_AUTOPACK=false make -C src loader.elf loader-m32.elf build.h
+    make -C src proot care
+    make -C src install PREFIX="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain(), git(), talloc(), uthash(), libarchive())
+    .toDirectory();
+
+  return proot;
+}
+
+function uthash(): std.Recipe<std.Directory> {
+  const uthash = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/troydhanson/uthash.git",
+      ref: "master",
+    }),
+  );
+
+  return std.setEnv(uthash, {
+    CPATH: { append: [{ path: "include" }] },
+  });
+}
+
+export function test() {
+  return std.runBash`
+    proot --version
+    proot -R "$tools" ls /
+    exit 1
+  `
+    .dependencies(proot())
+    .env({ tools: std.tools() });
+}

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -33,6 +33,8 @@ export default function proot(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain(), git(), talloc(), uthash(), libarchive())
     .toDirectory();
 
+  proot = std.withRunnableLink(proot, "bin/proot");
+
   return proot;
 }
 


### PR DESCRIPTION
This PR adds a package for [PRoot](https://github.com/proot-me/proot), a userland `chroot` implementation on Linux (which uses `ptrace` under the hood, so it should work even in contexts where user namespaces aren't allowed)