### PR TITLE
refactor(cmake): enhance version check to retrieve only relevant output

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -209,10 +209,19 @@ export function cmakeBuild(
   return result;
 }
 
-export function test() {
-  return std.runBash`
-    cmake --version | tee "$BRIOCHE_OUTPUT"
+export async function test() {
+  const script = std.runBash`
+    # Only retrieve the first line of the output, other lines are not relevant for the version check
+    echo -n $(cmake --version | head -n 1) | tee "$BRIOCHE_OUTPUT"
   `.dependencies(cmake());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `cmake version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche build -e test -p packages/cmake
19142  │ cmake version 3.31.1
 0.16s ✓ Process 19142
Build finished, completed 1 job in 5.08s
Result: 19eeda682ce5ddc8a4e2119325e9561483cfc9f198dad755a3bc296430ed6b3a
```