### PR TITLE
feat(xsv): add test function to validate version output

### DIFF
--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -15,11 +15,25 @@ const source = gitCheckout(
   }),
 );
 
-export default function (): std.Recipe<std.Directory> {
+export default function xsv(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
     runnable: "bin/xsv",
   });
+}
+
+export async function test() {
+  const script = std.runBash`
+    xsv --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(xsv());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
[container@f1fcb7d2edd4 workspace]$ brioche run -e autoUpdate -p packages/xsv/
Build finished, completed (no new jobs) in 2.25s
Running brioche-run
{
  "name": "xsv",
  "version": "0.13.0"
}
[container@f1fcb7d2edd4 workspace]$ brioche build -e test -p packages/xsv/
Build finished, completed (no new jobs) in 2.25s
Result: 4b4f6561b950349651a7775654f1a697f3f3ccb2c51a66d5c97b0057ce97141f
```