### PR TITLE
feat: update gitui to version 0.27.0

### DIFF
--- a/packages/gitui/brioche.lock
+++ b/packages/gitui/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/extrawurst/gitui.git": {
-      "v0.26.3": "95e1d4d4324bf1eab34f8100afc7f3ae7e435252"
+      "v0.27.0": "99f69671445a8b9f069e07cd4c6c3fee7e07a77b"
     }
   }
 }

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -1,10 +1,11 @@
 import * as std from "std";
+import cmake from "cmake";
 import git, { gitCheckout } from "git";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "gitui",
-  version: "0.26.3",
+  version: "0.27.0",
 };
 
 const source = gitCheckout(
@@ -17,7 +18,7 @@ const source = gitCheckout(
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
-    dependencies: [git()],
+    dependencies: [cmake(), git()],
     env: {
       GITUI_RELEASE: "1",
     },


### PR DESCRIPTION
Update gitui to the latest release. I had to add the cmake dependency to make it build, otherwise this error was popping:

```bash
ERROR build:bake:bake_inner:run_bake: brioche_core::bake: error=process failed, view full output by runing `brioche jobs logs /home/container/.local/share/brioche/process-temp/01JJ2P8SDJ8RK4FZ183CKA1NK3/events.bin.zst`: process exited with status code exit status: 101
    at file:///workspace/packages/std/core/recipes/process.bri:208:14
    at file:///workspace/packages/rust/project.bri:196:6
    at file:///workspace/packages/gitui/project.bri:18:10
    at file:///workspace/packages/rust/project.bri:197:6
    at file:///workspace/packages/rust/project.bri:200:29
    at file:///workspace/packages/rust/project.bri:201:29 scope=Project { project_hash: ProjectHash(Hash("5c1a2de7fe6fc93d70646b9394aa21fda348c152490ad405d2808073c49102bf")), export: "default" } recipe_hash=137c3548dc3cd74f4c489ba33f30b8c7d7029e62901e3b10f15ea6070ba8be28 recipe_kind=Insert recipe_hash=137c3548dc3cd74f4c489ba33f30b8c7d7029e62901e3b10f15ea6070ba8be28 recipe_kind=Insert
64400  │ PATH="/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/.local/share/brioche/locals/e1ed32b0f032eb21008a38d286836b9b841956370cebbbd006b5c1eb3c95271
       │ 0" LC_ALL="C" "cmake" "/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/work/vendor/libz-ng-sys/src/zlib-ng" "-DBUILD_SHARED_LIBS=OFF" "-DZLIB_COM
       │ PAT=OFF" "-DZLIB_ENABLE_TESTS=OFF" "-DWITH_GZFILEOP=ON" "-DCMAKE_INSTALL_PREFIX=/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/work/target/relea
       │ se/build/libz-ng-sys-0f8a0c19828c4b9c/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24
       │ de374e9fabdf28cb96ae9f16f7cf5fb/.local/share/brioche/locals/e1ed32b0f032eb21008a38d286836b9b841956370cebbbd006b5c1eb3c952710/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sec
       │ tions -fPIC -m64" "-DCMAKE_CXX_COMPILER=/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/.local/share/brioche/locals/e1ed32b0f032eb21008a38d286836
       │ b9b841956370cebbbd006b5c1eb3c952710/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/home/brioche-runner-dddda4ada716c7a6204f6c346a1
       │ fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/.local/share/brioche/locals/e1ed32b0f032eb21008a38d286836b9b841956370cebbbd006b5c1eb3c952710/bin/cc" "-DCMAKE_BUILD_TYPE=MinSizeRel"
       │   --- stderr
       │   thread 'main' panicked at /home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/work/vendor/cmake/src/lib.rs:1115:5:
       │   command did not execute successfully, got: exit status: 127, is `cmake` not installed?
       │   build script failed, must exit now
       │   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       │ warning: build failed, waiting for other jobs to finish...
       │ error: failed to compile `gitui v0.27.0 (/home/brioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/work)`, intermediate artifacts can be found at `/home/br
       │ ioche-runner-dddda4ada716c7a6204f6c346a1fc9b24de374e9fabdf28cb96ae9f16f7cf5fb/work/target`.
       │ To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

This is due to the usage of a new dependency in gitui package as referred here: https://github.com/Homebrew/homebrew-core/commit/825cae440cf259cf83e9ee2d7b96f841356812b0