### PR TITLE
[eza] Update to v0.20.20

### DIFF
--- a/packages/eza/brioche.lock
+++ b/packages/eza/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/eza-community/eza.git": {
-      "v0.20.17": "2353c15e2fc091e74a813cc90463bfffe67d50e3"
+      "v0.20.20": "745444b68ffa3bb6489eb7c042b9d618d28648cd"
     }
   }
 }

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
 import { gitCheckout } from "git";
+import nushell from "nushell";
 
 export const project = {
   name: "eza",
@@ -14,9 +15,52 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function eza(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/eza",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n "$(eza --version)" | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(eza());
+  const output = await script.toFile().read();
+
+  const version = output
+    .split("\n")
+    .flatMap((line) => {
+      const versionMatch = line.match(/^v([^\s]+)/);
+      if (versionMatch == null) {
+        return [];
+      }
+      const version = versionMatch[1];
+      return version != null ? [version] : [];
+    })
+    .at(0);
+
+  std.assert(
+    version === project.version,
+    `expected version ${project.version}, got ${version}`,
+  );
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/eza-community/eza/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
   });
 }

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -4,7 +4,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "eza",
-  version: "0.20.17",
+  version: "0.20.20",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
This PR updates eza to the latest release of v0.20.0. I also added `test` and `autoUpdate` functions for https://github.com/brioche-dev/brioche/issues/94 and https://github.com/brioche-dev/brioche/issues/165.