### PR TITLE
chore: update aws_cdk version to 2.176.0

### DIFF
--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -3,7 +3,7 @@ import { npmInstallGlobal } from "nodejs";
 
 export const project = {
   name: "aws_cdk",
-  version: "2.150.0",
+  version: "2.176.0",
 };
 
 export default function awsCdk() {


### PR DESCRIPTION
Just update aws-cdk package to the latest version available.