### PR TITLE
Switch to new self-hosted GH Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build packages
     needs: [check]
     if: github.repository == 'brioche-dev/brioche-packages' && github.event_name == 'push' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/build/') )
-    runs-on: proxmox-runner-set
+    runs-on: brioche-dev-builder-runner
     timeout-minutes: 720
     steps:
       - name: Install system packages


### PR DESCRIPTION
This PR updates the runner label used for the "Build packages" job in CI GitHub Actions workflow. This is backed by new hardware that should be faster!