### PR TITLE
feat(kubent): add package with test and autoUpdate capabilities

### DIFF
--- a/packages/kubent/brioche.lock
+++ b/packages/kubent/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/doitintl/kube-no-trouble.git": {
+      "0.7.3": "57480c07b3f91238f12a35d0ec88d9368aae99aa"
+    }
+  }
+}

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -1,0 +1,61 @@
+import nushell from "nushell";
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "kubent",
+  version: "0.7.3",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/doitintl/kube-no-trouble.git",
+    ref: project.version,
+  }),
+);
+
+export default function kubent(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/kubent",
+    buildParams: {
+      ldflags: ["-s", "-w", `-X main.version=v${project.version}`],
+    },
+    runnable: "bin/kubent",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    kubent --version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(kubent());
+
+  const result = (await script.toFile().read()).trim();
+
+  const versionMatch = result.match(/version v([^\s]+)/);
+  const version = versionMatch == null ? null : versionMatch[1];
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/doitintl/kube-no-trouble/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/kubent/
Build finished, completed (no new jobs) in 2.77s
Running brioche-run
{
  "name": "kubent",
  "version": "0.7.3"
}
bash-5.2$ brioche build -e test -p packages/kubent/
Build finished, completed (no new jobs) in 2.24s
Result: bbf9c4592da293e95fc3db4e42d696ccc1ae67d307322a35b56a3a58bfaa6401
```