### PR TITLE
Add `seaweedfs` package

### DIFF
--- a/packages/seaweedfs/brioche.lock
+++ b/packages/seaweedfs/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/seaweedfs/seaweedfs.git": {
+      "3.82": "ca4dca14d8b92bc193477f1b97d95fb440f21b43"
+    }
+  }
+}

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { goBuild } from "go";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "seaweedfs",
+  version: "3.82",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/seaweedfs/seaweedfs.git",
+    ref: project.version,
+  }),
+);
+
+export default function seaweedfs(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./weed",
+    runnable: "bin/weed",
+  });
+}
+
+export async function test() {
+  const recipe = std.runBash`
+    weed version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(seaweedfs());
+
+  const result = await recipe.toFile().read();
+  std.assert(result.includes(` ${project.version} `));
+
+  return recipe;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/seaweedfs/seaweedfs/releases/latest
+      | get tag_name
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
[SeaweedFS](https://github.com/seaweedfs/seaweedfs) is a distributed object storage system written in Go, which offers an S3-compatible API along with lots of other protocols

cc @jaudiger I added new `test` and `autoUpdate` functions here based on the implementations from #212 (for brioche-dev/brioche#94 and brioche-dev/brioche#165)