### PR TITLE
Add `nginx` package

### DIFF
--- a/packages/nginx/brioche.lock
+++ b/packages/nginx/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/nginx/nginx/releases/download/release-1.27.4/nginx-1.27.4.tar.gz": {
+      "type": "sha256",
+      "value": "294816f879b300e621fa4edd5353dd1ec00badb056399eceb30de7db64b753b2"
+    }
+  }
+}

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -1,5 +1,6 @@
 import * as std from "std";
 import pcre2 from "pcre2";
+import nushell from "nushell";
 
 export const project = {
   name: "nginx",
@@ -27,4 +28,42 @@ export default function nginx(): std.Recipe<std.Directory> {
   nginx = std.withRunnableLink(nginx, "bin/nginx");
 
   return nginx;
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n "$(nginx -v 2>&1)" | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(nginx());
+
+  const versionMessage = await script.toFile().read();
+  const expectedVersionMessage = `nginx version: nginx/${project.version}`;
+
+  std.assert(
+    versionMessage === expectedVersionMessage,
+    `expected '${expectedVersionMessage}', got '${versionMessage}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/nginx/nginx/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^release-' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -1,0 +1,30 @@
+import * as std from "std";
+import pcre2 from "pcre2";
+
+export const project = {
+  name: "nginx",
+  version: "1.27.4",
+};
+
+const source = Brioche.download(
+  `https://github.com/nginx/nginx/releases/download/release-${project.version}/nginx-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function nginx(): std.Recipe<std.Directory> {
+  let nginx = std.runBash`
+    ./configure \\
+      --prefix=/etc/nginx \\
+      --sbin-path=/bin/nginx
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain(), pcre2())
+    .toDirectory();
+
+  nginx = std.withRunnableLink(nginx, "bin/nginx");
+
+  return nginx;
+}


### PR DESCRIPTION
This PR adds a package for [nginx](https://nginx.org/), an HTTP server. It also includes test and auto-update functions (https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165)