### PR TITLE
chore(aws_cdk): update version to 2.1010.0; update test function; add autoUpdate capability

### DIFF
--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -1,22 +1,57 @@
 import * as std from "std";
 import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
 
 export const project = {
   name: "aws_cdk",
-  version: "2.176.0",
+  version: "2.1010.0",
+  packageName: "aws-cdk",
 };
 
 export default function awsCdk() {
   const recipe = npmInstallGlobal({
-    packageName: "aws-cdk",
+    packageName: project.packageName,
     version: project.version,
   });
 
   return std.withRunnableLink(recipe, "bin/cdk");
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     cdk --version | tee "$BRIOCHE_OUTPUT"
   `.dependencies(awsCdk());
+
+  const result = await script.toFile().read();
+
+  const versionMatch = result.match(/([^\s]+) \(build [^\s]+\)/);
+  const version = versionMatch == null ? null : versionMatch[1];
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/aws_cdk/
 0.06s ✓ Process 906
Build finished, completed 1 job in 4.72s
Running brioche-run
{
  "name": "aws_cdk",
  "version": "2.1010.0",
  "packageName": "aws-cdk"
}
bash-5.2$ brioche build -e test -p packages/aws_cdk/
Build finished, completed (no new jobs) in 3.06s
Result: 67bc66f7a4072ccc8f1d73c30de5d055096a5c3162b34db7c07395d080c8d7e8
```