### PR TITLE
feat(miniserve): add test function to validate version output

### DIFF
--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function miniserve(): std.Recipe<std.Directory> {
   return cargoBuild({
     source: source,
     runnable: "bin/miniserve",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    miniserve --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(miniserve());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `miniserve ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
bash-5.2$ brioche run -e autoUpdate -p packages/miniserve
 0.06s ✓ Process 1755
Build finished, completed 1 job in 4.60s
Running brioche-run
{
  "name": "miniserve",
  "version": "0.29.0"
}
bash-5.2$ brioche build -e test -p packages/miniserve
Build finished, completed (no new jobs) in 2.95s
Result: 803012377a24b08195555aedddd27034dc05fde3dbfe16b331daaab10c24d322
```