### PR TITLE
Add `dasel` package

### DIFF
--- a/packages/dasel/brioche.lock
+++ b/packages/dasel/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/TomWright/dasel.git": {
+      "v2.8.1": "5e3a3cffdd50bacb493fb041d65211f440a560a5"
+    }
+  }
+}

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -1,0 +1,39 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "dasel",
+  version: "2.8.1",
+};
+
+const majorVersion = "2";
+std.assert(
+  project.version.split(".").at(0) === majorVersion,
+  `Dasel major version ${majorVersion} does not match version number ${project.version}`,
+);
+
+const gitRef = Brioche.gitRef({
+  repository: "https://github.com/TomWright/dasel.git",
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function dasel(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/dasel",
+    runnable: "bin/dasel",
+    buildParams: {
+      ldflags: [
+        `-X github.com/tomwright/dasel/v${majorVersion}/internal.Version=${project.version}`,
+      ],
+    },
+  });
+}
+
+export function test() {
+  return std.runBash`
+    dasel --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(dasel());
+}


### PR DESCRIPTION
This PR adds a new package for [Dasel](https://github.com/TomWright/dasel), a CLI tool for converting, querying, and editing JSON/YAML/TOML/XML/CSV documents