### PR TITLE
chore(autoUpdate): update API endpoint to fetch tags for versioning

### DIFF
--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -128,7 +128,7 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/
+    let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -57,7 +57,7 @@ export async function test() {
 export function autoUpdate() {
   const src = std.file(std.indoc`
     # Version can either be prefixed with 'v' or not
-    let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/
+    let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -30,7 +30,7 @@ export default function () {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/netwide-assembler/nasm/git/matching-refs/
+    let version = http get https://api.github.com/repos/netwide-assembler/nasm/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -78,7 +78,7 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/virtualsquare/s2argv-execs/git/matching-refs/
+    let version = http get https://api.github.com/repos/virtualsquare/s2argv-execs/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -44,7 +44,7 @@ export async function test() {
 export function autoUpdate() {
   const src = std.file(std.indoc`
     # Version can be suffixed with '-alpha.X'
-    let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/
+    let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -32,7 +32,7 @@ export default function (): std.Recipe<std.Directory> {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/rd235/vdeplug4/git/matching-refs/
+    let version = http get https://api.github.com/repos/rd235/vdeplug4/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref


### PR DESCRIPTION
While working on https://github.com/brioche-dev/brioche-packages/pull/333, I was first getting a 504 in the autoUpdate function. During the initial testing of the nodejs PR, doing a GET on `https://api.github.com/repos/nodejs/node/git/matching-refs/` was leading a 504 error code from the GitHub API. After having read the documentation of [this REST API](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references), I saw that it was returning all the heads, tags, remotes of the repositories. While we only want the tags here.

Here is a quick showcase test (using Nushell) to demonstrate the different capabilities of the API:

```nu
➜ http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/tags | length 
2833

➜ http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/heads | length 
85

➜ http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/ | length 
7757
```

The thing is, the larger the output, the longer it takes to process. Only fetching the tags here lead to two advantages:

- Reduce the size of the response (and thus, reduce the possibility to get a 504 from the GitHub API)
- Reduce the process time by stripping during the first stage the unwanted data