### PR TITLE
Fix git repo URL to fix `carapace` build

### DIFF
--- a/packages/carapace/brioche.lock
+++ b/packages/carapace/brioche.lock
@@ -1,8 +1,8 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/carapace-sh/carapace.git": {
-      "v1.1.1": "74167cbe2c66c0bbd8a11c5adcd58ec68b1be337"
+    "https://github.com/carapace-sh/carapace-bin.git": {
+      "v1.1.1": "08c3a82ad974e6904329b6b674670689da068d81"
     }
   }
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -9,7 +9,7 @@ export const project = {
 
 const source = gitCheckout(
   Brioche.gitRef({
-    repository: "https://github.com/carapace-sh/carapace.git",
+    repository: "https://github.com/carapace-sh/carapace-bin.git",
     ref: `v${project.version}`,
   }),
 );


### PR DESCRIPTION
Followup to #214, it seems like the git repo URL `https://github.com/carapace-sh/carapace.git` was used, where it should be `https://github.com/carapace-sh/carapace-bin.git`. I missed that during the review!

Verified locally that the build works with the adjusted repo URL