### PR TITLE
Add `libtirpc` package

### DIFF
--- a/packages/libtirpc/brioche.lock
+++ b/packages/libtirpc/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "git://git.linux-nfs.org/projects/steved/libtirpc.git": {
+      "libtirpc-1-3-6": "cf7441f5b90f043308cc34ae8d25127aed844c92"
+    }
+  }
+}

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "libtirpc",
+  version: "1.3.6",
+  extra: {
+    versionTag: "libtirpc-1-3-6",
+  },
+};
+
+std.assert(
+  project.extra.versionTag ===
+    `libtirpc-${project.version.replaceAll(".", "-")}`,
+  `version tag '${project.extra.versionTag}' does not match version ${project.version}`,
+);
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "git://git.linux-nfs.org/projects/steved/libtirpc.git",
+    ref: project.extra.versionTag,
+  }),
+);
+
+export default function (): std.Recipe<std.Directory> {
+  let libtirpc = std.runBash`
+    ./bootstrap
+    ./configure \\
+      --prefix=/ \\
+      --disable-gssapi
+    make -j16
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  libtirpc = std.setEnv(libtirpc, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+  libtirpc = makePkgConfigPathsRelative(libtirpc);
+
+  return libtirpc;
+}
+
+// TODO: Figure out where to move this, this is copied from `std`
+function makePkgConfigPathsRelative(
+  recipe: std.AsyncRecipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  // Replaces things that look like absolute paths in pkg-config files with
+  // relative paths (using the `${pcfiledir}` variable)
+  return std.runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
+}


### PR DESCRIPTION
This PR adds a new `libtirpc` package. I ran into this as a dependency while working on a package for MySQL.

This is a very minimal initial implementation to unblock MySQL work, so it'd be worth revisiting to handle auto-updates and tests. I also included the function used for patching pkg-config files seen elsewhere (see #135)