### PR TITLE
chore(k9s): update version to 0.50.3 and add testing capability

### DIFF
--- a/packages/k9s/brioche.lock
+++ b/packages/k9s/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/derailed/k9s.git": {
-      "v0.40.5": "af8aa5fc41b3db202941a264a3011f490bede97b"
+      "v0.50.3": "594c2c6e4c8dce30e5553e84e4a16a3e55e36066"
     }
   }
 }

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -5,7 +5,7 @@ import { goBuild } from "go";
 
 export const project = {
   name: "k9s",
-  version: "0.40.5",
+  version: "0.50.3",
 };
 
 const gitRef = await Brioche.gitRef({
@@ -14,7 +14,7 @@ const gitRef = await Brioche.gitRef({
 });
 const source = gitCheckout(gitRef);
 
-export default function (): std.Recipe<std.Directory> {
+export default function k9s(): std.Recipe<std.Directory> {
   return goBuild({
     source,
     buildParams: {
@@ -27,6 +27,21 @@ export default function (): std.Recipe<std.Directory> {
     },
     runnable: "bin/k9s",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    # Remove ANSI color codes from the output, before extracting the version
+    echo -n $(k9s version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }') | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(k9s());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export async function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/k9s/
Build finished, completed (no new jobs) in 2.72s
Running brioche-run
{
  "name": "k9s",
  "version": "0.50.3"
}
bash-5.2$ brioche build -e test -p packages/k9s
Build finished, completed (no new jobs) in 2.18s
Result: f6b6691d43f49cdbe416eeb298142760b7a889b567a3ade5535c1660c52349bc
```