### PR TITLE
chore(ruff): update version to 0.11.5 and add testing capability

### DIFF
--- a/packages/ruff/brioche.lock
+++ b/packages/ruff/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/astral-sh/ruff.git": {
-      "0.9.9": "091d0af2ab026a08b82d4aa7d3ab6b1ca4db778c"
+      "0.11.5": "7186d5e9add868037df5bb9a42c43d5340c7ea44"
     }
   }
 }

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "ruff",
-  version: "0.9.9",
+  version: "0.11.5",
 };
 
 const source = gitCheckout(
@@ -15,12 +15,26 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function ruff(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     path: "crates/ruff",
     runnable: "bin/ruff",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n "$(ruff --version)" | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(ruff());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `ruff ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/ruff    
 0.08s ✓ Process 97647
Build finished, completed 1 job in 5.34s
Running brioche-run
{
  "name": "ruff",
  "version": "0.11.5"
}
bash-5.2$ brioche build -e test -p packages/ruff
10160  │ ruff 0.11.5
 0.23s ✓ Process 10160
Build finished, completed 1 job in 5.38s
Result: a91a50f5cbfcaf0256f7491ca6ce066880fb2b1bd166ccf7a15a7962607b11a8
```