### PR TITLE
feat(nodejs): add test and autoUpdate capabilities

### DIFF
--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -32,10 +32,47 @@ interface NpmInstallOptions {
   source: std.AsyncRecipe<std.Directory>;
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     node --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(nodejs());
+  `
+    .dependencies(nodejs())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/nodejs/node/git/matching-refs/tags
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }
 
 /**


### PR DESCRIPTION
```bash
[container@ba5998f2ae1e workspace]$ brioche run -e autoUpdate -p packages/nodejs
Build finished, completed (no new jobs) in 2.53s
Running brioche-run
{
  "name": "nodejs",
  "version": "23.11.0"
}
[container@ba5998f2ae1e workspace]$ brioche build -e test -p packages/nodejs
Build finished, completed (no new jobs) in 1.64s
Result: 9e89d218601329b5aac2aa3dab82b9df143651b77642fd580b402f7b8b334b5a
```