### PR TITLE
chore(nushell): update version to 0.103.0

### DIFF
--- a/packages/nushell/brioche.lock
+++ b/packages/nushell/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/nushell/nushell.git": {
-      "0.102.0": "1aa2ed1947a0b891398558fcf4e4289849cc5a1d"
+      "0.103.0": "c98642647878b4f66fb7e38388a3973071b0e27b"
     }
   }
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "nushell",
-  version: "0.102.0",
+  version: "0.103.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/nushell
 0.10s ✓ Process 62062
Build finished, completed 1 job in 14.06s
Running brioche-run
{
  "name": "nushell",
  "version": "0.103.0"
}
bash-5.2$ brioche build -e test -p packages/nushell
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
62278  │    Compiling alphanumeric-sort v1.5.3
       │    Compiling termcolor v1.4.1
       │    Compiling roxmltree v0.20.0
       │    Compiling filesize v0.2.0
       │    Compiling data-encoding v2.8.0
       │    Compiling nu-explore v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-explore)
       │    Compiling nu-cmd-extra v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-cmd-extra)
       │    Compiling simplelog v0.12.2
       │    Compiling nu-std v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-std)
       │    Compiling nu-cmd-plugin v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-cmd-plugin)
       │    Compiling ctrlc v3.4.5
       │    Compiling rusqlite v0.31.0
       │    Compiling reedline v0.39.0
       │    Compiling nu-command v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-command)
       │    Compiling nu-cli v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-cli)
       │    Compiling nu-lsp v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work/crates/nu-lsp)
       │     Finished `release` profile [optimized] target(s) in 5m 51s
       │   Installing /home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/.local/share/brioche/outputs/output-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/bin/nu
       │    Installed package `nu v0.103.0 (/home/brioche-runner-1051ac7841f9dd49732220ebf5021d3d8f155ce5bce43d8db3636f6e6df110f0/work)` (executable `nu`)
69470  │ 0.103.0
 0.22s ✓ Process 69470
 5m52s ✓ Process 62278
35.94s ✓ Process 62159
 0.19s ✓ Process 62157
Build finished, completed 6 jobs in 8m 6s
Result: a8c7f3a62e274129e1a696b4fabe626ffa616ddec6a43ddc374f03f09ed89bec
```