### PR TITLE
Add `libffi` package

### DIFF
--- a/packages/libffi/brioche.lock
+++ b/packages/libffi/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz": {
+      "type": "sha256",
+      "value": "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
+    }
+  }
+}

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -1,0 +1,29 @@
+import * as std from "std";
+
+export const project = {
+  name: "libffi",
+  version: "3.4.6",
+};
+
+const source = Brioche.download(
+  `https://github.com/libffi/libffi/releases/download/v${project.version}/libffi-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  const libffi = std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  return std.setEnv(libffi, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+}

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -56,7 +56,16 @@ export default async function python() {
     dynamicBinaryConfig: {
       // Listing the modules both under `extraLibraries` and `skipLibraries`
       // forces Python to be linked with the modules' transitive dependencies
-      extraLibraries: nativeModules,
+      extraLibraries: [
+        ...nativeModules,
+
+        // Extra libraries used for FFI (needed for e.g. `aws_cli`)
+        // TODO: Figure out when/where/why these are used and how to simplify!
+        "librt.so.1",
+        "libpthread.so.0",
+        "libgcc_s.so.1",
+        "libdl.so.2",
+      ],
       skipLibraries: nativeModules,
       libraryPaths: [
         std.glob(python, ["lib/python*/lib-dynload"]).peel(3),

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -1,4 +1,5 @@
 import * as std from "std";
+import libffi from "libffi";
 import openssl from "openssl";
 import sqlite from "sqlite";
 
@@ -28,7 +29,7 @@ export default async function python() {
     python3 -m ensurepip --default-pip
   `
     .workDir(source)
-    .dependencies(std.toolchain(), openssl(), sqlite())
+    .dependencies(std.toolchain(), libffi(), openssl(), sqlite())
     .toDirectory();
 
   // Get all the native Python modules


### PR DESCRIPTION
This PR adds a new package for [libffi](https://github.com/libffi/libffi), a library for FFI (foreign function interface) calls.

The main motivation here was to include support for Python, so I went ahead and updated Python. This was as simple as adding libffi as a dependency during the Python build-- the `configure` script auto-detects it. I also updated the Python build to link in a few extra native libraries. I noticed these libraries were required while working on packaging AWS CLI (which uses libffi), and these all seemed like common, low-level libraries, so I thought it made sense to add them to Python by default.

Later, we should probably work backwards and figure out _where_ these libraries are being used, and figure out if we can auto-detect them too.