### PR TITLE
chore(carapace): update version to 1.3.0

### DIFF
--- a/packages/carapace/brioche.lock
+++ b/packages/carapace/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/carapace-sh/carapace-bin.git": {
-      "v1.2.1": "92a29fba75e2308416a5026dadbe82ff6fc2b14c"
+      "v1.3.0": "2790a2b7a1055d3c03b3e913c0ea0b0ca0a81d96"
     }
   }
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "carapace",
-  version: "1.2.1",
+  version: "1.3.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/carapace/
 0.06s ✓ Process 65282
Build finished, completed 1 job in 4.77s
Running brioche-run
{
  "name": "carapace",
  "version": "1.3.0"
}
bash-5.2$ brioche build -e test -p packages/carapace/
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
65567  │ Initialized empty Git repository in /home/brioche-runner-079ba9e6aa5b4461225b7d12feb5ce5ee9aaf8c7f51ee82f4c1014c51992ae56/.local/share/brioche/outputs/output-079ba9e6aa5b4461225b7d12feb5ce5ee9aaf8c7f51ee82f4c1014c51992ae56/.gi
       │ t/
       │ From https://github.com/carapace-sh/carapace-bin
       │  * branch            2790a2b7a1055d3c03b3e913c0ea0b0ca0a81d96 -> FETCH_HEAD
       │ HEAD is now at 2790a2b Merge pull request #2741 from carapace-sh/update-bridge
65758  │ go: downloading go1.24.1 (linux/amd64)
78122  │ carapace-bin 1.3.0
 0.81s ✓ Process 78122
 2m20s ✓ Process 66020
10.33s ✓ Process 65758
 4.09s ✓ Process 65567
Build finished, completed 6 jobs in 3m30s
Result: 6ecbb32e9b14003cdab98cd2b401e592c1770b65a4479775f70890bfcbfdaa9f
```