### PR TITLE
feat: update cargo-chef to version 0.1.70 in dependencies

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.70/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
       "type": "sha256",
-      "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
+      "value": "6c4bcfbe408b0f73826d5e454650f2221ba734de1b14ec90779a93f81787f7d0"
     },
     "https://static.rust-lang.org/dist/channel-rust-1.84.0.toml": {
       "type": "sha256",

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -294,7 +294,7 @@ export function vendorCrate(
 
 function cargoChef(): std.Recipe<std.Directory> {
   const pkg = Brioche.download(
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.70/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
   );
 
   return std.directory({


### PR DESCRIPTION
Nothing else than updating the cargo-check package