### PR TITLE
Add `postgresql` package

### DIFF
--- a/packages/postgresql/brioche.lock
+++ b/packages/postgresql/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.postgresql.org/pub/source/v17.4/postgresql-17.4.tar.bz2": {
+      "type": "sha256",
+      "value": "c4605b73fea11963406699f949b966e5d173a7ee0ccaef8938dec0ca8a995fe7"
+    }
+  }
+}

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -3,6 +3,8 @@ import icu from "icu";
 import openssl from "openssl";
 import libxml from "libxml2";
 import libxslt from "libxslt";
+import nushell from "nushell";
+import curl from "curl";
 
 export const project = {
   name: "postgresql",
@@ -31,4 +33,42 @@ export default function postgresql(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain(), icu(), openssl(), libxml(), libxslt())
     .toDirectory();
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(postgres --version) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(postgresql());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `postgres (PostgreSQL) ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    # Get the URL that '/ftp/latest' redirects to. The resulting URL
+    # will have the version number at the end
+    let latestUrl = curl --proto '=https' --tlsv1.2 -fsSLI -o /dev/null 'https://www.postgresql.org/ftp/latest' -w '%{url_effective}'
+
+    let version = $latestUrl
+      | parse --regex '/ftp/source/v([\\d\\.]+)/?$'
+      | get 0.capture0
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell(), curl()],
+  });
 }

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -1,0 +1,34 @@
+import * as std from "std";
+import icu from "icu";
+import openssl from "openssl";
+import libxml from "libxml2";
+import libxslt from "libxslt";
+
+export const project = {
+  name: "postgresql",
+  version: "17.4",
+};
+
+const source = Brioche.download(
+  `https://ftp.postgresql.org/pub/source/v${project.version}/postgresql-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function postgresql(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-rpath \\
+      --with-zstd \\
+      --with-openssl \\
+      --with-uuid=e2fs \\
+      --with-libxml \\
+      --with-libxslt
+    make world-bin -j16
+    make install-world-bin DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain(), icu(), openssl(), libxml(), libxslt())
+    .toDirectory();
+}


### PR DESCRIPTION
This PR adds a package for [PostgreSQL](https://postgresql.org/), an open source relational database. I also added `test` and `autoUpdate` functions for https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165.

I enabled several of the optional features in the build with various flags when calling `./configure`-- mainly the ones that used dependencies we already have packaged. I think it'd be worthwhile to go through and enable more of these options over time.