### PR TITLE
Add `strace` package

### DIFF
--- a/packages/strace/brioche.lock
+++ b/packages/strace/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/strace/strace/releases/download/v6.14/strace-6.14.tar.xz": {
+      "type": "sha256",
+      "value": "244f3b5c20a32854ca9b7ca7a3ee091dd3d4bd20933a171ecee8db486c77d3c9"
+    }
+  }
+}

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "strace",
+  version: "6.14",
+};
+
+const source = Brioche.download(
+  `https://github.com/strace/strace/releases/download/v${project.version}/strace-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function strace(): std.Recipe<std.Directory> {
+  let strace = std.runBash`
+    ./configure --prefix=/
+    make -j16
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  strace = std.withRunnableLink(strace, "bin/strace");
+
+  return strace;
+}
+
+export async function test() {
+  const script = std.runBash`
+    strace --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(strace());
+
+  const result = await script.toFile().read();
+
+  const version = result.match(/^strace -- version ([\d.]+)$/m)?.at(1);
+  std.assert(
+    version === project.version,
+    `expected '${project.version}', got '${version}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/strace/strace/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a package for [strace](https://strace.io), a debugging tool for tracing Linux syscalls. I also added test and auto-update functions (https://github.com/brioche-dev/brioche/issues/94 / https://github.com/brioche-dev/brioche/issues/165)