### PR TITLE
chore: remove unecessary export modifier from source definitions

### DIFF
--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -16,7 +16,7 @@ std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
 // Ensure the minor version number matches the version
 std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
 
-export const source = Brioche.download(
+const source = Brioche.download(
   `https://download.gnome.org/sources/libxml2/${project.extra.majorVersion}.${project.extra.minorVersion}/libxml2-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -10,7 +10,7 @@ export const project = {
   version: "0.70",
 };
 
-export const source = gitCheckout(
+const source = gitCheckout(
   Brioche.gitRef({
     repository: "git://git.joeyh.name/moreutils",
     ref: project.version,

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -15,7 +15,7 @@ const gitRef = Brioche.gitRef({
   repository: "https://github.com/F1bonacc1/process-compose.git",
   ref: `v${project.version}`,
 });
-export const source = gitCheckout(gitRef);
+const source = gitCheckout(gitRef);
 
 export default function processCompose(): std.Recipe<std.Directory> {
   let processCompose = std.recipeFn(async () =>

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -9,7 +9,7 @@ export const project = {
   version: "5.4.0",
 };
 
-export const source = std.recipeFn(() => {
+const source = std.recipeFn(() => {
   const source = gitCheckout(
     Brioche.gitRef({
       repository: "https://github.com/proot-me/proot.git",

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -8,7 +8,7 @@ export const project = {
   version: "1.4",
 };
 
-export const source = gitCheckout(
+const source = gitCheckout(
   Brioche.gitRef({
     repository: "https://github.com/virtualsquare/s2argv-execs.git",
     ref: project.version,

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -5,7 +5,7 @@ export const project = {
   version: "1.11.3",
 };
 
-export const source = Brioche.download(
+const source = Brioche.download(
   `https://git.sr.ht/~sircmpwn/scdoc/archive/${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -9,7 +9,7 @@ export const project = {
   version: "4.0.1",
 };
 
-export const source = gitCheckout(
+const source = gitCheckout(
   Brioche.gitRef({
     repository: "https://github.com/rd235/vdeplug4.git",
     ref: `v${project.version}`,


### PR DESCRIPTION
This PR standardizes the declaration of `source` variables across projects by removing the `export` keyword. We don't need to export it normally.