### PR TITLE
[jujutsu] Update to v0.26.0

### DIFF
--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/martinvonz/jj.git": {
-      "v0.25.0": "041c4fecb77434dd6720e7d7f1ce48d9575ac5f7"
+      "v0.26.0": "613742dfbbd89324b25672a75ef8ce9e671ae0d3"
     }
   }
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "jujutsu",
-  version: "0.25.0",
+  version: "0.26.0",
 };
 
 const source = gitCheckout(

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -2,6 +2,7 @@ import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
 import { gitCheckout } from "git";
+import nushell from "nushell";
 
 export const project = {
   name: "jujutsu",
@@ -15,11 +16,45 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function jujutsu(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/jj",
     path: "cli",
     dependencies: [openssl()],
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    jj version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(jujutsu());
+
+  const version = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expectedVersion = `jj ${project.version}`;
+  std.assert(
+    version === expectedVersion,
+    `expected '${expectedVersion}', got '${version}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/jj-vcs/jj/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
   });
 }


### PR DESCRIPTION
This PR updates the `jujutsu` (jj) package to v0.26.0. I also added `test` and `autoUpdate` functions for https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165