### PR TITLE
chore(aws_cli): update version to 2.26.1 and adjust packaging dependency to 24.2

### DIFF
--- a/packages/aws_cli/brioche.lock
+++ b/packages/aws_cli/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/aws/aws-cli.git": {
-      "2.24.17": "af27bc220808f50dfec3002b594801bc2ec4499a"
+      "2.26.1": "33c91f930361aa6990b72a3d75194a624e09a23c"
     }
   }
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "aws_cli",
-  version: "2.24.17",
+  version: "2.26.1",
 };
 
 const source = std.recipeFn(() => {

--- a/packages/aws_cli/resolved-lockfiles.patch
+++ b/packages/aws_cli/resolved-lockfiles.patch
@@ -1,17 +1,18 @@
 diff --git a/requirements-dev-lock.txt b/requirements-dev-lock.txt
-index a7a849fb9..5cd1c7e62 100644
+index b58e3645c..5ed0ba5fb 100644
 --- a/requirements-dev-lock.txt
 +++ b/requirements-dev-lock.txt
-@@ -131,16 +131,10 @@ macholib==1.16.3 \
-     --hash=sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30 \
-     --hash=sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c
-     # via pyinstaller
+@@ -131,17 +131,10 @@ macholib==1.16.3 \
+     # via
+     #   -r requirements-build.txt
+     #   pyinstaller
 -packaging==24.1 \
 -    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
 -    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
 -    # via
 -    #   -r requirements-test.txt
 -    #   build
+-    #   pyinstaller
 -    #   pyinstaller-hooks-contrib
 -    #   pyproject-api
 -    #   pytest
@@ -24,10 +25,10 @@ index a7a849fb9..5cd1c7e62 100644
      --hash=sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc \
      --hash=sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6
 diff --git a/requirements-test-lock.txt b/requirements-test-lock.txt
-index b838c3940..c891e0e86 100644
+index 5d211d4fd..ea193c20e 100644
 --- a/requirements-test-lock.txt
 +++ b/requirements-test-lock.txt
-@@ -97,13 +97,10 @@ jsonschema==4.7.2 \
+@@ -93,13 +93,10 @@ jsonschema==4.7.2 \
      --hash=sha256:73764f461d61eb97a057c929368610a134d1d1fffd858acfe88864ee94f1f1d3 \
      --hash=sha256:c7448a421b25e424fccfceea86b4e3a8672b4436e1988ccbde92c80828d4f085
      # via -r requirements-test.txt
@@ -45,3 +46,13 @@ index b838c3940..c891e0e86 100644
  pip-tools==7.0.0 \
      --hash=sha256:6a2308712727c86cc8a6cedc0e6ba01232a337c706d63926d3789462ad083d06 \
      --hash=sha256:ae185db747195c8ed011866c366279cbb64f7f8c1528e7a828f515bd2bb0b31b
+diff --git a/requirements-test.txt b/requirements-test.txt
+index 1d5405c40..0b2021ccc 100644
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -9,4 +9,4 @@ coverage==7.0.1
+ pytest-cov==4.1.0
+ pytest-xdist==3.1.0
+ pip-tools==7.0.0
+-packaging==24.1
++packaging==24.2


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/aws_cli/    
Build finished, completed (no new jobs) in 3.51s
Running brioche-run
{
  "name": "aws_cli",
  "version": "2.26.1"
}
bash-5.2$ brioche build -e test -p packages/aws_cli/    
83519  │ d4a0eefef665a59a8/lib/python3.12/site-packages (from awscli==2.26.1) (1.0.1)
       │ Requirement already satisfied: urllib3<1.27,>=1.25.4 in /home/brioche-runner-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59a8/.local/share/brioche/outputs/output-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d
       │ 4a0eefef665a59a8/lib/python3.12/site-packages (from awscli==2.26.1) (1.26.20)
       │ Requirement already satisfied: cffi>=1.12 in /home/brioche-runner-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59a8/.local/share/brioche/outputs/output-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665
       │ a59a8/lib/python3.12/site-packages (from cryptography<43.0.2,>=40.0.0->awscli==2.26.1) (1.17.1)
       │ Requirement already satisfied: wcwidth in /home/brioche-runner-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59a8/.local/share/brioche/outputs/output-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59
       │ a8/lib/python3.12/site-packages (from prompt-toolkit<3.0.39,>=3.0.24->awscli==2.26.1) (0.2.13)
       │ Requirement already satisfied: six>=1.5 in /home/brioche-runner-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59a8/.local/share/brioche/outputs/output-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a5
       │ 9a8/lib/python3.12/site-packages (from python-dateutil<=2.9.0,>=2.1->awscli==2.26.1) (1.17.0)
       │ Requirement already satisfied: pycparser in /home/brioche-runner-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a59a8/.local/share/brioche/outputs/output-bb4f040f10078b094fd494b56c6ac92ac75dbc9057ec1f8d4a0eefef665a
       │ 59a8/lib/python3.12/site-packages (from cffi>=1.12->cryptography<43.0.2,>=40.0.0->awscli==2.26.1) (2.22)
       │ Building wheels for collected packages: awscli
       │   Building wheel for awscli (pyproject.toml): started
       │   Building wheel for awscli (pyproject.toml): finished with status 'done'
       │   Created wheel for awscli: filename=awscli-2.26.1-py3-none-any.whl size=20206551 sha256=f4385f1fbdac2ffb3f489b3ad60d1dd877b1746bf4a2fc3fa5a4034b4c166e08
       │   Stored in directory: /tmp/pip-ephem-wheel-cache-qr4yi4y_/wheels/34/7a/30/d258a3c0a693ba350a244af718e0e4a552794a43fc1cc37028
       │ Successfully built awscli
       │ Installing collected packages: awscli
       │ Successfully installed awscli-2.26.1
83973  │ aws-cli/2.26.1 Python/3.12.8 Linux/6.10.14-linuxkit source/x86_64
 2.53s ✓ Process 83973
57.12s ✓ Process 83519
 0.14s ✓ Process 83344
 1.16s ✓ Process 83267
Build finished, completed 7 jobs in 3m13s
Result: 72a79a593ddbd89872a3a60df5702415362816dc92e12ea233e9a01c0af224b5
```