### PR TITLE
chore(dust): update version to 1.2.0 and add testing support

### DIFF
--- a/packages/dust/brioche.lock
+++ b/packages/dust/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/bootandy/dust.git": {
-      "v1.1.2": "b24f4c8096557529e63e6fb09fc6ecdb497d153b"
+      "v1.2.0": "646cdd976ded146779f4fc57c34c56fa850d728f"
     }
   }
 }

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "dust",
-  version: "1.1.2",
+  version: "1.2.0",
 };
 
 const source = gitCheckout(
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function dust(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/dust",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(dust --version) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(dust());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `Dust ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche build -e test -p packages/dust  
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
ERROR build:evaluate: brioche_core::script::evaluate: error=Error: expected 'dust 1.2.0', got 'Dust 1.2.0'
    at Module.assert (file:///workspace/packages/std/core/utils.bri:9:11)
    at Module.test (file:///workspace/packages/dust/project.bri:34:7)
    at eventLoopTick (ext:core/01_core.js:175:7) export="test" project_hash=72861b665f17eae23d143337140084f589fbcae67a7438d14512c8faf61b2193
84284  │    Compiling ansi_term v0.12.1
       │    Compiling itoa v1.0.15
       │    Compiling ryu v1.0.20
       │    Compiling iana-time-zone v0.1.61
       │    Compiling sysinfo v0.27.8
       │    Compiling lscolors v0.13.0
       │    Compiling toml v0.5.11
       │    Compiling chrono v0.4.40
       │    Compiling regex v1.11.1
       │    Compiling directories v4.0.1
       │    Compiling config-file v0.2.3
       │    Compiling ctrlc v3.4.5
       │    Compiling terminal_size v0.2.6
       │    Compiling thousands v0.2.0
       │    Compiling unicode-width v0.1.14
       │    Compiling stfu8 v0.2.7
       │     Finished `release` profile [optimized] target(s) in 1m 09s
       │   Installing /home/brioche-runner-e1ef3e4e48433a920c74ed19b9a79baf9594c6bd92bc3886188efb7a334e0f42/.local/share/brioche/outputs/output-e1ef3e4e48433a920c74ed19b9a79baf9594c6bd92bc3886188efb7a334e0f42/bin/dust
       │    Installed package `du-dust v1.2.0 (/home/brioche-runner-e1ef3e4e48433a920c74ed19b9a79baf9594c6bd92bc3886188efb7a334e0f42/work)` (executable `dust`)
85190  │ Dust 1.2.0
 0.14s ✓ Process 85190
 1m 9s ✓ Process 84284
 9.21s ✓ Process 84225
 0.18s ✓ Process 84223
Result: 0882428231ac361ca8a2a52bd2fd2044b9119016dc4ea4586bfaa2c3ae751807
```