### PR TITLE
Add `llvm` package

### DIFF
--- a/packages/llvm/brioche.lock
+++ b/packages/llvm/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/llvm/llvm-project.git": {
+      "llvmorg-20.1.0": "24a30daaa559829ad079f2ff7f73eb4e18095f88"
+    }
+  }
+}

--- a/packages/llvm/brioche.lock
+++ b/packages/llvm/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/llvm/llvm-project.git": {
-      "llvmorg-20.1.0": "24a30daaa559829ad079f2ff7f73eb4e18095f88"
+      "llvmorg-20.1.1": "424c2d9b7e4de40d0804dd374721e6411c27d1d1"
     }
   }
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -34,6 +34,15 @@ export default function llvm(): std.Recipe<std.Directory> {
     CPATH: { append: [{ path: "include" }] },
   });
 
+  // Remove a bunch of `*.tmp*` files left over in the build
+  // TODO: Figure out where these temp files are coming from!
+  llvm = std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+    find . -name '*.tmp*' -delete
+  `
+    .outputScaffold(llvm)
+    .toDirectory();
+
   return llvm;
 }
 

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -47,6 +47,14 @@ export default function llvm(): std.Recipe<std.Directory> {
   return llvm;
 }
 
+/**
+ * A minimal toolchain that uses LLVM-based tools for compilation, such
+ * as Clang and LLD. It currently still uses components from
+ * `std.toolchain()`, such as system libraries and headers.
+ *
+ * The LLVM toolchain in Brioche is considered experimental, and is very
+ * likely to have major breaking changes over time!
+ */
 export function llvmToolchain(): std.Recipe<std.Directory> {
   const clangConfig = std.file(std.indoc`
     --sysroot <CFGDIR>/../toolchain

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -2,6 +2,7 @@ import * as std from "std";
 import { cmakeBuild } from "cmake";
 import { gitCheckout } from "git";
 import python from "python";
+import nushell from "nushell";
 
 export const project = {
   name: "llvm",
@@ -61,4 +62,41 @@ export function llvmToolchain(): std.Recipe<std.Directory> {
   toolchain = toolchain.insert("bin/clang++.cfg", clangConfig);
 
   return toolchain;
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n "$(llvm-config --version)" | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(llvm());
+
+  const version = await script.toFile().read();
+
+  std.assert(
+    version === project.version,
+    `expected '${project.version}', got '${version}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/llvm/llvm-project/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^llvmorg-' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -20,7 +20,7 @@ export default function llvm(): std.Recipe<std.Directory> {
     source,
     path: "llvm",
     set: {
-      LLVM_ENABLE_PROJECTS: "clang;clang-tools-extra",
+      LLVM_ENABLE_PROJECTS: "clang;clang-tools-extra;lld;lldb",
       CMAKE_BUILD_TYPE: "Release",
     },
     env: {

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -6,7 +6,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "llvm",
-  version: "20.1.0",
+  version: "20.1.1",
 };
 
 const source = gitCheckout(

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -15,8 +15,8 @@ const source = gitCheckout(
   }),
 );
 
-export default function () {
-  return cmakeBuild({
+export default function llvm(): std.Recipe<std.Directory> {
+  let llvm = cmakeBuild({
     source,
     path: "llvm",
     set: {
@@ -28,4 +28,11 @@ export default function () {
     },
     dependencies: [std.toolchain(), python()],
   });
+
+  llvm = std.setEnv(llvm, {
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    CPATH: { append: [{ path: "include" }] },
+  });
+
+  return llvm;
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -36,3 +36,20 @@ export default function llvm(): std.Recipe<std.Directory> {
 
   return llvm;
 }
+
+export function llvmToolchain(): std.Recipe<std.Directory> {
+  const clangConfig = std.file(std.indoc`
+    --sysroot <CFGDIR>/../toolchain
+  `);
+
+  let toolchain = llvm();
+  toolchain = toolchain.insert("toolchain", std.toolchain());
+  toolchain = toolchain.insert(
+    "bin/ld",
+    std.symlink({ target: "../toolchain/bin/ld" }),
+  );
+  toolchain = toolchain.insert("bin/clang.cfg", clangConfig);
+  toolchain = toolchain.insert("bin/clang++.cfg", clangConfig);
+
+  return toolchain;
+}

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -1,0 +1,31 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { gitCheckout } from "git";
+import python from "python";
+
+export const project = {
+  name: "llvm",
+  version: "20.1.0",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/llvm/llvm-project.git",
+    ref: `llvmorg-${project.version}`,
+  }),
+);
+
+export default function () {
+  return cmakeBuild({
+    source,
+    path: "llvm",
+    set: {
+      LLVM_ENABLE_PROJECTS: "clang;clang-tools-extra",
+      CMAKE_BUILD_TYPE: "Release",
+    },
+    env: {
+      CMAKE_BUILD_PARALLEL_LEVEL: "16",
+    },
+    dependencies: [std.toolchain(), python()],
+  });
+}


### PR DESCRIPTION
> Small note about this PR: I tested this build against LLVM v20.1.0, but a new version had released since I started work on this package. I updated the package definition, but due to the very slow build times, I'm going to merge it as-is and let the CI pipeline take care of the build.

This PR adds a new package for [LLVM](https://llvm.org/), a compiler/toolchain project that includes multiple sub-projects including Clang (a C/C++ compiler), LLDB (a debugger), and LLD (a linker).

This PR adds initial support for LLVM, and the default build includes some, but not all, of LLVMs projects: currently, it includes `clang`, `clang-tools-extra`, `lld`, and `lldb`.

I also added an initial iteration of a toolchain function, called `llvm.llvmToolchain()`. It's meant to be similar-ish to `std.toolchain()`, except use LLVM-based tools where possible. Currently, it relies on `std.toolchain()`-- namely, for glibc and standard include headers. I'd like to get it to a point where it's independent from `std.toolchain()` in the future.

I also haven't tested `llvm.llvmToolchain()` much, but here's a minimal working example:

```ts
import * as std from "std";
import { llvmToolchain } from "llvm";

export default function () {
  return std.runBash`
    mkdir -p "$BRIOCHE_OUTPUT/bin"
    clang -v main.c -o "$BRIOCHE_OUTPUT/bin/hello-world"
    ln -s bin/hello-world "$BRIOCHE_OUTPUT/brioche-run"
  `
    .workDir(
      std.directory({
        "main.c": std.file(std.indoc`
          #include <stdio.h>

          int main() {
              printf("Hello, world!\\n");
              return 0;
          }
        `),
      }),
    )
    .dependencies(llvmToolchain())
    .toDirectory();
}
```