### PR TITLE
chore(restic): update version to 0.18.0

### DIFF
--- a/packages/restic/brioche.lock
+++ b/packages/restic/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/restic/restic.git": {
-      "v0.17.3": "bc64921a8ea73dfaeaf4d9b66676a76998e144fc"
+      "v0.18.0": "d401ad6c1ec93a8fbcfcd9f6855a7a4468878ec2"
     }
   }
 }

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "restic",
-  version: "0.17.3",
+  version: "0.18.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/restic/
 0.07s ✓ Process 90112
Build finished, completed 1 job in 5.48s
Running brioche-run
{
  "name": "restic",
  "version": "0.18.0"
}
bash-5.2$ brioche build -e test -p packages/restic/
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
90175  │ Initialized empty Git repository in /home/brioche-runner-af38bb13d6c3b9a638ba3ca3a6f53f53c4c0e29a559aadf8457b54876e8d1b45/.local/share/brioche/outputs/output-af38bb13d6c3b9a638ba3ca3a6f53f53c4c0e29a559aadf8457b54876e8d1b45/.gi
       │ t/
       │ From https://github.com/restic/restic
       │  * branch            d401ad6c1ec93a8fbcfcd9f6855a7a4468878ec2 -> FETCH_HEAD
       │ HEAD is now at d401ad6 Add version for 0.18.0
97503  │ restic 0.18.0 compiled with go1.24.0 on linux/amd64
 0.24s ✓ Process 97503
 1m18s ✓ Process 90333
16.16s ✓ Process 90223
 3.01s ✓ Process 90175
Build finished, completed 4 jobs in 2m33s
Result: 14759a7153f77569b17233af78fbf518ab7330c452fbdf7b3c1c5712d6e154e1
```