### PR TITLE
fix(joshuto): update regex to correctly parse version tags

### DIFF
--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -37,11 +37,12 @@ export default function (): std.Recipe<std.Directory> {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
+    # Version can either be prefixed with 'v' or not
     let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
         | get -i 0
       }
       | sort-by -n major minor patch


### PR DESCRIPTION
Joshuto can either contains a tag prefixed with 'v' or not:

![image](https://github.com/user-attachments/assets/b2c524fa-d641-4d06-b1c3-515999fad25b)


Before:

```bash
bash-5.2$ brioche run -e autoUpdate -p packages/joshuto
 0.06s ✓ Process 28439
Build finished, completed 1 job in 4.84s
Running brioche-run
{
  "name": "joshuto",
  "version": "0.9.3"
}
```

After:

```bash
bash-5.2$ brioche run -e autoUpdate -p packages/joshuto
Build finished, completed (no new jobs) in 3.17s
Running brioche-run
{
  "name": "joshuto",
  "version": "0.9.8"
}
```
