### PR TITLE
Add `s2argv_execs` package

### DIFF
--- a/packages/s2argv_execs/brioche.lock
+++ b/packages/s2argv_execs/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/virtualsquare/s2argv-execs.git": {
+      "1.4": "d357705f8678f5299d90fc33245b8783cfd0d29c"
+    }
+  }
+}

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -1,0 +1,29 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "s2argv_execs",
+  version: "1.4",
+};
+
+export const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/virtualsquare/s2argv-execs.git",
+    ref: project.version,
+  }),
+);
+
+export default function (): std.Recipe<std.Directory> {
+  let s2argv_execs = cmakeBuild({
+    source,
+    dependencies: [std.toolchain()],
+  });
+
+  s2argv_execs = std.setEnv(s2argv_execs, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+  });
+
+  return s2argv_execs;
+}


### PR DESCRIPTION
This PR adds a new package for the [`s2argv-execs`](https://github.com/virtualsquare/s2argv-execs) project, named as `s2argv_execs` (underscore instead of dash) for consistency with Brioche's package naming rules.

This project contains the `libexecs` C library, which at least is used by the [vdeplug4](https://github.com/rd235/vdeplug4) project.