### PR TITLE
chore(just): update test function to validate version

### DIFF
--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -22,10 +22,21 @@ export default function just(): std.Recipe<std.Directory> {
   });
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     just --version | tee "$BRIOCHE_OUTPUT"
   `.dependencies(just());
+
+  const version = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expectedVersion = `just ${project.version}`;
+  std.assert(
+    version === expectedVersion,
+    `expected '${expectedVersion}', got '${version}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/just    
 0.07s ✓ Process 30785
Build finished, completed 1 job in 13.18s
Running brioche-run
{
  "name": "just",
  "version": "1.40.0"
}
bash-5.2$ brioche build -e test -p packages/just
Build finished, completed (no new jobs) in 2.78s
Result: ed728a7d6d3136f1d657295d9790e10d614088e5c1623be8f1f40047c6a6ca19
```