### PR TITLE
Update GitHub packages reference

### DIFF
--- a/packages/amber/brioche.lock
+++ b/packages/amber/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/amber-lang/amber/archive/refs/tags/0.4.0-alpha.tar.gz": {
-      "type": "sha256",
-      "value": "14046dd50c12c5f470177fc43029495fb8f489ba84fe301e3aada1f32493b211"
+  "git_refs": {
+    "https://github.com/amber-lang/amber.git": {
+      "0.4.0-alpha": "d3ceda317fc053ae9645e9f3c8f166657eba24e9"
     }
   }
 }

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -1,5 +1,6 @@
 import nushell from "nushell";
 import * as std from "std";
+import { gitCheckout } from "git";
 import { cargoBuild } from "rust";
 
 export const project = {
@@ -7,11 +8,12 @@ export const project = {
   version: "0.4.0-alpha",
 };
 
-const source = Brioche.download(
-  `https://github.com/amber-lang/amber/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/amber-lang/amber.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function amber(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/asciinema/brioche.lock
+++ b/packages/asciinema/brioche.lock
@@ -8,10 +8,11 @@
     "https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl": {
       "type": "sha256",
       "value": "35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"
-    },
-    "https://github.com/asciinema/asciinema/archive/refs/tags/v2.4.0.tar.gz": {
-      "type": "sha256",
-      "value": "b0e05f0b5ae7ae4e7186c6bd824e6d670203bb24f1c89ee52fc8fae7254e6091"
+    }
+  },
+  "git_refs": {
+    "https://github.com/asciinema/asciinema.git": {
+      "v2.4.0": "1a71be26c4c29e7cd98b97a11233cf3fb724ba9b"
     }
   }
 }

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import python from "python";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "asciinema",
   version: "2.4.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/asciinema/asciinema/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/asciinema/asciinema.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 const pipDependencies = std.directory({
   "setuptools-75.1.0-py3-none-any.whl": Brioche.download(

--- a/packages/bat/brioche.lock
+++ b/packages/bat/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/sharkdp/bat/archive/refs/tags/v0.25.0.tar.gz": {
-      "type": "sha256",
-      "value": "4433403785ebb61d1e5d4940a8196d020019ce11a6f7d4553ea1d324331d8924"
+  "git_refs": {
+    "https://github.com/sharkdp/bat.git": {
+      "v0.25.0": "25f4f96ea3afb6fe44552f3b38ed8b1540ffa1b3"
     }
   }
 }

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "bat",
   version: "0.25.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/sharkdp/bat/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/sharkdp/bat.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function bat(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/broot/brioche.lock
+++ b/packages/broot/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/Canop/broot/archive/refs/tags/v1.44.6.tar.gz": {
-      "type": "sha256",
-      "value": "554abc12c8343a0e921f92740e06bf3a86993f71eb78246c9b494293da13b1df"
+  "git_refs": {
+    "https://github.com/Canop/broot.git": {
+      "v1.44.6": "ba709580aa824549674ac5f424f67e2297ddfe19"
     }
   }
 }

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "broot",
   version: "1.44.6",
 };
 
-const source = Brioche.download(
-  `https://github.com/Canop/broot/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/Canop/broot.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/carapace/brioche.lock
+++ b/packages/carapace/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v1.1.1.tar.gz": {
-      "type": "sha256",
-      "value": "c479ef19a9d1b5a8579abb2da437afe7fb024ab23d11feadf746ffda0bbc833a"
+  "git_refs": {
+    "https://github.com/carapace-sh/carapace.git": {
+      "v1.1.1": "74167cbe2c66c0bbd8a11c5adcd58ec68b1be337"
     }
   }
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -1,4 +1,5 @@
 import * as std from "std";
+import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
@@ -6,11 +7,12 @@ export const project = {
   version: "1.1.1",
 };
 
-const source = Brioche.download(
-  `https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/carapace-sh/carapace.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/dust/brioche.lock
+++ b/packages/dust/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/bootandy/dust/archive/refs/tags/v1.1.1.tar.gz": {
-      "type": "sha256",
-      "value": "98cae3e4b32514e51fcc1ed07fdbe6929d4b80942925348cc6e57b308d9c4cb0"
+  "git_refs": {
+    "https://github.com/bootandy/dust.git": {
+      "v1.1.1": "dbd18f90e7b184d12f14533e76e5915dbe4a2051"
     }
   }
 }

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "dust",
   version: "1.1.1",
 };
 
-const source = Brioche.download(
-  `https://github.com/bootandy/dust/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/bootandy/dust.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/eza/brioche.lock
+++ b/packages/eza/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/eza-community/eza/archive/refs/tags/v0.20.17.tar.gz": {
-      "type": "sha256",
-      "value": "62bcf8f1b2d087fa0c2c8365e4427ad30ffa986330413191da47061aecfe20de"
+  "git_refs": {
+    "https://github.com/eza-community/eza.git": {
+      "v0.20.17": "2353c15e2fc091e74a813cc90463bfffe67d50e3"
     }
   }
 }

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "eza",
   version: "0.20.17",
 };
 
-const source = Brioche.download(
-  `https://github.com/eza-community/eza/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/eza-community/eza.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/fd/brioche.lock
+++ b/packages/fd/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/sharkdp/fd/archive/refs/tags/v10.2.0.tar.gz": {
-      "type": "sha256",
-      "value": "73329fe24c53f0ca47cd0939256ca5c4644742cb7c14cf4114c8c9871336d342"
+  "git_refs": {
+    "https://github.com/sharkdp/fd.git": {
+      "v10.2.0": "b19136871310b01500b4f09eadd7387b8476be47"
     }
   }
 }

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "fd",
   version: "10.2.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/sharkdp/fd/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/sharkdp/fd.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function fd(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/joshuto/brioche.lock
+++ b/packages/joshuto/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/kamiyaa/joshuto/archive/refs/tags/v0.9.8.tar.gz": {
-      "type": "sha256",
-      "value": "877d841b2e26d26d0f0f2e6f1dab3ea2fdda38c345abcd25085a3f659c24e013"
+  "git_refs": {
+    "https://github.com/kamiyaa/joshuto.git": {
+      "v0.9.8": "2a392e85633d73a7bfc55feb80c62ecabe70de75"
     }
   }
 }

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "joshuto",
   version: "0.9.8",
 };
 
-const source = Brioche.download(
-  `https://github.com/kamiyaa/joshuto/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/kamiyaa/joshuto.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 // Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
 // from the `Cargo.lock` from this commit in Joshuto:

--- a/packages/jq/brioche.lock
+++ b/packages/jq/brioche.lock
@@ -1,8 +1,9 @@
 {
   "dependencies": {},
-  "git_refs": {
-    "https://github.com/jqlang/jq.git": {
-      "jq-1.7.1": "71c2ab509a8628dbbad4bc7b3f98a64aa90d3297"
+  "downloads": {
+    "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-1.7.1.tar.gz": {
+      "type": "sha256",
+      "value": "478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2"
     }
   }
 }

--- a/packages/jq/brioche.lock
+++ b/packages/jq/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-1.7.1.tar.gz": {
-      "type": "sha256",
-      "value": "478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2"
+  "git_refs": {
+    "https://github.com/jqlang/jq.git": {
+      "jq-1.7.1": "71c2ab509a8628dbbad4bc7b3f98a64aa90d3297"
     }
   }
 }

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -1,4 +1,3 @@
-import { gitCheckout } from "git";
 import * as std from "std";
 
 export const project = {
@@ -6,12 +5,11 @@ export const project = {
   version: "1.7.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/jqlang/jq.git",
-    ref: `jq-${project.version}`,
-  }),
-);
+const source = Brioche.download(
+  `https://github.com/jqlang/jq/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
 
 export default function (): std.Recipe<std.Directory> {
   const jq = std.runBash`

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -1,3 +1,4 @@
+import { gitCheckout } from "git";
 import * as std from "std";
 
 export const project = {
@@ -5,11 +6,12 @@ export const project = {
   version: "1.7.1",
 };
 
-const source = Brioche.download(
-  `https://github.com/jqlang/jq/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/jqlang/jq.git",
+    ref: `jq-${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   const jq = std.runBash`

--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/martinvonz/jj/archive/refs/tags/v0.25.0.tar.gz": {
-      "type": "sha256",
-      "value": "3a99528539e414a3373f24eb46a0f153d4e52f7035bb06df47bd317a19912ea3"
+  "git_refs": {
+    "https://github.com/martinvonz/jj.git": {
+      "v0.25.0": "041c4fecb77434dd6720e7d7f1ce48d9575ac5f7"
     }
   }
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -1,17 +1,19 @@
 import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "jujutsu",
   version: "0.25.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/martinvonz/jj/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/martinvonz/jj.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/just/brioche.lock
+++ b/packages/just/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/casey/just/archive/refs/tags/1.38.0.tar.gz": {
-      "type": "sha256",
-      "value": "3d47e27755d39f40e1ca34bc0ef535fa514e7ed547b2af62311dcadd8bd6d564"
+  "git_refs": {
+    "https://github.com/casey/just.git": {
+      "1.38.0": "37dc2e490e765b4a54c182b7b35a67f7e09e2049"
     }
   }
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "just",
   version: "1.38.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/casey/just/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/casey/just.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function just(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/jwt_cli/brioche.lock
+++ b/packages/jwt_cli/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/mike-engel/jwt-cli/archive/refs/tags/6.2.0.tar.gz": {
-      "type": "sha256",
-      "value": "49d67d920391978684dc32b75e553a2abbd46c775365c0fb4b232d22c0ed653a"
+  "git_refs": {
+    "https://github.com/mike-engel/jwt-cli.git": {
+      "6.2.0": "fe5fdd375c9ae4094490d47b3e7bdd6c597d9945"
     }
   }
 }

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "jwt_cli",
   version: "6.2.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/mike-engel/jwt-cli/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/mike-engel/jwt-cli.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/lurk/brioche.lock
+++ b/packages/lurk/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/JakWai01/lurk/archive/refs/tags/v0.3.9.tar.gz": {
-      "type": "sha256",
-      "value": "c26f6c76dfad463108cf1559636136b51ec59d96971dd54477e8be1151c55a57"
+  "git_refs": {
+    "https://github.com/JakWai01/lurk.git": {
+      "v0.3.9": "4a9c7f5fc2b4a07509c0652fa1bb777d3ce77b08"
     }
   }
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "lurk",
   version: "0.3.9",
 };
 
-const source = Brioche.download(
-  `https://github.com/JakWai01/lurk/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/JakWai01/lurk.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/miniserve/brioche.lock
+++ b/packages/miniserve/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/svenstaro/miniserve/archive/refs/tags/v0.28.0.tar.gz": {
-      "type": "sha256",
-      "value": "c4c5e12796bdae2892eff3832b66c4c04364738b62cf1429259428b03363d1f1"
+  "git_refs": {
+    "https://github.com/svenstaro/miniserve.git": {
+      "v0.28.0": "8876500f3caa42b21771576367bf5426782da104"
     }
   }
 }

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "miniserve",
   version: "0.28.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/svenstaro/miniserve/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/svenstaro/miniserve.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/nushell/brioche.lock
+++ b/packages/nushell/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/nushell/nushell/archive/refs/tags/0.101.0.tar.gz": {
-      "type": "sha256",
-      "value": "43e4a123e86f0fb4754e40d0e2962b69a04f8c2d58470f47cb9be81daabab347"
+  "git_refs": {
+    "https://github.com/nushell/nushell.git": {
+      "0.101.0": "fb2610904997f54f50ad52095948bede81695f31"
     }
   }
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -1,17 +1,19 @@
 import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "nushell",
   version: "0.101.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/nushell/nushell/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/nushell/nushell.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/oha/brioche.lock
+++ b/packages/oha/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/hatoo/oha/archive/refs/tags/v1.6.0.tar.gz": {
-      "type": "sha256",
-      "value": "44ae493c24f42f8994b4192ace99e63866c054e305d368bf77176108cbfa93fd"
+  "git_refs": {
+    "https://github.com/hatoo/oha.git": {
+      "v1.6.0": "349b43dabf889933d2332922aa69b0ed9cb205b3"
     }
   }
 }

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "oha",
   version: "1.6.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/hatoo/oha/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/hatoo/oha.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/oniguruma/brioche.lock
+++ b/packages/oniguruma/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/kkos/oniguruma/archive/refs/tags/v6.9.10.tar.gz": {
-      "type": "sha256",
-      "value": "ad92309d0d13eebc27f6592e875f3efbfa3dda2bf6da5952e00f0a2120c921a8"
+  "git_refs": {
+    "https://github.com/kkos/oniguruma.git": {
+      "v6.9.10": "4ef89209a239c1aea328cf13c05a2807e5c146d1"
     }
   }
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -1,15 +1,17 @@
 import * as std from "std";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "oniguruma",
   version: "6.9.10",
 };
 
-const source = Brioche.download(
-  `https://github.com/kkos/oniguruma/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/kkos/oniguruma.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   let oniguruma = std.runBash`

--- a/packages/opentofu/brioche.lock
+++ b/packages/opentofu/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/opentofu/opentofu/archive/refs/tags/v1.9.0.tar.gz": {
-      "type": "sha256",
-      "value": "95234f00bb8a6d73bcd3f3920e376a32189004df3aaf26cb95917cec5441f8a8"
+  "git_refs": {
+    "https://github.com/opentofu/opentofu.git": {
+      "v1.9.0": "0d57aa4f35998bf2847ac3acb343f9e16b5c2995"
     }
   }
 }

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { goBuild } from "go";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "opentofu",
   version: "1.9.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/opentofu/opentofu/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/opentofu/opentofu.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function tofu(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/pcre2/brioche.lock
+++ b/packages/pcre2/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.44.tar.gz": {
-      "type": "sha256",
-      "value": "07a002e8216382a96f722bc4a831f3d77457fe3e9e62a6dff250a2dd0e9c5e6d"
+  "git_refs": {
+    "https://github.com/PCRE2Project/pcre2.git": {
+      "pcre2-10.44": "6ae58beca071f13ccfed31d03b3f479ab520639b"
     }
   }
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -1,15 +1,17 @@
 import * as std from "std";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "pcre2",
   version: "10.44",
 };
 
-const source = Brioche.download(
-  `https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/PCRE2Project/pcre2.git",
+    ref: `pcre2-${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   const pcre2 = std.runBash`

--- a/packages/ripgrep/brioche.lock
+++ b/packages/ripgrep/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.1.1.tar.gz": {
-      "type": "sha256",
-      "value": "4dad02a2f9c8c3c8d89434e47337aa654cb0e2aa50e806589132f186bf5c2b66"
+  "git_refs": {
+    "https://github.com/BurntSushi/ripgrep.git": {
+      "14.1.1": "4649aa9700619f94cf9c66876e9549d83420e16c"
     }
   }
 }

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "ripgrep",
   version: "14.1.1",
 };
 
-const source = Brioche.download(
-  `https://github.com/BurntSushi/ripgrep/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/BurntSushi/ripgrep.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/ruff/brioche.lock
+++ b/packages/ruff/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/astral-sh/ruff/archive/refs/tags/0.9.2.tar.gz": {
-      "type": "sha256",
-      "value": "d47a61bbbfceda23ddd29dd0c3cb3bb55f240e80a7aa0ba944e7f9f3f6ed886f"
+  "git_refs": {
+    "https://github.com/astral-sh/ruff.git": {
+      "0.9.2": "0a393483811e0999578b5655d82e2c03238296f3"
     }
   }
 }

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "ruff",
   version: "0.9.2",
 };
 
-const source = Brioche.download(
-  `https://github.com/astral-sh/ruff/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/astral-sh/ruff.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/terraform/brioche.lock
+++ b/packages/terraform/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/hashicorp/terraform/archive/refs/tags/v1.10.4.tar.gz": {
-      "type": "sha256",
-      "value": "5c37405e2203da140e7019c3ed44bef55a1a25dff9ce698903a9f07f20d75968"
+  "git_refs": {
+    "https://github.com/hashicorp/terraform.git": {
+      "v1.10.4": "369495a8601caad9c0b5052739db42f421bf1c03"
     }
   }
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { goBuild } from "go";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "terraform",
   version: "1.10.4",
 };
 
-const source = Brioche.download(
-  `https://github.com/hashicorp/terraform/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/hashicorp/terraform.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/tokei/brioche.lock
+++ b/packages/tokei/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/XAMPPRocky/tokei/archive/refs/tags/v12.1.2.tar.gz": {
-      "type": "sha256",
-      "value": "81ef14ab8eaa70a68249a299f26f26eba22f342fb8e22fca463b08080f436e50"
+  "git_refs": {
+    "https://github.com/XAMPPRocky/tokei.git": {
+      "v12.1.2": "7e0b30ff4c1fe78fe2cc615d1f0f52c7ce6cb761"
     }
   }
 }

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "tokei",
   version: "12.1.2",
 };
 
-const source = Brioche.download(
-  `https://github.com/XAMPPRocky/tokei/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/XAMPPRocky/tokei.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/xplr/brioche.lock
+++ b/packages/xplr/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/sayanarijit/xplr/archive/refs/tags/v0.21.9.tar.gz": {
-      "type": "sha256",
-      "value": "345400c2fb7046963b2e0fcca8802b6e523e0fb742d0d893cb7fd42f10072a55"
+  "git_refs": {
+    "https://github.com/sayanarijit/xplr.git": {
+      "v0.21.9": "a82ea6a3e5eb9bb2e528d2a3320056acfe312101"
     }
   }
 }

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "xplr",
   version: "0.21.9",
 };
 
-const source = Brioche.download(
-  `https://github.com/sayanarijit/xplr/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/sayanarijit/xplr.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/xsv/brioche.lock
+++ b/packages/xsv/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/BurntSushi/xsv/archive/refs/tags/0.13.0.tar.gz": {
-      "type": "sha256",
-      "value": "2b75309b764c9f2f3fdc1dd31eeea5a74498f7da21ae757b3ffd6fd537ec5345"
+  "git_refs": {
+    "https://github.com/BurntSushi/xsv.git": {
+      "0.13.0": "2b4cbaa0eecf7b507a612632fe00289b1b358c15"
     }
   }
 }

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "xsv",
   version: "0.13.0",
 };
 
