### PR TITLE
Add `meson` package

### DIFF
--- a/packages/meson/brioche.lock
+++ b/packages/meson/brioche.lock
@@ -1,0 +1,18 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://files.pythonhosted.org/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f"
+    },
+    "https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"
+    }
+  },
+  "git_refs": {
+    "https://github.com/mesonbuild/meson.git": {
+      "1.7.2": "082917b40c8416bde925c64d22a2e60b2c059120"
+    }
+  }
+}

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -1,0 +1,107 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import python from "python";
+import nushell from "nushell";
+
+export const project = {
+  name: "meson",
+  version: "1.7.2",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/mesonbuild/meson.git",
+    ref: project.version,
+  }),
+);
+
+const pipDependencies = std.directory({
+  "setuptools-75.1.0-py3-none-any.whl": Brioche.download(
+    `https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl`,
+  ),
+  "wheel-0.44.0-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl",
+  ),
+});
+
+export default function meson(): std.Recipe<std.Directory> {
+  // Create a venv for meson
+  let venv = std.recipe(python());
+
+  // Install setuptools from the archive we downloaded. Setuptools is the
+  // only dependency we need installed in the venv, the rest will be installed
+  // by setuptools itself
+  venv = std.runBash`
+    pip install setuptools
+  `
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Install meson into the venv
+  venv = std.runBash`
+    pip install .
+  `
+    .workDir(source)
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Create the final recipe with the venv under `venv`
+  let recipe = std.directory({
+    venv,
+  });
+
+  // Add `bin/meson` to run the main script
+  recipe = std.addRunnable(recipe, "bin/meson", {
+    command: { relativePath: "venv/bin/python" },
+    args: [{ relativePath: "venv/bin/meson" }],
+  });
+  return std.withRunnableLink(recipe, "bin/meson");
+}
+
+export async function test() {
+  const script = std.runBash`
+    meson --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(meson())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/mesonbuild/meson/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a package for [Meson](https://mesonbuild.com/), a user-friendly build system. Meson builds often use Ninja (added as a separate package in #374).

Meson is written in Python, and I used the `asciinema` package as a base for the build. That also means that this package will need to be cleaned up like `asciinema` in #219 