### PR TITLE
feat(nasm): add test function to validate version output

### DIFF
--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -25,7 +25,8 @@ export default function nasm() {
     ln -s "bin/nasm" "$BRIOCHE_OUTPUT/brioche-run"
   `
     .dependencies(std.toolchain())
-    .workDir(source);
+    .workDir(source)
+    .toDirectory();
 }
 
 export async function test() {

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -14,7 +14,7 @@ const source = gitCheckout(
   }),
 );
 
-export default function () {
+export default function nasm() {
   return std.runBash`
     ./autogen.sh
     ./configure
@@ -26,6 +26,25 @@ export default function () {
   `
     .dependencies(std.toolchain())
     .workDir(source);
+}
+
+export async function test() {
+  const script = std.runBash`
+    nasm --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nasm())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `NASM version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
 }
 
 export function autoUpdate() {


### PR DESCRIPTION
```bash
[container@ba5998f2ae1e workspace]$ brioche run -e autoUpdate -p packages/nasm
Build finished, completed (no new jobs) in 2.21s
Running brioche-run
{
  "name": "nasm",
  "version": "2.16.03"
}
[container@ba5998f2ae1e workspace]$ brioche build -e test -p packages/nasm
Build finished, completed (no new jobs) in 1.61s
Result: 9422ec73e0924baf043aa8f1d1db2d902e4c0be7d71c5b3068b15eb45b09b61d
```