### PR TITLE
feat: enhance alsa_lib by adding testing and auto-update functionalities

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -1,3 +1,5 @@
+import caCertificates from "ca_certificates";
+import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
@@ -11,7 +13,7 @@ const source = Brioche.download(
   .unarchive("tar", "bzip2")
   .peel();
 
-export default function (): std.Recipe<std.Directory> {
+export default function alsaLib(): std.Recipe<std.Directory> {
   const alsaLib = std.runBash`
     ./configure --prefix=/
     make install DESTDIR="$BRIOCHE_OUTPUT"
@@ -25,4 +27,58 @@ export default function (): std.Recipe<std.Directory> {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
+}
+
+export async function test() {
+  const src = std.file(std.indoc`
+      #include <stdio.h>
+      #include <alsa/asoundlib.h>
+
+      int main(void)
+      {
+          const char *alsa_version = snd_asoundlib_version();
+          printf("%s", alsa_version);
+
+          return 0;
+      }
+  `);
+
+  const script = std.runBash`
+    cp "$src" main.c
+    gcc main.c -o main -lasound
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), alsaLib())
+    .env({ src: src });
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    http get https://www.alsa-project.org/files/pub/lib
+      | lines
+      | where {|it| ($it | str contains "alsa-lib") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="alsa-lib-(?<version>.+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+      | tee { save $env.BRIOCHE_OUTPUT }
+  `);
+
+  return std
+    .process({
+      command: std.tpl`${nushell()}/bin/nu`,
+      args: [src],
+      unsafe: {
+        networking: true,
+      },
+    })
+    .dependencies(caCertificates())
+    .toFile();
 }

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -1,4 +1,3 @@
-import caCertificates from "ca_certificates";
 import nushell from "nushell";
 import * as std from "std";
 
@@ -62,23 +61,20 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    http get https://www.alsa-project.org/files/pub/lib
+    let version = http get https://www.alsa-project.org/files/pub/lib
       | lines
       | where {|it| ($it | str contains "alsa-lib") and (not ($it | str contains ".sig")) }
       | parse --regex '<a href="alsa-lib-(?<version>.+)\.tar\.bz2">'
       | sort-by --natural --reverse version
       | get 0.version
-      | tee { save $env.BRIOCHE_OUTPUT }
+
+    $env.project | from json | update version $version | to json
   `);
 
-  return std
-    .process({
-      command: std.tpl`${nushell()}/bin/nu`,
-      args: [src],
-      unsafe: {
-        networking: true,
-      },
-    })
-    .dependencies(caCertificates())
-    .toFile();
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }


### PR DESCRIPTION
This is part of the POC for [testing](https://github.com/brioche-dev/brioche/issues/94) and [auto-update](https://github.com/brioche-dev/brioche/issues/165) functionalities.

## Testing

```bash
> brioche build -p packages/alsa_lib/ -e test      
141    │ 1.2.13
 0.87s ✓ Process 141
 8.08s ✓ Registry  100% Fetch 136 blobs + 163 recipes from registry                                                                                                                                                                        
14.73s ✓ Registry  100% Fetch 1 blob + 1 recipe from registry                                                                                                                                                                              
 2.02s ✓ Registry  100% Fetch 1 blob + 1 recipe from registry                                                                                                                                                                              
Build finished, completed 6 jobs in 1m32s
Result: 52e866444decd8be3438780f92a27cbe76dd34b9fea832de3ca29c37b35703eb
```

## Auto-Update

```bash
> brioche build -p packages/alsa_lib/ -e autoUpdate
40     │ 1.2.13
 0.51s ✓ Process 40
 1.65s ✓ Registry  100% Fetch 1 blob + 1 recipe from registry                                                                                                                                                    
 0.63s ✓ Registry  100% Fetch 1 blob + 1 recipe from registry                                                                                                                                                    
 0.62s ✓ Registry  100% Fetch 1 blob + 1 recipe from registry                                                                                                                                                    
Build finished, completed 11 jobs in 20.05s
```

I took the decision to use nushell for the auto-update feature. It enables easier IMO writing of the script to retrieve the latest release for a package. I personally like the workflow of the nushell scripts. But it's a personal opinion. I'm open on this point. But I think we should stick with the same approach for other packages, if we validate this one.