### PR TITLE
chore(zx): update version to 8.5.2 and add test and auto-update functions

### DIFF
--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -1,9 +1,10 @@
 import * as std from "std";
 import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
 
 export const project = {
   name: "zx",
-  version: "8.3.0",
+  version: "8.5.2",
 };
 
 export default function zx() {
@@ -15,8 +16,41 @@ export default function zx() {
   return std.withRunnableLink(recipe, "bin/zx");
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     zx --version | tee "$BRIOCHE_OUTPUT"
   `.dependencies(zx());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.name}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/zx
Build finished, completed (no new jobs) in 2.86s
Running brioche-run
{
  "name": "zx",
  "version": "8.5.2"
}
bash-5.2$ brioche build -e test -p packages/zx
30507  │ npm notice
       │ npm notice New major version of npm available! 10.9.2 -> 11.3.0
       │ npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
       │ npm notice To update run: npm install -g npm@11.3.0
       │ npm notice
       │ added 1 package in 826ms
30539  │ 8.5.2
 0.78s ✓ Process 30539
 0.18s ✓ Process 30530
 2.78s ✓ Process 30507
Build finished, completed 3 jobs in 21.99s
Result: 808db600fd3bd07d95d9bbb82627d0918f6b8cfe62e051e08f839d111559c29b
```