### PR TITLE
Add `aws_cli` package

### DIFF
--- a/packages/aws_cli/brioche.lock
+++ b/packages/aws_cli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/aws/aws-cli.git": {
+      "2.23.7": "81168857bbf1ae97c243cce8b61515077ef0e316"
+    }
+  }
+}

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -1,0 +1,144 @@
+import * as std from "std";
+import python from "python";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "aws_cli",
+  version: "2.23.7",
+};
+
+const source = std.recipeFn(() => {
+  const source = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/aws/aws-cli.git",
+      ref: project.version,
+    }),
+  );
+  const patch = Brioche.includeFile("resolved-lockfiles.patch");
+
+  // Patch the source to fix unresolvable `packaging` dependencies
+  // across `requirements*.txt` files
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    patch -p1 < $patch
+  `
+    .outputScaffold(source)
+    .env({ patch })
+    .toDirectory();
+});
+
+export default function awsCli(): std.Recipe<std.Directory> {
+  // Create a venv for aws-cli
+  let venv = std.recipe(python({ version: "3.12" }));
+
+  // Download dependencies from PyPI
+  // SAFETY: the `requirements-*-lock.txt` files have hashes, and the
+  // `--require-hashes` flag ensures we use hashes to verify dependencies
+  const dependencies = std.runBash`
+    pip download --require-hashes \\
+      -r requirements-base-lock.txt \\
+      -r requirements-dev-lock.txt \\
+      -r requirements-docs-lock.txt \\
+      -d "$BRIOCHE_OUTPUT"
+  `
+    .workDir(
+      std.glob(source, [
+        "requirements-base-lock.txt",
+        "requirements-dev-lock.txt",
+        "requirements-docs-lock.txt",
+      ]),
+    )
+    .dependencies(venv)
+    .unsafe({ networking: true })
+    .toDirectory();
+
+  // Install dependencies into the venv
+  venv = std.runBash`
+    pip install --require-hashes \\
+      -r requirements-base-lock.txt \\
+      -r requirements-dev-lock.txt \\
+      -r requirements-docs-lock.txt
+  `
+    .workDir(
+      std.glob(source, [
+        "requirements-base-lock.txt",
+        "requirements-dev-lock.txt",
+        "requirements-docs-lock.txt",
+      ]),
+    )
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_NO_INDEX: "1",
+      PIP_FIND_LINKS: dependencies,
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Install aws-cli into the venv
+  venv = std.runBash`
+    pip install .
+  `
+    .workDir(source)
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_NO_INDEX: "1",
+      PIP_FIND_LINKS: dependencies,
+      LD_LIBRARY_PATH: std.tpl`${std.toolchain()}/lib`,
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Create the final recipe with the venv under `venv`
+  let recipe = std.directory({
+    venv,
+  });
+
+  // Add `bin/aws` to run the main script
+  recipe = std.addRunnable(recipe, "bin/aws", {
+    command: { relativePath: "venv/bin/python" },
+    args: [{ relativePath: "venv/bin/aws" }],
+  });
+  return std.withRunnableLink(recipe, "bin/aws");
+}
+
+export async function test() {
+  const script = std.runBash`
+    aws --version | tr -d '\n' | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(awsCli());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `aws-cli/${project.version} `;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}

--- a/packages/aws_cli/resolved-lockfiles.patch
+++ b/packages/aws_cli/resolved-lockfiles.patch
@@ -1,0 +1,47 @@
+diff --git a/requirements-dev-lock.txt b/requirements-dev-lock.txt
+index a7a849fb9..5cd1c7e62 100644
+--- a/requirements-dev-lock.txt
++++ b/requirements-dev-lock.txt
+@@ -131,16 +131,10 @@ macholib==1.16.3 \
+     --hash=sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30 \
+     --hash=sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c
+     # via pyinstaller
+-packaging==24.1 \
+-    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
+-    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+-    # via
+-    #   -r requirements-test.txt
+-    #   build
+-    #   pyinstaller-hooks-contrib
+-    #   pyproject-api
+-    #   pytest
+-    #   tox
++packaging==24.2 \
++    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
++    --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
++    # (manually patched)
+ pefile==2023.2.7 \
+     --hash=sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc \
+     --hash=sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6
+diff --git a/requirements-test-lock.txt b/requirements-test-lock.txt
+index b838c3940..c891e0e86 100644
+--- a/requirements-test-lock.txt
++++ b/requirements-test-lock.txt
+@@ -97,13 +97,10 @@ jsonschema==4.7.2 \
+     --hash=sha256:73764f461d61eb97a057c929368610a134d1d1fffd858acfe88864ee94f1f1d3 \
+     --hash=sha256:c7448a421b25e424fccfceea86b4e3a8672b4436e1988ccbde92c80828d4f085
+     # via -r requirements-test.txt
+-packaging==24.1 \
+-    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
+-    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+-    # via
+-    #   -r requirements-test.txt
+-    #   build
+-    #   pytest
++packaging==24.2 \
++    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
++    --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
++    # (manually patched)
+ pip-tools==7.0.0 \
+     --hash=sha256:6a2308712727c86cc8a6cedc0e6ba01232a337c706d63926d3789462ad083d06 \
+     --hash=sha256:ae185db747195c8ed011866c366279cbb64f7f8c1528e7a828f515bd2bb0b31b


### PR DESCRIPTION
This PR adds a new package for the [AWS CLI](https://github.com/aws/aws-cli): the Amazon Web Services Command Line Interface.

This one ended up being trickier than expected, for 3 reasons:

1. It (currently) requires Python 3.12. I updated `python` to support both v3.12 and v3.13 in #216 
2. It builds a native dependency, and requires libffi. I added a new `libffi` package and linked it to Python in #215
3. It has `requirements.txt` files that include hashes, but there are conflicting requirements around the `packaging` dependency (this only applies to the `requirements-*-lock.txt` files I believe, the standard `requirements.txt` file shouldn't have this problem but also doesn't have hashes). I solved this with a small patch file to resolve `packaging` to v24.2, which was the latest version used across all the files.

The actual packaging code was based heavily on the `asciinema` package. It'd be nice to write a general `pythonInstall()` function or something, but at least `asciinema` and `aws_cli` are different enough that I don't feel that it'd be easy to generalize them. My gut instinct is it'd be better to support a newer package manager first, such as `uv`.