### PR TITLE
refactor(testing): uniformize test functions

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -48,9 +48,10 @@ export async function test() {
     ./main | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain(), alsaLib())
-    .env({ src: src });
+    .env({ src: src })
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -24,10 +24,12 @@ export default function amber(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(amber --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(amber());
+    amber --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(amber())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `amber ${project.version}`;

--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -20,9 +20,11 @@ export default function awsCdk() {
 export async function test() {
   const script = std.runBash`
     cdk --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(awsCdk());
+  `
+    .dependencies(awsCdk())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   const versionMatch = result.match(/([^\s]+) \(build [^\s]+\)/);
   const version = versionMatch == null ? null : versionMatch[1];

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -110,9 +110,11 @@ export default function awsCli(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     aws --version | tr -d '\n' | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(awsCli());
+  `
+    .dependencies(awsCli())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `aws-cli/${project.version} `;

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -24,10 +24,12 @@ export default function bat(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(bat --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(bat());
+    bat --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bat())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `bat ${project.version}`;

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -24,10 +24,12 @@ export default function broot(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(broot --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(broot());
+    broot --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(broot())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `broot ${project.version}`;

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -66,9 +66,11 @@ function xcaddy(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     caddy version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(caddy());
+  `
+    .dependencies(caddy())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   std.assert(
     result.startsWith(`v${project.version} `),

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -29,10 +29,12 @@ export default function carapace(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(carapace --version 2>&1) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(carapace());
+    carapace --version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(carapace())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `carapace-bin ${project.version}`;

--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -19,10 +19,12 @@ export default function claudeCode() {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(claude --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(claudeCode());
+    claude --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(claudeCode())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `${project.version} (Claude Code)`;

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -212,10 +212,12 @@ export function cmakeBuild(
 export async function test() {
   const script = std.runBash`
     # Only retrieve the first line of the output, other lines are not relevant for the version check
-    echo -n $(cmake --version | head -n 1) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(cmake());
+    cmake --version | head -n 1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cmake())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `cmake version ${project.version}`;

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -36,10 +36,12 @@ export default function dasel(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(dasel --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(dasel());
+    dasel --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dasel())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `dasel version ${project.version}`;

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -24,10 +24,12 @@ export default function dust(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(dust --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(dust());
+    dust --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dust())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `Dust ${project.version}`;

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -24,11 +24,14 @@ export default function eza(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(eza --version)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(eza());
-  const output = await script.toFile().read();
+    eza --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(eza())
+    .toFile();
 
-  const version = output
+  const result = (await script.read()).trim();
+
+  const version = result
     .split("\n")
     .flatMap((line) => {
       const versionMatch = line.match(/^v([^\s]+)/);

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -25,13 +25,15 @@ export default function fd(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     fd --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(fd());
+  `
+    .dependencies(fd())
+    .toFile();
 
-  const version = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `fd ${project.version}`;
-  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -25,13 +25,15 @@ export default function fx(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     fx --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(fx());
+  `
+    .dependencies(fx())
+    .toFile();
 
-  const version = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;
-  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -33,10 +33,12 @@ export default function gh(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(gh --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(gh());
+    gh --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gh())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `gh version ${project.version} (${project.latestBuildDate}) https://github.com/cli/cli/releases/tag/v${project.version}`;

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -30,9 +30,11 @@ export default function gitui(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     gitui --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(gitui());
+  `
+    .dependencies(gitui())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `gitui ${project.version}`;

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -64,8 +64,11 @@ export default function icu(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     icuinfo | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(icu());
-  const result = await script.toFile().read();
+  `
+    .dependencies(icu())
+    .toFile();
+
+  const result = (await script.read()).trim();
 
   const version = result.match(/<param name="version">([^<]*)<\/param>/)?.at(1);
   const returnCode = result

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -38,9 +38,11 @@ export default function joshuto(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     joshuto --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(joshuto());
+  `
+    .dependencies(joshuto())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `joshuto-${project.version}`;

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -28,10 +28,12 @@ export default function jq(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(jq --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(jq());
+    jq --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(jq())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `jq-${project.version}`;

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -28,13 +28,15 @@ export default function jujutsu(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     jj version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(jujutsu());
+  `
+    .dependencies(jujutsu())
+    .toFile();
 
-  const version = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `jj ${project.version}`;
-  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -25,13 +25,15 @@ export default function just(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     just --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(just());
+  `
+    .dependencies(just())
+    .toFile();
 
-  const version = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `just ${project.version}`;
-  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -25,9 +25,11 @@ export default function jwtCli(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     jwt --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(jwtCli());
+  `
+    .dependencies(jwtCli())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `jwt ${project.version}`;

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -32,10 +32,12 @@ export default function k9s(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     # Remove ANSI color codes from the output, before extracting the version
-    echo -n $(k9s version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }') | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(k9s());
+    k9s version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(k9s())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -29,9 +29,11 @@ export default function kubent(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     kubent --version 2>&1 | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(kubent());
+  `
+    .dependencies(kubent())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   const versionMatch = result.match(/version v([^\s]+)/);
   const version = versionMatch == null ? null : versionMatch[1];

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -34,9 +34,11 @@ export default function libarchive(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     pkg-config --modversion libarchive | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(std.toolchain(), libarchive());
+  `
+    .dependencies(std.toolchain(), libarchive())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -31,10 +31,12 @@ export default function libffi(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(pkg-config --modversion libffi) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(std.toolchain(), libffi());
+    pkg-config --modversion libffi | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), libffi())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -31,9 +31,11 @@ export default function libpcap(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     pkg-config --modversion libpcap | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(std.toolchain(), libpcap());
+  `
+    .dependencies(std.toolchain(), libpcap())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -49,9 +49,10 @@ export async function test() {
     ./main | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain(), libPsl())
-    .env({ src: src });
+    .env({ src: src })
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `${project.version} (no IDNA support)`;

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -74,14 +74,16 @@ export function llvmToolchain(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(llvm-config --version)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(llvm());
+    llvm-config --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(llvm())
+    .toFile();
 
-  const version = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;
-  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -25,9 +25,11 @@ export default function lurk(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     lurk --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(lurk());
+  `
+    .dependencies(lurk())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `lurk ${project.version}`;

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -25,9 +25,11 @@ export default function miniserve(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     miniserve --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(miniserve());
+  `
+    .dependencies(miniserve())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `miniserve ${project.version}`;

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -32,10 +32,12 @@ export default function nginx(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(nginx -v 2>&1)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(nginx());
+    nginx -v 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nginx())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `nginx version: nginx/${project.version}`;

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -25,10 +25,12 @@ export default function nushell(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(nu --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(nushell());
+    nu --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nushell())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `${project.version}`;

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -25,9 +25,11 @@ export default function oha(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     oha --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(oha());
+  `
+    .dependencies(oha())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `oha ${project.version}`;

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -39,9 +39,11 @@ export default function oniguruma(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     onig-config --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(oniguruma());
+  `
+    .dependencies(oniguruma())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -39,9 +39,11 @@ export default function openssl(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     openssl version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(openssl());
+  `
+    .dependencies(openssl())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `OpenSSL ${project.version}`;

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -31,9 +31,11 @@ export default function tofu(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     tofu --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(tofu());
+  `
+    .dependencies(tofu())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `OpenTofu v${project.version}`;

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -34,10 +34,12 @@ export default function php(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(php --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(php());
+    php --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(php())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `PHP ${project.version} (cli)`;

--- a/packages/popeye/project.bri
+++ b/packages/popeye/project.bri
@@ -32,10 +32,12 @@ export default function popeye(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     # Remove ANSI color codes from the output, before extracting the version
-    echo -n $(popeye version| sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }') | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(popeye());
+    popeye version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(popeye())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -47,10 +47,12 @@ export default function postgresql(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(postgres --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(postgresql());
+    postgres --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(postgresql())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `postgres (PostgreSQL) ${project.version}`;

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -51,9 +51,11 @@ export default function processCompose(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     process-compose version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(processCompose());
+  `
+    .dependencies(processCompose())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   const version = result.match(/^Version:\s*v([\d.]+)$/m)?.at(1);
 

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -33,9 +33,11 @@ export default async function pstack(): Promise<std.Recipe<std.Directory>> {
 export async function test() {
   const script = std.runBash`
     pstack --version 2>&1 | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(pstack());
+  `
+    .dependencies(pstack())
+    .toFile();
 
-  const version = (await script.toFile().read()).trim();
+  const version = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = (await gitRef).commit;

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -30,14 +30,17 @@ export default function rclone(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     rclone --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(rclone());
+  `
+    .dependencies(rclone())
+    .toFile();
 
-  const scriptOutput = await script.toFile().read();
-  const result = scriptOutput.split("\n").at(0);
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
 
   // Check that the result contains the expected version
   const expected = `rclone v${project.version}`;
-  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;
 }

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -16,7 +16,7 @@ const source = Brioche.download(
 export default function re2c(): std.Recipe<std.Directory> {
   let re2c = std.runBash`
     ./configure \\
-      --prefix=/ 
+      --prefix=/
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
@@ -35,10 +35,12 @@ export default function re2c(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(re2c --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(re2c());
+    re2c --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(re2c())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `re2c ${project.version}`;

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -25,15 +25,18 @@ export default function restic(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(restic version)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(restic());
-  const output = await script.toFile().read();
+    restic version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(restic())
+    .toFile();
+
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `restic ${project.version}`;
   std.assert(
-    output.startsWith(expected),
-    `expected '${expected}', got '${JSON.stringify(output)}'`,
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -27,11 +27,14 @@ export default function ripgrep(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(rg --version)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(ripgrep());
-  const output = await script.toFile().read();
+    rg --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ripgrep())
+    .toFile();
 
-  const version = output.split("\n").at(0);
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
 
   // Check that the result contains the expected version
   const expected = `ripgrep ${project.version}`;

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -25,10 +25,12 @@ export default function ruff(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n "$(ruff --version)" | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(ruff());
+    ruff --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ruff())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `ruff ${project.version}`;

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -113,14 +113,15 @@ export async function test() {
     .dependencies(rust())
     .toFile();
 
-  const versionOutput = await script.read().then((output) => output.trim());
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `rustc ${project.version}`;
   std.assert(
-    versionOutput.startsWith(expected),
-    `expected '${expected}', got '${JSON.stringify(versionOutput)}'`,
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
   );
+
   return script;
 }
 

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -61,12 +61,13 @@ export async function test() {
     gcc main.c -o main -lexecs
 
     # Output 'Hello, World!' through s2argv_execs
-    echo -n $(echo "echo 'Hello, World!'" | ./main) | tee "$BRIOCHE_OUTPUT"
+    echo "echo 'Hello, World!'" | ./main | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain(), s2argvExecs())
-    .env({ src: src });
+    .env({ src: src })
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected result
   const expected = "Hello, World!";

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -27,10 +27,12 @@ export default function steampipe(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(steampipe --version 2>&1) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(steampipe());
+    steampipe --version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(steampipe())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `Steampipe v${project.version}`;

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -30,9 +30,11 @@ export default function strace(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     strace --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(strace());
+  `
+    .dependencies(strace())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   const version = result.match(/^strace -- version ([\d.]+)$/m)?.at(1);
 

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -37,10 +37,12 @@ export default function terraform(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     # Only retrieve the first line of the output, other lines are not relevant for the version check
-    echo -n $(terraform --version | head -n 1) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(terraform());
+    terraform --version | head -n 1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(terraform())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `Terraform v${project.version}`;

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -25,9 +25,11 @@ export default function tokei(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     tokei --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(tokei());
+  `
+    .dependencies(tokei())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `tokei ${project.version}`;

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -24,10 +24,12 @@ export default function wasmtime(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(wasmtime --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(wasmtime());
+    wasmtime --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmtime())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `wasmtime ${project.version}`;

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -35,10 +35,12 @@ export default function xplr(): std.Recipe<std.Directory> {
 
 export async function test() {
   const script = std.runBash`
-    echo -n $(xplr --version) | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(xplr());
+    xplr --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(xplr())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `xplr ${project.version}`;

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -25,9 +25,11 @@ export default function xsv(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     xsv --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(xsv());
+  `
+    .dependencies(xsv())
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -25,9 +25,11 @@ export default function zoxide(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     zoxide --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(zoxide());
+  `
+    .dependencies(zoxide())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `zoxide ${project.version}`;

--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -19,9 +19,11 @@ export default function zx() {
 export async function test() {
   const script = std.runBash`
     zx --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(zx());
+  `
+    .dependencies(zx())
+    .toFile();
 
-  const result = await script.toFile().read();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = project.version;


### PR DESCRIPTION
This PR does a few things:

- Always ensure that the `script` variable is cast as a file before being returned
- Remove the `echo -n $()" encapsulation in few test methods, and always trim the empty end of line on typescript side
- Try to always use `result` instead of `output` for script result content.