### PR TITLE
feat(unzip): add test capability

### DIFF
--- a/packages/unzip/project.bri
+++ b/packages/unzip/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 // https://www.linuxfromscratch.org/blfs/view/12.2/general/unzip.html
 const patches = Brioche.includeDirectory("patches");
 
-export default function (): std.Recipe<std.Directory> {
+export default function unzip(): std.Recipe<std.Directory> {
   return std.runBash`
     patch -Np1 -i "$patches"/unzip-6.0-consolidated_fixes-1.patch
     patch -Np1 -i "$patches"/unzip-6.0-gcc14-1.patch
@@ -27,4 +27,23 @@ export default function (): std.Recipe<std.Directory> {
     .dependencies(std.toolchain())
     .workDir(source)
     .toDirectory();
+}
+
+export async function test() {
+  const script = std.runBash`
+    unzip --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(unzip())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `UnZip ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
 }


### PR DESCRIPTION
There is no dedicated `--version` flag for UnZip.

```bash
[container@ba5998f2ae1e workspace]$ brioche build -e test -p packages/unzip
14857  │   Default action is to extract files in list, except those in xlist, to exdir;
       │   file[.zip] may be a wildcard.  -Z => ZipInfo mode ("unzip -Z" for usage).
       │   -p  extract files to pipe, no messages     -l  list files (short format)
       │   -f  freshen existing files, create none    -t  test compressed archive data
       │   -u  update files, create if necessary      -z  display archive comment only
       │   -v  list verbosely/show version info       -T  timestamp archive to latest
       │   -x  exclude files that follow (in xlist)   -d  extract files into exdir
       │ modifiers:
       │   -n  never overwrite existing files         -q  quiet mode (-qq => quieter)
       │   -o  overwrite files WITHOUT prompting      -a  auto-convert any text files
       │   -j  junk paths (do not make directories)   -aa treat ALL files as text
       │   -U  use escapes for all non-ASCII Unicode  -UU ignore any Unicode fields
       │   -C  match filenames case-insensitively     -L  make (some) names lowercase
       │   -X  restore UID/GID info                   -V  retain VMS version numbers
       │   -K  keep setuid/setgid/tacky permissions   -M  pipe through "more" pager
       │   -O CHARSET  specify a character encoding for DOS, Windows and OS/2 archives
       │   -I CHARSET  specify a character encoding for UNIX and other archives
       │ See "unzip -hh" or unzip.txt for more help.  Examples:
       │   unzip data1 -x joe   => extract all files except joe from zipfile data1.zip
       │   unzip -p foo | more  => send contents of foo.zip via pipe into program more
       │   unzip -fo foo ReadMe => quietly replace existing ReadMe if archive file newer
 0.12s ✓ Process 14857
Build finished, completed 1 job in 2.78s
Result: 97241ee125576f15e063ee513827c85459d58290a4927dc3c400a9c2ad22cda7
```