### PR TITLE
[linux] Update to v6.12.9

### DIFF
--- a/packages/linux/brioche.lock
+++ b/packages/linux/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.8.tar.xz": {
+    "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.9.tar.xz": {
       "type": "sha256",
-      "value": "2291da065ca04b715c89ee50362aec3f021a7414bc963f1b56736682c8122979"
+      "value": "87be0360df0931b340d2bac35161a548070fbc3a8c352c49e21e96666c26aeb4"
     }
   }
 }

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -4,7 +4,7 @@ import openssl from "openssl";
 
 export const project = {
   name: "linux",
-  version: "6.12.8",
+  version: "6.12.9",
   extra: {
     majorVersion: "6",
   },

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -83,6 +83,9 @@ export default function linux(
 
   const source = linuxSource().insert(".config", config);
 
+  // Build and install the kernel. We explicitly install the kernel image
+  // and `System.map` because not all architectures have a `make install`
+  // target
   return std.runBash`
     make -j16
 
@@ -107,7 +110,6 @@ export default function linux(
       std.toolchain(),
     )
     .env({
-      INSTALL_PATH: std.tpl`${std.outputPath}/boot`,
       INSTALL_MOD_PATH: std.outputPath,
 
       // Needed since we're using `ld.bfd`, which tries to resolve transitive


### PR DESCRIPTION
This PR updates the Linux kernel package (`packages/linux`) from v6.12.8 to v6.12.9, which is the current stable release. I also removed an unused env var from the build.