### PR TITLE
chore(libffi): update version to 3.4.8 and add testing capability

### DIFF
--- a/packages/libffi/brioche.lock
+++ b/packages/libffi/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/libffi/libffi/releases/download/v3.4.7/libffi-3.4.7.tar.gz": {
+    "https://github.com/libffi/libffi/releases/download/v3.4.8/libffi-3.4.8.tar.gz": {
       "type": "sha256",
-      "value": "138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d"
+      "value": "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b"
     }
   }
 }

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -3,7 +3,7 @@ import * as std from "std";
 
 export const project = {
   name: "libffi",
-  version: "3.4.7",
+  version: "3.4.8",
 };
 
 const source = Brioche.download(
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default function (): std.Recipe<std.Directory> {
+export default function libffi(): std.Recipe<std.Directory> {
   const libffi = std.runBash`
     ./configure --prefix=/
     make
@@ -27,6 +27,20 @@ export default function (): std.Recipe<std.Directory> {
     LIBRARY_PATH: { append: [{ path: "lib" }] },
     PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(pkg-config --modversion libffi) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(std.toolchain(), libffi());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/libffi/
 0.06s ✓ Process 39608
Build finished, completed 1 job in 4.51s
Running brioche-run
{
  "name": "libffi",
  "version": "3.4.8"
}
bash-5.2$ brioche build -e test -p packages/libffi
Build finished, completed (no new jobs) in 1.89s
Result: 8e41eaf699967fcb84f81e22254417c0776b019ba274b0272baab0001fa818c9
```