### PR TITLE
chore: update bat to version 0.25.0

### DIFF
--- a/packages/bat/brioche.lock
+++ b/packages/bat/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/sharkdp/bat/archive/refs/tags/v0.24.0.tar.gz": {
+    "https://github.com/sharkdp/bat/archive/refs/tags/v0.25.0.tar.gz": {
       "type": "sha256",
-      "value": "907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb"
+      "value": "4433403785ebb61d1e5d4940a8196d020019ce11a6f7d4553ea1d324331d8924"
     }
   }
 }

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -3,7 +3,7 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "bat",
-  version: "0.24.0",
+  version: "0.25.0",
 };
 
 const source = Brioche.download(


### PR DESCRIPTION
Just update bat to the latest version.