### PR TITLE
chore(github_cli): update version to 2.69.0

### DIFF
--- a/packages/github_cli/brioche.lock
+++ b/packages/github_cli/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/cli/cli.git": {
-      "v2.67.0": "6899fe21dd80873893dd1a3bf3bdd4d33b1b2338"
+      "v2.69.0": "45ffa3c668f7105e92089220d42aa64c9acbd11c"
     }
   }
 }

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -5,8 +5,8 @@ import { goBuild } from "go";
 
 export const project = {
   name: "github_cli",
-  version: "2.67.0",
-  latestBuildDate: "2025-02-11",
+  version: "2.69.0",
+  latestBuildDate: "2025-03-19",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/github_cli/
 0.06s ✓ Process 19180
Build finished, completed 1 job in 5.28s
Running brioche-run
{
  "name": "github_cli",
  "version": "2.69.0",
  "latestBuildDate": "2025-03-19"
}
bash-5.2$ brioche build -e test -p packages/github_cli/
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
19259  │ Initialized empty Git repository in /home/brioche-runner-98fb5519a8748b5726cbf9bf25afa82ef14b946e6bd24606647355dcac68b566/.local/share/brioche/outputs/output-98fb5519a8748b5726cbf9bf25afa82ef14b946e6bd24606647355dcac68b566/.git/
       │ From https://github.com/cli/cli
       │  * branch            45ffa3c668f7105e92089220d42aa64c9acbd11c -> FETCH_HEAD
       │ HEAD is now at 45ffa3c Merge pull request #10625 from cli/andyfeller/10580-edit-last-regression
28315  │ gh version 2.69.0 (2025-03-19) https://github.com/cli/cli/releases/tag/v2.69.0
 0.38s ✓ Process 28315
 1m33s ✓ Process 19404
23.53s ✓ Process 19292
 2.48s ✓ Process 19259
Build finished, completed 4 jobs in 3m48s
Result: 12312c4f827ecaf0cf7a93ef7d13e45b227051c18fb69f4149321051e37c0c4f
```