### PR TITLE
fix(autoUpdate): correct JSON parsing and date formatting in release data retrieval

### DIFF
--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -47,7 +47,7 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let releaseData = (http get https://api.github.com/repos/cli/cli/releases/latest | from json)
+    let releaseData = http get https://api.github.com/repos/cli/cli/releases/latest
 
     let version = $releaseData
       | get tag_name
@@ -56,7 +56,7 @@ export function autoUpdate() {
     let latestBuildDate = $releaseData
       | get created_at
       | into datetime
-      | date format "%Y-%m-%d"
+      | format date "%Y-%m-%d"
 
     $env.project
       | from json


### PR DESCRIPTION
Fix the following errors:

```bash
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[/home/container/.local/share/brioche/locals/9d8325ca9f10271621f4751d9e527987e5995f518d792adff863613d93ea2209/brioche-run.d/recipe-0:1:29]
 1 │ let releaseData = (http get https://api.github.com/repos/cli/cli/releases/latest | from json)
   ·                             ──────────────────────────┬─────────────────────────
   ·                                                       ╰── string
 2 │
   ╰────
```

```bash
  × Removed command: date format
    ╭─[/home/container/.local/share/brioche/locals/f8274885199553a1ee910c27d5e60468e5b72e73da706fba45803f69d55a9b0a/brioche-run.d/recipe-0:10:5]
  9 │   | into datetime
 10 │   | date format "%Y-%m-%d"
    ·     ─────┬─────
    ·          ╰── 'date format' has been removed from Nushell. Please use 'format date' instead.
 11 │
    ╰────
```