### PR TITLE
fix: update autoUpdate function to fetch latest version from restic repository instead of ripgrep

### DIFF
--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -39,7 +39,7 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/BurntSushi/ripgrep/releases/latest
+    let version = http get https://api.github.com/repos/restic/restic/releases/latest
       | get tag_name
       | str replace --regex '^v' ''
 


### PR DESCRIPTION
This PR includes a small but important change to the `autoUpdate` function in the `packages/restic/project.bri` file. The change updates the URL used to fetch the latest release version