### PR TITLE
Add `vdeplug4` package

### DIFF
--- a/packages/vdeplug4/brioche.lock
+++ b/packages/vdeplug4/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rd235/vdeplug4.git": {
+      "v4.0.1": "d482de1719ba198d020e756a9c81fb436f601267"
+    }
+  }
+}

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -1,0 +1,30 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { gitCheckout } from "git";
+import s2argvExecs from "s2argv_execs";
+
+export const project = {
+  name: "vdeplug4",
+  version: "4.0.1",
+};
+
+export const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/rd235/vdeplug4.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function (): std.Recipe<std.Directory> {
+  let vdeplug = cmakeBuild({
+    source,
+    dependencies: [std.toolchain(), s2argvExecs()],
+  });
+
+  vdeplug = std.setEnv(vdeplug, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+  });
+
+  return vdeplug;
+}


### PR DESCRIPTION
This PR adds a package for the [vdeplug4](https://github.com/rd235/vdeplug4) project. It offers a library and plugin system for networking with VMs, including when building [User-mode Linux](https://en.wikipedia.org/wiki/User-mode_Linux).

This is the same project backing the Debian package [`libvdeplug-dev`](https://packages.debian.org/sid/libvdeplug-dev). As best as I can tell, it's the latest of several projects providing the "libvde" library. I chose to name it `vdeplug4` because that's the name advertised in the upstream repo, and it appears to have an entirely separate codebase from prior versions. 