### PR TITLE
[rust] Add `buildParams.defaultFeatures` option to `rust.cargoBuild()`

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -115,6 +115,7 @@ export default rust;
 
 interface CargoBuildParameters {
   features?: string[];
+  defaultFeatures?: boolean;
 }
 
 export interface CargoBuildOptions {
@@ -146,6 +147,8 @@ export interface CargoBuildOptions {
  *   the build is hermetic when setting these options!
  * - `buildParams`: Optional build parameters:
  *   - `features`: An array of features to enable.
+ *   - `defaultFeatures`: Set to `false` to opt out of the crate's
+ *     default features.
  *
  * ## Example
  *
@@ -183,7 +186,10 @@ export function cargoBuild(options: CargoBuildOptions) {
       crate_path: options.path ?? ".",
       features:
         options.buildParams?.features != null
-          ? featuresWrapper(options.buildParams.features)
+          ? featuresWrapper(
+              options.buildParams.features,
+              options.buildParams.defaultFeatures ?? true,
+            )
           : "",
       ...options.env,
     })
@@ -299,7 +305,18 @@ function cargoChef(): std.Recipe<std.Directory> {
  * @param features An array of features.
  * @returns A string of features for a Cargo build.
  */
-function featuresWrapper(features: string[]): string {
+function featuresWrapper(features: string[], defaultFeatures: boolean): string {
   // From ["feature1", "feature2", "feature3"] to '--features feature1,feature2,feature3'
-  return `--features ${features.join(",")}`;
+  for (const feature of features) {
+    std.assert(
+      /^[a-zA-Z0-9\-_]+$/.test(feature),
+      `Unsupported feature name: ${feature}`,
+    );
+  }
+
+  return [
+    "--features",
+    features.join(","),
+    ...(defaultFeatures ? [] : ["--no-default-features"]),
+  ].join(" ");
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -175,6 +175,11 @@ export function cargoBuild(options: CargoBuildOptions) {
   // Vendor the crate's dependencies
   const crate = vendorCrate({ source: options.source });
 
+  const featuresArgs = makeFeaturesArgs(
+    options.buildParams?.features ?? [],
+    options.buildParams?.defaultFeatures ?? true,
+  );
+
   // Use `cargo install` to build and install the project to `$BRIOCHE_OUTPUT`
   let buildResult = std.runBash`
     cargo install --path "$crate_path" $features --frozen
@@ -184,13 +189,7 @@ export function cargoBuild(options: CargoBuildOptions) {
       CARGO_INSTALL_ROOT: std.outputPath,
       PATH: std.tpl`${std.outputPath}/bin`,
       crate_path: options.path ?? ".",
-      features:
-        options.buildParams?.features != null
-          ? featuresWrapper(
-              options.buildParams.features,
-              options.buildParams.defaultFeatures ?? true,
-            )
-          : "",
+      features: featuresArgs?.join(" "),
       ...options.env,
     })
     .workDir(crate)
@@ -305,7 +304,10 @@ function cargoChef(): std.Recipe<std.Directory> {
  * @param features An array of features.
  * @returns A string of features for a Cargo build.
  */
-function featuresWrapper(features: string[], defaultFeatures: boolean): string {
+function makeFeaturesArgs(
+  features: string[],
+  defaultFeatures: boolean,
+): string[] | undefined {
   // From ["feature1", "feature2", "feature3"] to '--features feature1,feature2,feature3'
   for (const feature of features) {
     std.assert(
@@ -314,9 +316,17 @@ function featuresWrapper(features: string[], defaultFeatures: boolean): string {
     );
   }
 
-  return [
-    "--features",
-    features.join(","),
-    ...(defaultFeatures ? [] : ["--no-default-features"]),
-  ].join(" ");
+  const args = [];
+  if (features.length > 0) {
+    args.push("--features", features.join(","));
+  }
+  if (!defaultFeatures) {
+    args.push("--no-default-features");
+  }
+
+  if (args.length > 0) {
+    return args;
+  } else {
+    return undefined;
+  }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -196,6 +196,10 @@ export function cargoBuild(options: CargoBuildOptions) {
     .unsafe(options.unsafe)
     .toDirectory();
 
+  // Remove extra metadata created by `cargo install`
+  buildResult = buildResult.remove(".crates.toml");
+  buildResult = buildResult.remove(".crates2.json");
+
   // Add a runnable link if set in the options
   if (options.runnable != null) {
     buildResult = std.withRunnableLink(buildResult, options.runnable);


### PR DESCRIPTION
This PR updates the options for the `rust.cargoBuild()` function with a new `buildParams.defaultFeatures` option. When set to `false`, it adds the `--no-default-features` flag when building the crate.

Also, I made two tiny cleanup changes:

- Validate the feature strings in `buildParams.features` with a regex (this should avoid shell quoting issues)
- Remove extra `.crates.toml` / `.crates2.json` files from build output (see ["Cargo Home"](https://doc.rust-lang.org/cargo/guide/cargo-home.html#files) in the Cargo docs for more context)