### PR TITLE
Add `caddy` package

### DIFF
--- a/packages/caddy/brioche.lock
+++ b/packages/caddy/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/caddyserver/caddy.git": {
+      "v2.9.1": "0e570e0cc717f02cf3800ae741df70cd074c7275"
+    }
+  }
+}

--- a/packages/caddy/brioche.lock
+++ b/packages/caddy/brioche.lock
@@ -3,6 +3,9 @@
   "git_refs": {
     "https://github.com/caddyserver/caddy.git": {
       "v2.9.1": "0e570e0cc717f02cf3800ae741df70cd074c7275"
+    },
+    "https://github.com/caddyserver/xcaddy.git": {
+      "v0.4.4": "c548f44e2d9290d6c490868336699d65f43dd36e"
     }
   }
 }

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -1,23 +1,63 @@
 import * as std from "std";
+import caCertificates from "ca_certificates";
 import { gitCheckout } from "git";
-import { goBuild } from "go";
+import go, { goBuild } from "go";
 
 export const project = {
   name: "caddy",
   version: "2.9.1",
+  extra: {
+    xcaddy: {
+      version: "0.4.4",
+    },
+  },
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/caddyserver/caddy.git",
-    ref: `v${project.version}`,
-  }),
-);
+const sourceRef = Brioche.gitRef({
+  repository: "https://github.com/caddyserver/caddy.git",
+  ref: `v${project.version}`,
+});
 
 export default function caddy(): std.Recipe<std.Directory> {
+  let caddy = std.recipeFn(async () => {
+    const commit = (await sourceRef).commit;
+
+    // Build Caddy using `xcaddy build`. This is the officially-recommended
+    // way to build Caddy from source. Building it like a normal Go project
+    // leaves out version information
+    return std
+      .process({
+        command: "xcaddy",
+        args: [
+          "build",
+          commit,
+          "--output",
+          std.tpl`${std.outputPath}/bin/caddy`,
+        ],
+        dependencies: [xcaddy(), go(), caCertificates()],
+        unsafe: {
+          networking: true,
+        },
+      })
+      .toDirectory();
+  });
+
+  caddy = std.withRunnableLink(caddy, "bin/caddy");
+
+  return caddy;
+}
+
+function xcaddy(): std.Recipe<std.Directory> {
+  const source = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/caddyserver/xcaddy.git",
+      ref: `v${project.extra.xcaddy.version}`,
+    }),
+  );
+
   return goBuild({
     source,
-    path: "./cmd/caddy",
-    runnable: "bin/caddy",
+    path: "./cmd/xcaddy",
+    runnable: "bin/xcaddy",
   });
 }

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -1,0 +1,23 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "caddy",
+  version: "2.9.1",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/caddyserver/caddy.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function caddy(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/caddy",
+    runnable: "bin/caddy",
+  });
+}

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -2,6 +2,7 @@ import * as std from "std";
 import caCertificates from "ca_certificates";
 import { gitCheckout } from "git";
 import go, { goBuild } from "go";
+import nushell from "nushell";
 
 export const project = {
   name: "caddy",
@@ -59,5 +60,49 @@ function xcaddy(): std.Recipe<std.Directory> {
     source,
     path: "./cmd/xcaddy",
     runnable: "bin/xcaddy",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    caddy version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(caddy());
+
+  const result = await script.toFile().read();
+
+  std.assert(
+    result.startsWith(`v${project.version} `),
+    `expected '${project.version}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/caddyserver/caddy/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    let xcaddyReleaseData = http get https://api.github.com/repos/caddyserver/xcaddy/releases/latest
+
+    let xcaddyVersion = $xcaddyReleaseData
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.xcaddy.version $xcaddyVersion
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
   });
 }


### PR DESCRIPTION
This PR adds a package for [Caddy](https://caddyserver.com/), an HTTP server. It also includes test and auto-update functions (https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165)