### PR TITLE
feat(oha): add test function to validate version output

### DIFF
--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function oha(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/oha",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    oha --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(oha());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `oha ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/oha      
Build finished, completed (no new jobs) in 3.08s
Running brioche-run
{
  "name": "oha",
  "version": "1.8.0"
}
bash-5.2$ brioche build -e test -p packages/oha      
Build finished, completed (no new jobs) in 2.88s
Result: 5d25d9cd197a6d83524f1d6e0223d98af2c777cb0776f51e92229e383863b343
```