### PR TITLE
chore(jujutsu): update version to 0.28.2

### DIFF
--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/martinvonz/jj.git": {
-      "v0.27.0": "6ce7a77da5a18343f4f3effef49b77428e43bc74"
+      "v0.28.2": "b9ebe2f03c976515d2a155a411a368ae773c5493"
     }
   }
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -6,7 +6,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "jujutsu",
-  version: "0.27.0",
+  version: "0.28.2",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/jujutsu
 0.07s ✓ Process 28585
Build finished, completed 1 job in 12.76s
Running brioche-run
{
  "name": "jujutsu",
  "version": "0.28.2"
}
bash-5.2$ brioche build -e test -p packages/jujutsu/   
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
28835  │    Compiling unicode-linebreak v0.1.5
       │    Compiling jj-cli v0.28.2 (/home/brioche-runner-66da423960bc5f24a720e5a04f55e2de34f510eadb212240fa7ab07803d8ade1/work/cli)
       │    Compiling clap_mangen v0.2.25
       │    Compiling sapling-streampager v0.11.0
       │    Compiling textwrap v0.16.2
       │    Compiling rpassword v7.3.1
       │    Compiling tracing-chrome v0.7.2
       │    Compiling scm-record v0.8.0
       │    Compiling clap_complete_nushell v4.5.5
       │    Compiling clap-markdown v0.1.4
       │    Compiling sapling-renderdag v0.1.0
       │    Compiling os_pipe v1.2.1
       │    Compiling timeago v0.4.2
       │    Compiling whoami v1.6.0
       │    Compiling git2 v0.20.1
       │    Compiling jj-lib v0.28.2 (/home/brioche-runner-66da423960bc5f24a720e5a04f55e2de34f510eadb212240fa7ab07803d8ade1/work/lib)
       │     Finished `release` profile [optimized] target(s) in 9m 09s
       │   Installing /home/brioche-runner-66da423960bc5f24a720e5a04f55e2de34f510eadb212240fa7ab07803d8ade1/.local/share/brioche/outputs/output-66da423960bc5f24a720e5a04f55e2de34f510eadb212240fa7ab07803d8ade1/bin/jj
       │    Installed package `jj-cli v0.28.2 (/home/brioche-runner-66da423960bc5f24a720e5a04f55e2de34f510eadb212240fa7ab07803d8ade1/work/cli)` (executable `jj`)
33493  │ jj 0.28.2
 0.23s ✓ Process 33493
 9m10s ✓ Process 28835
18.89s ✓ Process 28689
 0.19s ✓ Process 28679
Build finished, completed 7 jobs in 11m44s
Result: a5f62dbb4e4daeea78890a47c05893dd87c3e79533e66bc114fe6c000f0506ff
```
