### PR TITLE
feat(tokei): add test and autoUpdate capabilities

### DIFF
--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
 import { gitCheckout } from "git";
+import nushell from "nushell";
 
 export const project = {
   name: "tokei",
@@ -14,9 +15,54 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function tokei(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/tokei",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    tokei --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(tokei());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `tokei ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected ${expected}, got ${result}`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    # Version can be suffixed with '-alpha.X'
+    let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
   });
 }


### PR DESCRIPTION
```bash
[container@f1fcb7d2edd4 workspace]$ brioche run -e autoUpdate -p packages/tokei/
Build finished, completed (no new jobs) in 2.40s
Running brioche-run
{
  "name": "tokei",
  "version": "12.1.2"
}
[container@f1fcb7d2edd4 workspace]$ brioche build -e test -p packages/tokei
Build finished, completed (no new jobs) in 2.27s
Result: 705bc7b35c164f287109ecd091c675540ff9138e1389391d300dada5c7c536a9
```