### PR TITLE
feat(gitui): add test function to validate version output

### DIFF
--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -16,7 +16,7 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function gitui(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     dependencies: [cmake(), git()],
@@ -25,6 +25,23 @@ export default function (): std.Recipe<std.Directory> {
     },
     runnable: "bin/gitui",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    gitui --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(gitui());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `gitui ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected ${expected}, got ${result}`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
[container@f1fcb7d2edd4 workspace]$ brioche run -e autoUpdate -p packages/gitui
Build finished, completed (no new jobs) in 2.53s
Running brioche-run
{
  "name": "gitui",
  "version": "0.27.0"
}
[container@f1fcb7d2edd4 workspace]$ brioche build -e test -p packages/gitui
Build finished, completed (no new jobs) in 2.73s
Result: 92bff9e3ecb20e3b021d536e7875829d0af51e36ae72a22480c9b26e49bdbffd
```