### PR TITLE
chore(fx): enhance test function to validate version

### DIFF
--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -22,11 +22,21 @@ export default function fx(): std.Recipe<std.Directory> {
   });
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     fx --version | tee "$BRIOCHE_OUTPUT"
-    echo '{"hello": "world"}' | fx 'Object.keys' | tee "$BRIOCHE_OUTPUT"
   `.dependencies(fx());
+
+  const version = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expectedVersion = project.version;
+  std.assert(
+    version === expectedVersion,
+    `expected '${expectedVersion}', got '${version}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/fx     
Build finished, completed (no new jobs) in 2.93s
Running brioche-run
{
  "name": "fx",
  "version": "35.0.0"
}
bash-5.2$ brioche build -e test -p packages/fx
Build finished, completed (no new jobs) in 2.20s
Result: f5d39d97c98d438dd23611d856fa866a7dd23f95336f11f689ca27244ddcc6ba
```