### PR TITLE
Update Python to support both v3.12 and v3.13 builds

### DIFF
--- a/packages/python/brioche.lock
+++ b/packages/python/brioche.lock
@@ -1,6 +1,10 @@
 {
   "dependencies": {},
   "downloads": {
+    "https://www.python.org/ftp/python/3.12.8/Python-3.12.8.tar.xz": {
+      "type": "sha256",
+      "value": "c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e"
+    },
     "https://www.python.org/ftp/python/3.13.1/Python-3.13.1.tar.xz": {
       "type": "sha256",
       "value": "9cf9427bee9e2242e3877dd0f6b641c1853ca461f39d6503ce260a59c80bf0d9"

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -5,15 +5,53 @@ import sqlite from "sqlite";
 export const project = {
   name: "python",
   version: "3.13.1",
+  extra: {
+    currentMinorVersion: "3.13",
+    minorVersions: {
+      "3.13": "3.13.1",
+      "3.12": "3.12.8",
+    },
+  },
 };
 
-const source = Brioche.download(
-  `https://www.python.org/ftp/python/${project.version}/Python-${project.version}.tar.xz`,
-)
-  .unarchive("tar", "xz")
-  .peel();
+std.assert(
+  project.extra.currentMinorVersion in project.extra.minorVersions,
+  "Python package extra.currentVersion not found in extra.minorVersions",
+);
+std.assert(
+  Object.keys(project.extra.minorVersions).some((minorVersion) =>
+    project.version.startsWith(`${minorVersion}.`),
+  ),
+  "Python package version not found in extra.minorVersions",
+);
 
-export default async function python() {
+type PythonVersion = keyof typeof project.extra.minorVersions;
+
+const sources: { [version: string]: std.Recipe<std.File> } = {
+  "3.12": Brioche.download(
+    `https://www.python.org/ftp/python/${project.extra.minorVersions["3.12"]}/Python-${project.extra.minorVersions["3.12"]}.tar.xz`,
+  ),
+  "3.13": Brioche.download(
+    `https://www.python.org/ftp/python/${project.version}/Python-${project.version}.tar.xz`,
+  ),
+} satisfies Record<PythonVersion, std.Recipe<std.File>>;
+
+interface PythonOptions {
+  version?: PythonVersion;
+}
+
+export default async function python(options: PythonOptions = {}) {
+  const { version = project.extra.currentMinorVersion } = options;
+
+  // Get the Python source for the selected version
+  const source = sources[version]?.unarchive("tar", "xz").peel();
+  std.assert(
+    source != null,
+    `Expected Python version ${JSON.stringify(
+      version,
+    )} to be one of ${JSON.stringify(Object.keys(sources))}`,
+  );
+
   let python = std.runBash`
     export LD_LIBRARY_PATH="$LIBRARY_PATH"
     export PATH="$BRIOCHE_OUTPUT/bin\${PATH:+:$PATH}"
@@ -97,11 +135,22 @@ export default async function python() {
 }
 
 export function test() {
-  return std.runBash`
-    python --version | tee -a "$BRIOCHE_OUTPUT"
-    pip --version | tee -a "$BRIOCHE_OUTPUT"
-    python-config --cflags --libs --ldflags | tee -a "$BRIOCHE_OUTPUT"
-  `.dependencies(python());
+  const pythonVersions = Object.keys(
+    project.extra.minorVersions,
+  ) as PythonVersion[];
+
+  const tests = pythonVersions.map((version) => {
+    return std.runBash`
+      mkdir "$BRIOCHE_OUTPUT"
+      python --version | tee "$BRIOCHE_OUTPUT/python-version.txt"
+      pip --version | tee "$BRIOCHE_OUTPUT/pip-version.txt"
+      python-config --cflags --libs --ldflags | tee "$BRIOCHE_OUTPUT/python-config.txt"
+    `
+      .dependencies(python({ version }))
+      .toDirectory();
+  });
+
+  return std.merge(...tests);
 }
 
 async function fixShebangs(


### PR DESCRIPTION
This PR updates the `python` package to take an optional `version` option as an input. It can be set to either `3.12` or `3.13`, and will return a recipe for the corresponding Python version.

This is a temporary measure until https://github.com/brioche-dev/brioche/issues/97 is resolved. In the meantime, I found that the AWS CLI isn't compatible with Python 3.13, so it seemed worthwhile to manually add support for using a specific version for Python.