### PR TITLE
chore(zoxide): add test function to validate version output

### DIFF
--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -15,11 +15,28 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function zoxide(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/zoxide",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    zoxide --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(zoxide());
+
+  const result = await script.toFile().read();
+
+  // Check that the result contains the expected version
+  const expected = `zoxide ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/zoxide
Build finished, completed (no new jobs) in 2.79s
Running brioche-run
{
  "name": "zoxide",
  "version": "0.9.7"
}
bash-5.2$ brioche build -e test -p packages/zoxide
Build finished, completed (no new jobs) in 2.62s
Result: d15066350b02e7409c7c78cca36f1b724ea9c08a2c7006f879e885817379ad5b
```