### PR TITLE
[pcre2] Fix build failure

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -32,9 +32,14 @@ export default function git(): std.Recipe<std.Directory> {
   return git;
 }
 
-interface GitCheckoutOptions {
+interface GitCheckoutInit {
   repository: string;
   commit: string;
+  options?: GitCheckoutOptions;
+}
+
+interface GitCheckoutOptions {
+  submodules?: boolean;
 }
 
 /**
@@ -49,6 +54,7 @@ interface GitCheckoutOptions {
  *
  * - `repository`: The URL of the git repository to checkout.
  * - `commit`: The full commit hash to checkout.
+ * - `submodules`: Set to true to recursively checkout git submodules too.
  *
  * ## Example
  *
@@ -67,10 +73,12 @@ interface GitCheckoutOptions {
  * ```
  */
 export function gitCheckout(
-  options: std.Awaitable<GitCheckoutOptions>,
+  init: std.Awaitable<GitCheckoutInit>,
+  options: GitCheckoutOptions = {},
 ): std.Recipe<std.Directory> {
   return std.recipeFn(async () => {
-    const { commit, repository } = await options;
+    const { commit, repository, options: initOptions } = await init;
+    options = { ...initOptions, ...options };
 
     // Validate that the commit is a hash
     std.assert(
@@ -80,7 +88,7 @@ export function gitCheckout(
 
     // Clone and fetch only the specified commit. See this article:
     // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
-    return std.runBash`
+    let repo = std.runBash`
       cd "$BRIOCHE_OUTPUT"
       git -c init.defaultBranch=main init
       git remote add origin "$repository"
@@ -95,5 +103,18 @@ export function gitCheckout(
       .outputScaffold(std.directory())
       .unsafe({ networking: true })
       .toDirectory();
+
+    if (options.submodules === true) {
+      repo = std.runBash`
+        cd "$BRIOCHE_OUTPUT"
+        git submodule update --init --recursive
+      `
+        .dependencies(git(), caCertificates())
+        .outputScaffold(repo)
+        .unsafe({ networking: true })
+        .toDirectory();
+    }
+
+    return repo;
   });
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -7,12 +7,14 @@ export const project = {
   version: "10.45",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/PCRE2Project/pcre2.git",
-    ref: `pcre2-${project.version}`,
-  }),
-);
+const gitRef = Brioche.gitRef({
+  repository: "https://github.com/PCRE2Project/pcre2.git",
+  ref: `pcre2-${project.version}`,
+});
+
+const source = gitCheckout(gitRef, {
+  submodules: true,
+});
 
 export default function (): std.Recipe<std.Directory> {
   const pcre2 = std.runBash`


### PR DESCRIPTION
This PR fixes the build failure seen in [CI#613](https://github.com/brioche-dev/brioche-packages/actions/runs/13671340922), which manifested with the following error:

```
[22.66s]   CC       src/libpcre2_8_la-pcre2_compile_class.lo
[25.52s]   CC       src/libpcre2_8_la-pcre2_config.lo
[25.72s]   CC       src/libpcre2_8_la-pcre2_context.lo
[26.16s]   CC       src/libpcre2_8_la-pcre2_convert.lo
[28.93s]   CC       src/libpcre2_8_la-pcre2_dfa_match.lo
[37.47s]   CC       src/libpcre2_8_la-pcre2_error.lo
[37.66s]   CC       src/libpcre2_8_la-pcre2_extuni.lo
[38.13s]   CC       src/libpcre2_8_la-pcre2_find_bracket.lo
[38.37s]   CC       src/libpcre2_8_la-pcre2_jit_compile.lo
[38.43s] src/pcre2_jit_compile.c:85:10: fatal error: ../deps/sljit/sljit_src/sljitLir.c: No such file or directory
[38.43s]    85 | #include "../deps/sljit/sljit_src/sljitLir.c"
[38.43s]       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[38.43s] compilation terminated.
[38.44s] make[1]: *** [Makefile:2707: src/libpcre2_8_la-pcre2_jit_compile.lo] Error 1
[38.44s] make[1]: Leaving directory '/home/brioche-runner-041ef9cb0d6e4662fb626491467ec2babd69b746c262364eeaf6bb18df5e5b51/work'
[38.44s] make: *** [Makefile:1581: all] Error 2
[38.44s] [process exited with code 2]
```

Turns out that, in the version bump from v10.44 to v10.45 (#252), pcre2 added a git submodule. We didn't have a way to handle those today, so I updated the `git.gitCheckout` function with a new `submodules` option. When set, it automatically calls `git submodule update --init --recursive` to initialize and checkout all included submodules.