### PR TITLE
chore(just): update version to 1.40.0

### DIFF
--- a/packages/just/brioche.lock
+++ b/packages/just/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/casey/just.git": {
-      "1.39.0": "9ec7b60b55cba4d9c095d3b8f119637980286165"
+      "1.40.0": "679a9403ac29d7fc9045285453e58e2534d98d8d"
     }
   }
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "just",
-  version: "1.39.0",
+  version: "1.40.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/just
 0.09s ✓ Process 33594
Build finished, completed 1 job in 12.70s
Running brioche-run
{
  "name": "just",
  "version": "1.40.0"
}
bash-5.2$ brioche build -e test -p packages/just/
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
33777  │    Compiling shellexpand v3.1.0
       │    Compiling clap_complete v4.5.46
       │    Compiling rand v0.9.0
       │    Compiling derive-where v1.2.7
       │    Compiling uuid v1.15.1
       │    Compiling num_cpus v1.16.0
       │    Compiling ansi_term v0.12.1
       │    Compiling lexiclean v0.0.1
       │    Compiling percent-encoding v2.3.1
       │    Compiling target v2.1.0
       │    Compiling typed-arena v2.0.2
       │    Compiling is_executable v1.0.4
       │    Compiling edit-distance v2.1.3
       │    Compiling unicode-width v0.2.0
       │    Compiling dotenvy v0.15.7
       │    Compiling just v1.40.0 (/home/brioche-runner-1baeebaea47e942a8aa5a36a58ce99d4f074cccd9f6056a17822eff20a68941d/work)
       │     Finished `release` profile [optimized] target(s) in 1m 44s
       │   Installing /home/brioche-runner-1baeebaea47e942a8aa5a36a58ce99d4f074cccd9f6056a17822eff20a68941d/.local/share/brioche/outputs/output-1baeebaea47e942a8aa5a36a58ce99d4f074cccd9f6056a17822eff20a68941d/bin/just
       │    Installed package `just v1.40.0 (/home/brioche-runner-1baeebaea47e942a8aa5a36a58ce99d4f074cccd9f6056a17822eff20a68941d/work)` (executable `just`)
35030  │ just 1.40.0
 0.17s ✓ Process 35030
 1m45s ✓ Process 33777
13.77s ✓ Process 33698
 0.23s ✓ Process 33696
Build finished, completed 6 jobs in 2m44s
Result: ed728a7d6d3136f1d657295d9790e10d614088e5c1623be8f1f40047c6a6ca19
```