### PR TITLE
chore(php): update version to 8.4.6

### DIFF
--- a/packages/php/brioche.lock
+++ b/packages/php/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://www.php.net/distributions/php-8.4.5.tar.gz": {
+    "https://www.php.net/distributions/php-8.4.6.tar.gz": {
       "type": "sha256",
-      "value": "f05530d350f1ffe279e097c2af7a8d78cab046ef99d91f6b3151b06f0ab05d05"
+      "value": "49be0f2f45c9b07c9b921d023bf28b1fc781700c829869725681300e72e3faa8"
     }
   }
 }

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -5,7 +5,7 @@ import sqlite from "sqlite";
 
 export const project = {
   name: "php",
-  version: "8.4.5",
+  version: "8.4.6",
 };
 
 const source = Brioche.download(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/php  
 0.09s ✓ Process 69687
Build finished, completed 1 job in 5.20s
Running brioche-run
{
  "name": "php",
  "version": "8.4.6"
}
bash-5.2$ brioche build -e test -p packages/php
75066  │ directorytreeiterator.inc
       │ invertedregexiterator.inc
       │ Build complete.
       │ Don't forget to run 'make test'.
       │ Installing shared extensions:     /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/lib/php/extensions/no-debug-non-zts-20240924/
       │ Installing PHP CLI binary:        /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/bin/
       │ Installing PHP CLI man page:      /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/php/man/man1/
       │ Installing phpdbg binary:         /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/bin/
       │ Installing phpdbg man page:       /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/php/man/man1/
       │ Installing PHP CGI binary:        /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/bin/
       │ Installing PHP CGI man page:      /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/php/man/man1/
       │ Installing build environment:     /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/lib/php/build/
       │ Installing header files:          /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/include/php/
       │ Installing helper programs:       /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/bin/
       │   program: phpize
       │   program: php-config
       │ Installing man pages:             /home/brioche-runner-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/.local/share/brioche/outputs/output-8fa05f607192ab33bb89b60e2c50c951d9bc10b551a011b8efed9ae939d50c25/php/man/man1/
       │   page: phpize.1
       │   page: php-config.1
89856  │ PHP 8.4.6 (cli) (built: Apr 14 2025 12:20:22) (NTS) Copyright (c) The PHP Group Zend Engine v4.4.6, Copyright (c) Zend Technologies
 0.32s ✓ Process 89856
27m38s ✓ Process 75066
 0.22s ✓ Process 74929
 4m19s ✓ Process 69821
Build finished, completed 7 jobs in 33m25s
Result: 62078702f8cb4d62ddb8d02c19080e490355b1d433fbc320c9bc7f940aaae77c
```