### PR TITLE
chore(pstack): enhance test function to validate version

### DIFF
--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -30,10 +30,21 @@ export default async function pstack(): Promise<std.Recipe<std.Directory>> {
   });
 }
 
-export function test() {
-  return std.runBash`
-    pstack --version | tee "$BRIOCHE_OUTPUT"
+export async function test() {
+  const script = std.runBash`
+    pstack --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `.dependencies(pstack());
+
+  const version = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expectedVersion = (await gitRef).commit;
+  std.assert(
+    version === expectedVersion,
+    `expected '${expectedVersion}', got '${version}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/pstack
Build finished, completed (no new jobs) in 3.18s
Running brioche-run
{
  "name": "pstack",
  "version": "2.10"
}
bash-5.2$ brioche build -e test -p packages/pstack
Build finished, completed (no new jobs) in 2.60s
Result: 9c297556324597f0b8be4e849ec33348e4f297917817150d114cc6e2530aa414
```