### PR TITLE
chore(claudecode): update version to 0.2.69 and adjust expected output format in tests

### DIFF
--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -4,7 +4,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "claude_code",
-  version: "0.2.29",
+  version: "0.2.69",
   packageName: "@anthropic-ai/claude-code",
 };
 
@@ -25,7 +25,7 @@ export async function test() {
   const result = await script.toFile().read();
 
   // Check that the result contains the expected version
-  const expected = `${project.version}`;
+  const expected = `${project.version} (Claude Code)`;
   std.assert(result === expected, `expected ${project.version}, got ${result}`);
 
   return script;


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/claude_code/
 0.06s ✓ Process 79095
Build finished, completed 1 job in 5.25s
Running brioche-run
{
  "name": "claude_code",
  "version": "0.2.69",
  "packageName": "@anthropic-ai/claude-code"
}
bash-5.2$ brioche build -e test -p packages/claude_code/
ERROR build:evaluate: brioche_core::script::evaluate: error=Error: expected 0.2.69, got 0.2.69 (Claude Code)
    at Module.assert (file:///workspace/packages/std/core/utils.bri:9:11)
    at Module.test (file:///workspace/packages/claude_code/project.bri:29:7)
    at eventLoopTick (ext:core/01_core.js:175:7) export="test" project_hash=99e989942061dca41c81570a6ebf7df6215402c5e3f12dd40acd72799dc22e5d
79999  │ npm notice
       │ npm notice New major version of npm available! 10.9.2 -> 11.3.0
       │ npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
       │ npm notice To update run: npm install -g npm@11.3.0
       │ npm notice
       │ added 3 packages in 2s
       │ 2 packages are looking for funding
       │   run `npm fund` for details
80117  │ (node:80126) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
       │ (Use `node --trace-deprecation ...` to show where the warning was created)
       │ 0.2.69 (Claude Code)
 1.21s ✓ Process 80117
 0.09s ✓ Process 80090
 0.23s ✓ Process 80070
 4.11s ✓ Process 79999
Error: Error: expected 0.2.69, got 0.2.69 (Claude Code)
    at Module.assert (file:///workspace/packages/std/core/utils.bri:9:11)
    at Module.test (file:///workspace/packages/claude_code/project.bri:29:7)
    at eventLoopTick (ext:core/01_core.js:175:7)
bash-5.2$ brioche build -e test -p packages/claude_code/
Build finished, completed (no new jobs) in 3.26s
Result: f17386cf3a71402be9d3f2dcdb935c2e63ba8b9b92eebb360537c990f0b0f677
```