### PR TITLE
[aws_cli] Fix build error and update to v2.24.17

### DIFF
--- a/packages/aws_cli/brioche.lock
+++ b/packages/aws_cli/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/aws/aws-cli.git": {
-      "2.24.15": "eb46f4810bae9248491909d7718c2a627f025e10"
+      "2.24.17": "af27bc220808f50dfec3002b594801bc2ec4499a"
     }
   }
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -75,6 +75,11 @@ export default function awsCli(): std.Recipe<std.Directory> {
     .outputScaffold(venv)
     .toDirectory();
 
+  // Fix shebangs in the venv. `pip install` could install a new version of
+  // pip (depending on the requirements file), which can re-introduce a
+  // shebang script that we need to re-fix
+  venv = std.recipe(fixShebangs(venv));
+
   // Install aws-cli into the venv
   venv = std.runBash`
     pip install .
@@ -141,4 +146,73 @@ export function autoUpdate() {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell()],
   });
+}
+
+// Copied from `python.fixShebangs`
+async function fixShebangs(
+  recipe: std.Recipe<std.Directory>,
+): Promise<std.Recipe<std.Directory>> {
+  // Get all Python shebang scripts under `bin/`. We assume _all_ shebang
+  // scripts we can find are Python scripts, except for `python-config`. This
+  // is because Python may install shebang scripts using `#!/bin/sh` when
+  // paths are long, so they won't necessarily have a shebang to call Python
+  // directly. See this function from Pip:
+  // https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_vendor/distlib/scripts.py#L154
+  const pythonShebangPathList = await std.runBash`
+    cd "$recipe"
+    find bin ! -name 'python*-config' -type f -executable \\
+    | while read file; do
+      if [[ "$(head -c 2 "$file")" == '#!' ]]; then
+        echo "$file" >> "$BRIOCHE_OUTPUT"
+      fi
+    done
+  `
+    .env({ recipe })
+    .toFile()
+    .read();
+  const pythonShebangPaths = pythonShebangPathList
+    .split("\n")
+    .filter((line) => line !== "");
+
+  // Get the list of shebang shell scripts. We only handle the `python-config`
+  // script.
+  const shellShebangPathList = await std.runBash`
+    cd "$recipe"
+    find bin -name 'python*-config' -type f -executable \\
+    | while read file; do
+      if [[ "$(head -c 2 "$file")" == '#!' ]]; then
+        echo "$file" >> "$BRIOCHE_OUTPUT"
+      fi
+    done
+  `
+    .env({ recipe })
+    .toFile()
+    .read();
+  const shellShebangPaths = shellShebangPathList
+    .split("\n")
+    .filter((line) => line !== "");
+
+  // Wrap each Python script using `std.addRunnable()`
+  const pythonWrappedShebangs = pythonShebangPaths.map((path) => {
+    return std.addRunnable(std.directory(), path, {
+      command: { relativePath: "bin/python" },
+      args: [[std.glob(recipe, [path]), `/${path}`]],
+    });
+  });
+
+  // Update each shell script by using `#!/usr/bin/env sh`. We can't
+  // use `std.addRunnable()` because `python-config` is sensitive to its
+  // path on disk.
+  const fixedShellShebangs = shellShebangPaths.map((path) => {
+    const fixedFile = std.runBash`
+      echo '#!/usr/bin/env sh' > "$BRIOCHE_OUTPUT"
+      tail -n+2 "$file" >> "$BRIOCHE_OUTPUT"
+      chmod +x "$BRIOCHE_OUTPUT"
+    `
+      .env({ file: recipe.get(path) })
+      .toFile();
+    return std.directory().insert(path, fixedFile);
+  });
+
+  return std.merge(recipe, ...pythonWrappedShebangs, ...fixedShellShebangs);
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "aws_cli",
-  version: "2.24.15",
+  version: "2.24.17",
 };
 
 const source = std.recipeFn(() => {


### PR DESCRIPTION
This PR fixes the build failure seen in [CI#611](https://github.com/brioche-dev/brioche-packages/actions/runs/13648116439), which manifested with this error:

```sh-session
$ brioche jobs logs ./01JNG382C31M5ZXEG4TH95YJ2K/events.bin.zst
process stack trace:
- file:///home/runner/_work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:202:14
- file:///home/runner/_work/brioche-packages/brioche-packages/packages/aws_cli/project.bri:89:6

[0.00s] [spawned process with pid 30785, preparation took 0.01s]
[0.01s] /home/brioche-runner-82a412d8707a3bbc5ee98bb1058e1915e1df3b505bf079b9d3e908579015a223/.local/share/brioche/outputs/output-82a412d8707a3bbc5ee98bb1058e1915e1df3b505bf079b9d3e908579015a223/bin/pip: 2: exec: /home/brioche-runner-1abf9068b6b9fde6e4df870738b786b31a7ea3bbfd408522ad2b2554c943d9ef/.local/share/brioche/outputs/output-1abf9068b6b9fde6e4df870738b786b31a7ea3bbfd408522ad2b2554c943d9ef/bin/python: not found
[0.01s] [process exited with code 127]
```

#250 upgraded from `aws_cli` v2.23.7 to v2.24.15, so I first narrowed it down to a failure that started as of [v2.23.10](https://github.com/aws/aws-cli/compare/2.23.9..2.23.10). During that release, the `requirements*.txt` files were updated, including a bump to the pip package.

This new requirement caused pip to install a new version of pip, which replaced our [manually wrapped shebang scripts](https://github.com/brioche-dev/brioche-packages/blob/27354b107c885f3c8ae5e1ff9c82d527c54c2c2b/packages/python/project.bri#L124-L126) with a new, broken shebang script for pip itself.

As a temporary workaround, I copied the `python.fixShebangs` function into the `aws_cli` package and used it to re-patch the shebang script after running `pip install`.

---

While making this change, I also updated `aws_cli` from v2.24.15 to v2.24.17 since I saw there were a few new releases