### PR TITLE
feat(lurk): add test function to validate version output

### DIFF
--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function lurk(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/lurk",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    lurk --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(lurk());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `lurk ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/lurk  
 0.06s ✓ Process 1517
Build finished, completed 1 job in 4.76s
Running brioche-run
{
  "name": "lurk",
  "version": "0.3.9"
}
bash-5.2$ brioche build -e test -p packages/lurk
Build finished, completed (no new jobs) in 2.91s
Result: 7dd22a3d3aa18713fda32745bc2e0f8f77c40b5ab16f1cb300799c673c8ae845
```