### PR TITLE
chore(fd): update test capability to enforce version checking

### DIFF
--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -22,10 +22,21 @@ export default function fd(): std.Recipe<std.Directory> {
   });
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     fd --version | tee "$BRIOCHE_OUTPUT"
   `.dependencies(fd());
+
+  const version = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expectedVersion = `fd ${project.version}`;
+  std.assert(
+    version === expectedVersion,
+    `expected '${expectedVersion}', got '${version}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/fd  
Build finished, completed (no new jobs) in 2.81s
Running brioche-run
{
  "name": "fd",
  "version": "10.2.0"
}
bash-5.2$ brioche build -e test -p packages/fd
Build finished, completed (no new jobs) in 2.82s
Result: 277121fee20cb8ef80722339012ebe987e879f6c979a6fa47d2bf76b1f27bb48
```