### PR TITLE
Add `rip2` package

### DIFF
--- a/packages/rip2/brioche.lock
+++ b/packages/rip2/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/MilesCranmer/rip2.git": {
+      "v0.9.4": "b0af446ef693c5d2b08a6ae36d7b6156c7ec72f6"
+    }
+  }
+}

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "rip2",
+  version: "0.9.4",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/MilesCranmer/rip2.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function rip2(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/rip",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    rip --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rip2())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `rip ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/MilesCranmer/rip2/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a package for [rip2](https://github.com/MilesCranmer/rip2), a CLI tool for managing deleted files (similar to trashing a file, but using its own independent trash scheme instead of integrating with the OS's trash).

rip2 is a fork of the earlier (unmaintained) [rip](https://github.com/nivekuil/rip) (rm-improved) project. rip2 seems to be the most complete and active fork of rip.