### PR TITLE
[rust] Update to v1.84.0

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -5,9 +5,9 @@
       "type": "sha256",
       "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
     },
-    "https://static.rust-lang.org/dist/channel-rust-1.83.0.toml": {
+    "https://static.rust-lang.org/dist/channel-rust-1.84.0.toml": {
       "type": "sha256",
-      "value": "b3544fb72bc3189697fc18ac2d3fa27d57ee8434f59d9919d4d70af2c6f010b3"
+      "value": "94c2c0ba9c6783815df45d680f0f20c7ea80d11b85ee8bbbc61354f3082cd0f5"
     }
   }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -5,7 +5,7 @@ import caCertificates from "ca_certificates";
 
 export const project = {
   name: "rust",
-  version: "1.83.0",
+  version: "1.84.0",
 };
 
 const ManifestPkgTarget = t.discriminatedUnion("available", [


### PR DESCRIPTION
This PR updates Rust to the v1.84.0, which is the newest release. [Rust v1.84.0 release notes](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html)