### PR TITLE
chore(steampipe): update version to 1.1.0

### DIFF
--- a/packages/steampipe/brioche.lock
+++ b/packages/steampipe/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/turbot/steampipe.git": {
-      "v1.0.3": "720a09bd49d508234c091755ec130ee241f4f5c9"
+      "v1.1.0": "a312d91d978c92d3bfb79cc02d1345a33cce3681"
     }
   }
 }

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -5,7 +5,7 @@ import nushell from "nushell";
 
 export const project = {
   name: "steampipe",
-  version: "1.0.3",
+  version: "1.1.0",
 };
 
 const source = gitCheckout(


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/steampipe/
 0.06s ✓ Process 10583
Build finished, completed 1 job in 5.01s
Running brioche-run
{
  "name": "steampipe",
  "version": "1.1.0"
}
bash-5.2$ brioche build -e test -p packages/steampipe/  
 INFO build: brioche::build: updated lockfiles num_lockfiles_updated=1
10644  │ Initialized empty Git repository in /home/brioche-runner-5fb9010657f60023fbc91376f6e179f68293fee4c05269135aaaceb9fa7a8cf0/.local/share/brioche/outputs/output-5fb9010657f60023fbc91376f6e179f68293fee4c05269135aaaceb9fa7a8cf0/.gi
       │ t/
       │ From https://github.com/turbot/steampipe
       │  * branch            a312d91d978c92d3bfb79cc02d1345a33cce3681 -> FETCH_HEAD
       │ HEAD is now at a312d91 v1.1.0
21671  │ Steampipe v1.1.0
 0.37s ✓ Process 21671
 1m57s ✓ Process 10813
40.77s ✓ Process 10692
 1.41s ✓ Process 10644
Build finished, completed 4 jobs in 5m 3s
Result: 82020712a229b818c29571365055dbf9085f7bf883028993499c51953a85bba9
```