### PR TITLE
[go] Update to v1.23.4

### DIFF
--- a/packages/go/brioche.lock
+++ b/packages/go/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://go.dev/dl/go1.23.1.linux-amd64.tar.gz": {
+    "https://go.dev/dl/go1.23.4.linux-amd64.tar.gz": {
       "type": "sha256",
-      "value": "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd"
+      "value": "6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971"
     }
   }
 }

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -3,7 +3,7 @@ import caCertificates from "ca_certificates";
 
 export const project = {
   name: "go",
-  version: "1.23.1",
+  version: "1.23.4",
 };
 
 /**


### PR DESCRIPTION
This PR updates Go to the latest version, which is v1.23.4. [Go v1.23.x release notes](https://go.dev/doc/devel/release#go1.23.minor)