### PR TITLE
chore(broot): update version to 1.45.1

### DIFF
--- a/packages/broot/brioche.lock
+++ b/packages/broot/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/Canop/broot.git": {
-      "v1.44.7": "4003692c6b6c099a4a1c49a3e8dd9b3f84dcb14b"
+      "v1.45.1": "12012e60d25ec819be1b157c1eb8d33c0a8eb090"
     }
   }
 }

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "broot",
-  version: "1.44.7",
+  version: "1.45.1",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/broot
 0.06s ✓ Process 49873
Build finished, completed 1 job in 5.16s
Running brioche-run
{
  "name": "broot",
  "version": "1.45.1"
}
bash-5.2$ brioche build -e test -p packages/broot
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
54928  │    Compiling lru v0.12.5
       │    Compiling deser-hjson v2.2.4
       │    Compiling umask v2.1.0
       │    Compiling uzers v0.12.1
       │    Compiling custom_error v1.9.2
       │    Compiling strict v0.1.4
       │    Compiling pathdiff v0.2.3
       │    Compiling flex-grow v0.1.0
       │    Compiling bet v1.0.4
       │    Compiling id-arena v2.2.1
       │    Compiling splitty v1.0.2
       │    Compiling glob v0.3.2
       │    Compiling base64 v0.21.7
       │    Compiling char_reader v0.1.1
       │    Compiling rustc-hash v2.1.1
       │    Compiling git2 v0.20.1
       │     Finished `release` profile [optimized] target(s) in 5m 11s
       │   Installing /home/brioche-runner-39ef71b543d09eb7ebab3875719e829672b539cb30d99b78192212d32b38f7a2/.local/share/brioche/outputs/output-39ef71b543d09eb7ebab3875719e829672b539cb30d99b78192212d32b38f7a2/bin/broot
       │    Installed package `broot v1.45.1 (/home/brioche-runner-39ef71b543d09eb7ebab3875719e829672b539cb30d99b78192212d32b38f7a2/work)` (executable `broot`)
60975  │ broot 1.45.1
 0.12s ✓ Process 60975
 5m11s ✓ Process 54928
13.72s ✓ Process 52288
 0.18s ✓ Process 52277
Build finished, completed 11 jobs in 7m39s
Result: 2cb2ad0e678d1f17a8e6f42bd493c37a8618ffb1455ce2466aea663d76786aa2
```