### PR TITLE
Add `rpcsvc_proto` package

### DIFF
--- a/packages/rpcsvc_proto/brioche.lock
+++ b/packages/rpcsvc_proto/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/thkukuk/rpcsvc-proto/releases/download/v1.4.4/rpcsvc-proto-1.4.4.tar.xz": {
+      "type": "sha256",
+      "value": "81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b"
+    }
+  }
+}

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -1,0 +1,29 @@
+import * as std from "std";
+
+export const project = {
+  name: "rpcsvc_proto",
+  version: "1.4.4",
+};
+
+const source = Brioche.download(
+  `https://github.com/thkukuk/rpcsvc-proto/releases/download/v${project.version}/rpcsvc-proto-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function (): std.Recipe<std.Directory> {
+  let rpcsvcProto = std.runBash`
+    ./configure --prefix=/
+    make -j16
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  rpcsvcProto = std.setEnv(rpcsvcProto, {
+    CPATH: { append: [{ path: "include" }] },
+  });
+
+  return rpcsvcProto;
+}


### PR DESCRIPTION
This PR adds an initial basic package for `rpcsvc-proto`, which I found as a dependency for MySQL. I kept the implementation very minimal for now, so it'd be worth revisiting to add tests and an auto-update script in the future.