### PR TITLE
Add `mdbook` package

### DIFF
--- a/packages/mdbook/brioche.lock
+++ b/packages/mdbook/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rust-lang/mdBook.git": {
+      "v0.4.48": "b7a27d2759e80d804a33a4bc9c31b2b6863a5cb2"
+    }
+  }
+}

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "mdbook",
+  version: "0.4.48",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/rust-lang/mdBook.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function mdbook(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/mdbook",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    mdbook --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(mdbook())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `mdbook v${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/rust-lang/mdBook/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a package for [mdBook](https://github.com/rust-lang/mdBook), a tool that converts Markdown files into a readable online book.