### PR TITLE
refactor: uniformize the way we retrieve dasel codebase

### DIFF
--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -14,11 +14,12 @@ std.assert(
   `Dasel major version ${majorVersion} does not match version number ${project.version}`,
 );
 
-const gitRef = Brioche.gitRef({
-  repository: "https://github.com/TomWright/dasel.git",
-  ref: `v${project.version}`,
-});
-const source = gitCheckout(gitRef);
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/TomWright/dasel.git",
+    ref: `v${project.version}`,
+  }),
+);
 
 export default function dasel(): std.Recipe<std.Directory> {
   return goBuild({


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/dasel/
Build finished, completed (no new jobs) in 2.85s
Running brioche-run
{
  "name": "dasel",
  "version": "2.8.1"
}
bash-5.2$ brioche build -e test -p packages/dasel/  
84138  │ dasel version 2.8.1
 0.17s ✓ Process 84138
 2.14s ✓ Registry  100% Fetch 1 blob + 3 recipes from registry                                                                                                                                                                              
Build finished, completed 2 jobs in 8.01s
Result: 1cf736f0c39c1490cfb9c2bb904ddd676bbcef9960ec18a5499d9c57365079f5
```