### PR TITLE
feat(jwt_cli): add test function to validate version output

### DIFF
--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -15,11 +15,28 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function jwtCli(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/jwt",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    jwt --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(jwtCli());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `jwt ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected ${expected}, got ${result}`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
[container@f1fcb7d2edd4 workspace]$ brioche run -e autoUpdate -p packages/jwt_cli/
Build finished, completed (no new jobs) in 2.30s
Running brioche-run
{
  "name": "jwt_cli",
  "version": "6.2.0"
}
[container@f1fcb7d2edd4 workspace]$ brioche build -e test -p packages/jwt_cli/
Build finished, completed (no new jobs) in 2.85s
Result: 9c215bf76bb881663c7022642eee666ae7ff7a316af5696ab21c87bd01f536f2
```