### PR TITLE
[Rust] Update to v1.85.0

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -5,9 +5,9 @@
       "type": "sha256",
       "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
     },
-    "https://static.rust-lang.org/dist/channel-rust-1.84.0.toml": {
+    "https://static.rust-lang.org/dist/channel-rust-1.85.0.toml": {
       "type": "sha256",
-      "value": "94c2c0ba9c6783815df45d680f0f20c7ea80d11b85ee8bbbc61354f3082cd0f5"
+      "value": "009e8b5ff43f12bf644b5e5b9fd89f96453072062a450c623882f64e85405da5"
     }
   }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -5,7 +5,7 @@ import caCertificates from "ca_certificates";
 
 export const project = {
   name: "rust",
-  version: "1.84.0",
+  version: "1.85.0",
 };
 
 const ManifestPkgTarget = t.discriminatedUnion("available", [

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -29,12 +29,6 @@ const Manifest = t.object({
   profiles: t.record(t.string(), t.array(t.string())),
 });
 
-export function test() {
-  return std.runBash`
-    cargo --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(rust());
-}
-
 /**
  * The main Rust recipe. Returns a recipe containing the following:
  *
@@ -43,7 +37,7 @@ export function test() {
  *
  * ...among other binaries.
  */
-async function rust(): Promise<std.Recipe<std.Directory>> {
+export default async function rust(): Promise<std.Recipe<std.Directory>> {
   const manifestToml = await Brioche.download(
     `https://static.rust-lang.org/dist/channel-rust-${project.version}.toml`,
   ).read();
@@ -111,7 +105,20 @@ async function rust(): Promise<std.Recipe<std.Directory>> {
   });
   return result;
 }
-export default rust;
+
+export async function test() {
+  const script = std.runBash`
+    rustc --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust())
+    .toFile();
+  const versionOutput = await script.read().then((output) => output.trim());
+  std.assert(
+    versionOutput.startsWith(`rustc ${project.version} `),
+    `expected ${project.version}, got ${JSON.stringify(versionOutput)}`,
+  );
+  return script;
+}
 
 interface CargoBuildParameters {
   features?: string[];


### PR DESCRIPTION
This PR upgrades the `rust` package to v1.85.0. I also cleaned up the test script a bit-- it now validates the version number when running `rustc --version`