### PR TITLE
chore(wasmtime): update version to 31.0.0 and add testing capability

### DIFF
--- a/packages/wasmtime/brioche.lock
+++ b/packages/wasmtime/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/bytecodealliance/wasmtime.git": {
-      "v30.0.2": "398694a59e24d37acde915086a9be308ec51f626"
+      "v31.0.0": "7a9be587f853ce4c4060fd4fcf9638d61907e6dd"
     }
   }
 }

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "wasmtime",
-  version: "30.0.2",
+  version: "31.0.0",
 };
 
 const source = gitCheckout(
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function wasmtime(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/wasmtime",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(wasmtime --version) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(wasmtime());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `wasmtime ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/wasmtime/
 0.08s ✓ Process 67100
Build finished, completed 1 job in 6.28s
Running brioche-run
{
  "name": "wasmtime",
  "version": "31.0.0"
}
bash-5.2$ brioche build -e test -p packages/wasmtime/
Build finished, completed (no new jobs) in 3.13s
Result: 246240b7a7ec4858f285e935015eada6428db04aa4cf8beacad43448957c7bdd
```