### PR TITLE
chore: update amber to version 0.4.0-alpha

### DIFF
--- a/packages/amber/brioche.lock
+++ b/packages/amber/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/amber-lang/amber/archive/refs/tags/0.3.5-alpha.tar.gz": {
+    "https://github.com/amber-lang/amber/archive/refs/tags/0.4.0-alpha.tar.gz": {
       "type": "sha256",
-      "value": "4030875270619e4520fa018a17bd213956a13133662151abd097aaf754df4a5d"
+      "value": "14046dd50c12c5f470177fc43029495fb8f489ba84fe301e3aada1f32493b211"
     }
   }
 }

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -3,7 +3,7 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "amber",
-  version: "0.3.5-alpha",
+  version: "0.4.0-alpha",
 };
 
 const source = Brioche.download(


### PR DESCRIPTION
Update amber to the latest release available.