### PR TITLE
[ca_certificates] Update to 2025-02-25 bundle

### DIFF
--- a/packages/ca_certificates/brioche.lock
+++ b/packages/ca_certificates/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://curl.se/ca/cacert-2024-12-31.pem": {
+    "https://curl.se/ca/cacert-2025-02-25.pem": {
       "type": "sha256",
-      "value": "a3f328c21e39ddd1f2be1cea43ac0dec819eaa20a90425d7da901a11531b3aa5"
+      "value": "50a6277ec69113f00c5fd45f09e8b97a4b3e32daa35d3a95ab30137a55386cef"
     }
   }
 }

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 
 export const project = {
   name: "ca_certificates",
-  version: "2024-12-31",
+  version: "2025-02-25",
 };
 
 export default function (): std.Recipe<std.Directory> {


### PR DESCRIPTION
This PR updates the `ca_certificates` package to the latest bundle version from https://curl.se/docs/caextract.html