### PR TITLE
chore(eza): update version to 0.21.0

### DIFF
--- a/packages/eza/brioche.lock
+++ b/packages/eza/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/eza-community/eza.git": {
-      "v0.20.23": "6ff233abbcb8af390c6356791c34a8676d3e4caa"
+      "v0.21.0": "974cde16b2002df7a0b29f2bcf51548e87fe433e"
     }
   }
 }

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "eza",
-  version: "0.20.23",
+  version: "0.21.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/eza   
 0.06s ✓ Process 85251
Build finished, completed 1 job in 5.22s
Running brioche-run
{
  "name": "eza",
  "version": "0.21.0"
}
bash-5.2$ brioche build -e test -p packages/eza 
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
85393  │    Compiling uutils_term_grid v0.6.0
       │    Compiling nu-ansi-term v0.50.1
       │    Compiling url v2.5.4
       │    Compiling proc-mounts v0.3.0
       │    Compiling uzers v0.12.1
       │    Compiling locale v0.2.2
       │    Compiling number_prefix v0.4.0
       │    Compiling once_cell v1.21.3
       │    Compiling timeago v0.4.2
       │    Compiling unicode-width v0.2.0
       │    Compiling path-clean v1.0.1
       │    Compiling glob v0.3.2
       │    Compiling natord-plus-plus v2.0.0
       │    Compiling git2 v0.20.1
       │     Finished `release` profile [optimized] target(s) in 2m 34s
       │   Installing /home/brioche-runner-6ed04f21b850d6b3e8d667af9b839e23290ec02120265ca03b58359c70ae055e/.local/share/brioche/outputs/output-6ed04f21b850d6b3e8d667af9b839e23290ec02120265ca03b58359c70ae055e/bin/eza
       │    Installed package `eza v0.21.0 (/home/brioche-runner-6ed04f21b850d6b3e8d667af9b839e23290ec02120265ca03b58359c70ae055e/work)` (executable `eza`)
87514  │ eza - A modern, maintained replacement for ls
       │ v0.21.0 [+git]
       │ https://github.com/eza-community/eza
 0.15s ✓ Process 87514
 2m35s ✓ Process 85393
 7.62s ✓ Process 85354
 0.18s ✓ Process 85352
Build finished, completed 6 jobs in 3m29s
Result: 495307cf4af4f0c6af6965837ed89d15610e2327ef854b12b0a9382bf28ee602
```