### PR TITLE
Add `xh` package

### DIFF
--- a/packages/xh/brioche.lock
+++ b/packages/xh/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/ducaale/xh.git": {
+      "v0.24.0": "21e998e5b2f8f2cef28da2b5ca83b9bf9dde5c60"
+    }
+  }
+}

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "xh",
+  version: "0.24.0",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/ducaale/xh.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function xh(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/xh",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    xh --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(xh())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `xh ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/ducaale/xh/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a package for [xh](https://github.com/ducaale/xh), a CLI tool for making HTTP requests. It's similar to Curl, but with a slicker UX largely based on [HTTPie](https://httpie.io/)