-const source = Brioche.download(
-  `https://github.com/BurntSushi/xsv/archive/refs/tags/${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/BurntSushi/xsv.git",
+    ref: `${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/zoxide/brioche.lock
+++ b/packages/zoxide/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v0.9.6.tar.gz": {
-      "type": "sha256",
-      "value": "e1811511a4a9caafa18b7d1505147d4328b39f6ec88b88097fe0dad59919f19c"
+  "git_refs": {
+    "https://github.com/ajeetdsouza/zoxide.git": {
+      "v0.9.6": "3d3267b4fd73e6292d317f96d60ef69ea035912d"
     }
   }
 }

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -1,16 +1,18 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
 
 export const project = {
   name: "zoxide",
   version: "0.9.6",
 };
 
-const source = Brioche.download(
-  `https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v${project.version}.tar.gz`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/ajeetdsouza/zoxide.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({


### PR DESCRIPTION
Prefer usage of gitCheckout() + Brioche.gitRef() instead of downloading directly the tarball file for packages available on Github. See this discussion for more information: https://github.com/brioche-dev/brioche-packages/discussions/176

Two packages have not been migrated:

- git
- openssl

Since both are used for the command gitCheckout(), which make me wonder how we could resolve this circular dependency other than doing the solution (1) of the discussion.