### PR TITLE
refactor(testing): uniformize version assertion in test functions

### DIFF
--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -40,10 +40,9 @@ export async function test() {
     })
     .at(0);
 
-  std.assert(
-    version === project.version,
-    `expected version ${project.version}, got ${version}`,
-  );
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -30,11 +30,8 @@ export async function test() {
   const version = (await script.toFile().read()).trim();
 
   // Check that the result contains the expected version
-  const expectedVersion = `fd ${project.version}`;
-  std.assert(
-    version === expectedVersion,
-    `expected '${expectedVersion}', got '${version}'`,
-  );
+  const expected = `fd ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -30,11 +30,8 @@ export async function test() {
   const version = (await script.toFile().read()).trim();
 
   // Check that the result contains the expected version
-  const expectedVersion = project.version;
-  std.assert(
-    version === expectedVersion,
-    `expected '${expectedVersion}', got '${version}'`,
-  );
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -38,7 +38,7 @@ export async function test() {
   const expected = `gitui ${project.version}`;
   std.assert(
     result.startsWith(expected),
-    `expected ${expected}, got ${result}`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -72,10 +72,11 @@ export async function test() {
     .match(/^ICU Initialization returned: (.*)$/m)
     ?.at(1);
 
-  std.assert(
-    version === project.version,
-    `expected version number to be '${project.version}', got ${version}`,
-  );
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  // Check that the result contains the expected return code
   std.assert(
     returnCode === "U_ZERO_ERROR",
     `expected icuinfo initialization to return U_ZERO_ERROR, got '${returnCode}'`,

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -46,7 +46,7 @@ export async function test() {
   const expected = `joshuto-${project.version}`;
   std.assert(
     result.startsWith(expected),
-    `expected ${expected}, got ${result}`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -33,11 +33,8 @@ export async function test() {
   const version = (await script.toFile().read()).trim();
 
   // Check that the result contains the expected version
-  const expectedVersion = `jj ${project.version}`;
-  std.assert(
-    version === expectedVersion,
-    `expected '${expectedVersion}', got '${version}'`,
-  );
+  const expected = `jj ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -30,11 +30,8 @@ export async function test() {
   const version = (await script.toFile().read()).trim();
 
   // Check that the result contains the expected version
-  const expectedVersion = `just ${project.version}`;
-  std.assert(
-    version === expectedVersion,
-    `expected '${expectedVersion}', got '${version}'`,
-  );
+  const expected = `just ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -33,7 +33,7 @@ export async function test() {
   const expected = `jwt ${project.version}`;
   std.assert(
     result.startsWith(expected),
-    `expected ${expected}, got ${result}`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -79,10 +79,9 @@ export async function test() {
 
   const version = await script.toFile().read();
 
-  std.assert(
-    version === project.version,
-    `expected '${project.version}', got '${version}'`,
-  );
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -35,13 +35,11 @@ export async function test() {
     echo -n "$(nginx -v 2>&1)" | tee "$BRIOCHE_OUTPUT"
   `.dependencies(nginx());
 
-  const versionMessage = await script.toFile().read();
-  const expectedVersionMessage = `nginx version: nginx/${project.version}`;
+  const result = await script.toFile().read();
 
-  std.assert(
-    versionMessage === expectedVersionMessage,
-    `expected '${expectedVersionMessage}', got '${versionMessage}'`,
-  );
+  // Check that the result contains the expected version
+  const expected = `nginx version: nginx/${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -45,7 +45,7 @@ export async function test() {
 
   // Check that the result contains the expected version
   const expected = project.version;
-  std.assert(result === expected, `expected ${expected}, got ${result}`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -56,10 +56,10 @@ export async function test() {
   const result = await script.toFile().read();
 
   const version = result.match(/^Version:\s*v([\d.]+)$/m)?.at(1);
-  std.assert(
-    version === project.version,
-    `expected '${project.version}', got '${version}'`,
-  );
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -38,11 +38,8 @@ export async function test() {
   const version = (await script.toFile().read()).trim();
 
   // Check that the result contains the expected version
-  const expectedVersion = (await gitRef).commit;
-  std.assert(
-    version === expectedVersion,
-    `expected '${expectedVersion}', got '${version}'`,
-  );
+  const expected = (await gitRef).commit;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -29,9 +29,11 @@ export async function test() {
   `.dependencies(restic());
   const output = await script.toFile().read();
 
+  // Check that the result contains the expected version
+  const expected = `restic ${project.version}`;
   std.assert(
-    output.startsWith(`restic ${project.version} `),
-    `expected version ${project.version}, got ${JSON.stringify(output)}`,
+    output.startsWith(expected),
+    `expected '${expected}', got '${JSON.stringify(output)}'`,
   );
 
   return script;

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -33,10 +33,9 @@ export async function test() {
 
   const version = output.split("\n").at(0);
 
-  std.assert(
-    version === `ripgrep ${project.version}`,
-    `expected version ${project.version}, got ${version}`,
-  );
+  // Check that the result contains the expected version
+  const expected = `ripgrep ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -112,10 +112,14 @@ export async function test() {
   `
     .dependencies(rust())
     .toFile();
+
   const versionOutput = await script.read().then((output) => output.trim());
+
+  // Check that the result contains the expected version
+  const expected = `rustc ${project.version}`;
   std.assert(
-    versionOutput.startsWith(`rustc ${project.version} `),
-    `expected ${project.version}, got ${JSON.stringify(versionOutput)}`,
+    versionOutput.startsWith(expected),
+    `expected '${expected}', got '${JSON.stringify(versionOutput)}'`,
   );
   return script;
 }

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -35,10 +35,10 @@ export async function test() {
   const result = await script.toFile().read();
 
   const version = result.match(/^strace -- version ([\d.]+)$/m)?.at(1);
-  std.assert(
-    version === project.version,
-    `expected '${project.version}', got '${version}'`,
-  );
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -33,7 +33,7 @@ export async function test() {
   const expected = `tokei ${project.version}`;
   std.assert(
     result.startsWith(expected),
-    `expected ${expected}, got ${result}`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;


### PR DESCRIPTION
This PR tries to uniformize the testing of the version in order to later refactor this code and it inside an helper function without too much rework.