### PR TITLE
chore(terraform): update version to 1.11.4 and update build process for Go 1.24 workaround

### DIFF
--- a/packages/terraform/brioche.lock
+++ b/packages/terraform/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/hashicorp/terraform.git": {
-      "v1.11.0": "41495103ac97aec044b4b939721e95014f9ab441"
+      "v1.11.4": "35645b8fca68ff7e0b8785a3b563724a529a0caf"
     }
   }
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "terraform",
-  version: "1.11.0",
+  version: "1.11.4",
 };
 
 const source = gitCheckout(
@@ -15,15 +15,38 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function terraform(): std.Recipe<std.Directory> {
+  const patchedSource = std.runBash`
+    # Workaround for Go 1.24, see: https://github.com/NixOS/nixpkgs/blob/2631b0b7abcea6e640ce31cd78ea58910d31e650/pkgs/applications/networking/cluster/terraform/default.nix#L48
+    cd "$BRIOCHE_OUTPUT"
+    sed -i 's/godebug tlskyber=0/godebug tlsmlkem=0/g' go.mod
+  `
+    .outputScaffold(source)
+    .toDirectory();
+
   return goBuild({
-    source,
+    source: patchedSource,
     buildParams: {
       ldflags: ["-w", "-s", `-X github.com/hashicorp/terraform/version.dev=no`],
       mod: "readonly",
     },
     runnable: "bin/terraform",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    # Only retrieve the first line of the output, other lines are not relevant for the version check
+    echo -n $(terraform --version | head -n 1) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(terraform());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `Terraform v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export async function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/terraform/
Build finished, completed (no new jobs) in 3.69s
Running brioche-run
{
  "name": "terraform",
  "version": "1.11.4"
}
bash-5.2$ brioche build -e test -p packages/terraform/
Build finished, completed (no new jobs) in 2.27s
Result: 5c387b866c7df48b7f58c60fa0defd419241d278e2f4db0b7c60b610def78be7
```