### PR TITLE
PostgreSQL improvements

### DIFF
--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -34,6 +34,8 @@ export default function postgresql(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain(), icu(), openssl(), libxml(), libxslt())
     .toDirectory();
 
+  postgresql = makePkgConfigPathsRelative(postgresql);
+
   postgresql = std.setEnv(postgresql, {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     CPATH: { append: [{ path: "include" }] },
@@ -79,4 +81,20 @@ export function autoUpdate() {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell(), curl()],
   });
+}
+
+// TODO: Figure out where to move this, this is copied from `std`
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std.runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
 }

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -18,7 +18,7 @@ const source = Brioche.download(
   .peel();
 
 export default function postgresql(): std.Recipe<std.Directory> {
-  return std.runBash`
+  let postgresql = std.runBash`
     ./configure \\
       --prefix=/ \\
       --disable-rpath \\
@@ -33,6 +33,14 @@ export default function postgresql(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain(), icu(), openssl(), libxml(), libxslt())
     .toDirectory();
+
+  postgresql = std.setEnv(postgresql, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+
+  return postgresql;
 }
 
 export async function test() {


### PR DESCRIPTION
This PR makes a few minor tweaks to the `postgresql` package:

- Use `std.setEnv` to set the `LIBRARY_PATH`, `CPATH`, and `PKG_CONFIG_PATH` env vars when used as a dependency (relates to #136)
- Patch pkg-config files (relates to #135)