### PR TITLE
feat: update curl to version 8.11.1

### DIFF
--- a/packages/curl/brioche.lock
+++ b/packages/curl/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://curl.se/download/curl-8.9.1.tar.gz": {
+    "https://curl.se/download/curl-8.11.1.tar.gz": {
       "type": "sha256",
-      "value": "291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5"
+      "value": "a889ac9dbba3644271bd9d1302b5c22a088893719b72be3487bc3d401e5c4e80"
     }
   }
 }

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -3,7 +3,7 @@ import openssl from "openssl";
 
 export const project = {
   name: "curl",
-  version: "8.9.1",
+  version: "8.11.1",
 };
 
 const source = Brioche.download(
@@ -19,7 +19,8 @@ export default function (): std.Recipe<std.Directory> {
       --with-openssl \\
       --without-ca-bundle \\
       --without-ca-path \\
-      --with-ca-fallback
+      --with-ca-fallback \\
+      --without-libpsl
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `


### PR DESCRIPTION
Update cURL package to the latest release. I had to add the following flag when building the package: `--without-libpsl`. Without it, I was getting this error:

```bash
ERROR build:bake:bake_inner:run_bake: brioche_core::bake: error=process failed, view full output by runing `brioche jobs logs /home/container/.local/share/brioche/process-temp/01JJ2D87R79C72ZPAXJZD26X5A/events.bin.zst`: process exited with status code exit status: 1
    at file:///workspace/packages/std/core/recipes/process.bri:190:14
    at file:///workspace/packages/curl/project.bri:27:6
    at file:///workspace/packages/curl/project.bri:28:6
    at file:///workspace/packages/std/extra/set_env.bri:50:25
    at file:///workspace/packages/curl/project.bri:30:14
    at file:///workspace/packages/std/extra/set_env.bri:61:23 scope=Project { project_hash: ProjectHash(Hash("0ab973073f06009c8336f33a01dfee09b2021b416c178e73055bb7a75ed4b825")), export: "default" } recipe_hash=07af32e16bba5c8df9528be6661ed1f7f9302f8b99c74546b814bbc2ebd9a4ca recipe_kind=Insert recipe_hash=07af32e16bba5c8df9528be6661ed1f7f9302f8b99c74546b814bbc2ebd9a4ca recipe_kind=Insert
13866  │ checking for AWS-LC... no
       │ checking for LibreSSL... no
       │ checking for OpenSSL >= v3... yes
       │ checking for SSL_set_quic_use_legacy_codepoint... no
       │ configure: OpenSSL version does not speak QUIC API
       │ checking for SRP support in OpenSSL... yes
       │ checking for QUIC support and OpenSSL >= 3.3... yes
       │ configure: built with one SSL backend
       │ checking default CA cert bundle/path... configure: want no ca no
       │ no
       │ checking whether to use built-in CA store of SSL library... yes
       │ checking CA cert bundle path to embed in the curl tool... no
       │ checking for pkg-config... (cached) /home/brioche-runner-346af3b030acc435cf524e5bdc732dc9cc7c7f80221366eb159c320d779a0b81/.local/share/brioche/locals/e1ed32b0f032eb21008a38d286836b9b8
       │ 41956370cebbbd006b5c1eb3c952710/bin/pkg-config
       │ checking for libpsl options with pkg-config... no
       │ checking for psl_builtin in -lpsl... no
       │ configure: error: libpsl libs and/or directories were not found where specified!
```

After having looked at nixpkgs and homebrew, both do not build by default with the library `PSL`. For example, from homebrew:

https://github.com/Homebrew/homebrew-core/blob/00aef4629a67551b17040cc8f9a85610a26c26e7/Formula/c/curl.rb:
![image](https://github.com/user-attachments/assets/be437c18-7a2a-41ca-a218-f73093e31d29)
