### PR TITLE
chore(xplr): update version to 1.0.0 and add testing capability

### DIFF
--- a/packages/xplr/brioche.lock
+++ b/packages/xplr/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/sayanarijit/xplr.git": {
-      "v0.21.10": "e766a9842b1bae0106c453c33d9f31e7d4959779"
+      "v1.0.0": "22968facf151ec090e197742ef12da2aa97e709b"
     }
   }
 }

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -5,7 +5,7 @@ import { gitCheckout } from "git";
 
 export const project = {
   name: "xplr",
-  version: "0.21.10",
+  version: "1.0.0",
 };
 
 const source = (() => {
@@ -26,11 +26,25 @@ const source = (() => {
   return source;
 })();
 
-export default function (): std.Recipe<std.Directory> {
+export default function xplr(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/xplr",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    echo -n $(xplr --version) | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(xplr());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `xplr ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/xplr/
 0.07s ✓ Process 69755
Build finished, completed 1 job in 6.53s
Running brioche-run
{
  "name": "xplr",
  "version": "1.0.0"
}
bash-5.2$ brioche build -e test -p packages/xplr/
67311  │    Compiling nu-ansi-term v0.50.1
       │    Compiling ansi-to-tui v7.0.0
       │    Compiling skim v0.16.1
       │    Compiling textwrap v0.16.2
       │    Compiling snailquote v0.3.1
       │    Compiling jf v0.6.2
       │    Compiling lscolors v0.20.0
       │    Compiling path-absolutize v3.1.1
       │    Compiling humansize v2.1.3
       │    Compiling tui-input v0.11.1
       │    Compiling gethostname v1.0.0
       │    Compiling natord v1.0.9
       │    Compiling xdg v2.5.2
       │    Compiling home v0.5.11
       │    Compiling mlua v0.10.3
       │    Compiling xplr v1.0.0 (/home/brioche-runner-18ad0df949dcce7df5918c81989616db722c55877b752f3b4eced59925cb629f/work)
       │     Finished `release` profile [optimized] target(s) in 5m 02s
       │   Installing /home/brioche-runner-18ad0df949dcce7df5918c81989616db722c55877b752f3b4eced59925cb629f/.local/share/brioche/outputs/output-18ad0df949dcce7df5918c81989616db722c55877b752f3b4eced59925cb629f/bin/xplr
       │    Installed package `xplr v1.0.0 (/home/brioche-runner-18ad0df949dcce7df5918c81989616db722c55877b752f3b4eced59925cb629f/work)` (executable `xplr`)
69719  │ xplr 1.0.0
 0.16s ✓ Process 69719
 5m 2s ✓ Process 67311
15.15s ✓ Process 67217
 0.19s ✓ Process 67215
Build finished, completed 7 jobs in 6m11s
Result: fecf2992cf14bc3f5a4b24f9b1ee58e0cd151d4e67e847e0aa550faf959e51e3
```