### PR TITLE
[rust] Update `cargo-chef`

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
       "type": "sha256",
-      "value": "91b518df5c8b02775026875f3aadef1946464354db1ca0758e4912249578f0bc"
+      "value": "bc601a12f1e086a995690e9eed86353b23d9e0429509bfaae1db2e39b41cde52"
     },
     "https://static.rust-lang.org/dist/channel-rust-1.85.0.toml": {
       "type": "sha256",

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -301,7 +301,7 @@ export function vendorCrate(
 
 function cargoChef(): std.Recipe<std.Directory> {
   const pkg = Brioche.download(
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.67/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
+    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
   );
 
   return std.directory({

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -267,7 +267,7 @@ export function vendorCrate(
     mkdir -p .cargo
 
     # If the crate has a .cargo/config file, then move it to .cargo/config.toml
-    # Cargo prefers the config over config.toml, so we need to rename it
+    # Cargo prefers config over config.toml, so we need to rename it
     # to avoid any conflicts. It will still need to be removed from the merged
     # crate later too
     if [ -f .cargo/config ]; then
@@ -276,7 +276,11 @@ export function vendorCrate(
 
     # Always add a newline in case the file already exists and
     # doesn't end with a newline
-    echo $'\n'"$(cargo vendor --locked)" >> .cargo/config.toml
+    echo >> .cargo/config.toml
+
+    # Vendor the dependencies, and update the config to use the
+    # vendored dependencies
+    cargo vendor --locked >> .cargo/config.toml
   `
     .dependencies(rust(), caCertificates())
     .outputScaffold(skeletonCrate)

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -7,12 +7,23 @@ export const project = {
   version: "0.21.9",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/sayanarijit/xplr.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = (() => {
+  let source = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/sayanarijit/xplr.git",
+      ref: `v${project.version}`,
+    }),
+  );
+
+  // HACK: Workaround for https://github.com/LukeMathWalker/cargo-chef/issues/295#issuecomment-2619963413
+  source = std.runBash`
+    sed -i "s|path = './benches/|path = 'benches/|g" "$BRIOCHE_OUTPUT/Cargo.toml"
+  `
+    .outputScaffold(source)
+    .toDirectory();
+
+  return source;
+})();
 
 export default function (): std.Recipe<std.Directory> {
   return cargoBuild({


### PR DESCRIPTION
This PR updates the version of `cargo-chef` (used for vendoring Cargo dependencies) used in the `rust` package from v0.1.67 to v0.1.71.

From my testing it seems like v0.1.67 doesn't support Rust 2024 edition, which we need to update Brioche itself to Rust 2024 (https://github.com/brioche-dev/brioche/pull/197). I also verified that v0.1.71 works.

We rolled back the last upgrade of `cargo-chef` (#177, rolled back in #189) due to an upstream issue that caused the build of the `xplr` package to fail. It seems like that issue is still open, so I decided to work around it for now by patching the `Cargo.toml` file in `xplr`.