### PR TITLE
chore(llvm): update version to 20.1.2

### DIFF
--- a/packages/llvm/brioche.lock
+++ b/packages/llvm/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/llvm/llvm-project.git": {
-      "llvmorg-20.1.1": "424c2d9b7e4de40d0804dd374721e6411c27d1d1"
+      "llvmorg-20.1.2": "58df0ef89dd64126512e4ee27b4ac3fd8ddf6247"
     }
   }
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -6,7 +6,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "llvm",
-  version: "20.1.1",
+  version: "20.1.2",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/llvm
 0.07s ✓ Process 39709
Build finished, completed 1 job in 12.00s
Running brioche-run
{
  "name": "llvm",
  "version": "20.1.2"
}
```

Sorry I didn't test the full build of LLVM on my machine. It was too slow to compile it. After one hour, it was just at 18%. Even with a M1 Pro... I think the abstraction with virtualisation is too slow for these kinds of things. Hope we'll have soon the cross-building support 😁 