### PR TITLE
Add `icu` package

### DIFF
--- a/packages/icu/brioche.lock
+++ b/packages/icu/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/unicode-org/icu/releases/download/release-77-1/icu4c-77_1-src.tgz": {
+      "type": "sha256",
+      "value": "588e431f77327c39031ffbb8843c0e3bc122c211374485fa87dc5f3faff24061"
+    }
+  }
+}

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -61,6 +61,29 @@ export default function icu(): std.Recipe<std.Directory> {
   return icu;
 }
 
+export async function test() {
+  const script = std.runBash`
+    icuinfo | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(icu());
+  const result = await script.toFile().read();
+
+  const version = result.match(/<param name="version">([^<]*)<\/param>/)?.at(1);
+  const returnCode = result
+    .match(/^ICU Initialization returned: (.*)$/m)
+    ?.at(1);
+
+  std.assert(
+    version === project.version,
+    `expected version number to be '${project.version}', got ${version}`,
+  );
+  std.assert(
+    returnCode === "U_ZERO_ERROR",
+    `expected icuinfo initialization to return U_ZERO_ERROR, got '${returnCode}'`,
+  );
+
+  return script;
+}
+
 export function autoUpdate() {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/unicode-org/icu/releases/latest

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -1,0 +1,73 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "icu",
+  version: "77.1",
+  extra: {
+    versionDash: "77-1",
+    versionUnderscore: "77_1",
+  },
+};
+
+std.assert(
+  project.extra.versionDash === project.version.replace(".", "-"),
+  `expected ICU 'project.extra.versionDash' field '${project.extra.versionDash}' to match version '${project.version}'`,
+);
+std.assert(
+  project.extra.versionUnderscore === project.version.replace(".", "_"),
+  `expected ICU 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
+);
+
+const source = Brioche.download(
+  `https://github.com/unicode-org/icu/releases/download/release-${project.extra.versionDash}/icu4c-${project.extra.versionUnderscore}-src.tgz`,
+).unarchive("tar", "gzip");
+
+export default function icu(): std.Recipe<std.Directory> {
+  let icu = std.runBash`
+    cd icu/source
+    ./runConfigureICU Linux \\
+      --prefix=/
+    make -j16
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+  icu = std.setEnv(icu, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+  return icu;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/unicode-org/icu/releases/latest
+
+    let versionDash = $releaseData
+      | get tag_name
+      | str replace --regex '^release-' ''
+
+    let versionUnderscore = $versionDash
+      | str replace '-' '_'
+
+    let version = $versionDash
+      | str replace '-' '.'
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.versionDash $versionDash
+      | update extra.versionUnderscore $versionUnderscore
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -34,11 +34,30 @@ export default function icu(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain())
     .toDirectory();
+
   icu = std.setEnv(icu, {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     CPATH: { append: [{ path: "include" }] },
     PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
+
+  // During the build, ICU uses "stub" libraries for compilation. Re-pack
+  // the artifact to use the final libraries after compilation instead
+  icu = std.autopack(icu, {
+    globs: ["bin/**", "lib/**"],
+    selfDependency: true,
+    dynamicBinaryConfig: {
+      enabled: true,
+    },
+    sharedLibraryConfig: {
+      enabled: true,
+      allowEmpty: true,
+    },
+    repackConfig: {
+      enabled: true,
+    },
+  });
+
   return icu;
 }
 


### PR DESCRIPTION
This PR adds a package for the [ICU4C](https://unicode-org.github.io/icu/userguide/icu4c/) library from the [Unicode ICU](https://icu.unicode.org/) project, including `test` and `autoUpdate` functions for https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165.

I went with the package name `icu`, even though the `default` export builds the "ICU4C" library from the greater ICU project (but also note: ICU4C is part of a larger monorepo that also includes ICU4J and some other files). This matches the naming convention [from Repology](https://repology.org/project/icu/versions), and additionally matches what most other package managers do. The biggest exceptions are Nix and Homebrew, both of which use the package name `icu4c`