### PR TITLE
Add `bubblewrap` package

### DIFF
--- a/packages/bubblewrap/brioche.lock
+++ b/packages/bubblewrap/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/containers/bubblewrap/releases/download/v0.11.0/bubblewrap-0.11.0.tar.xz": {
+      "type": "sha256",
+      "value": "988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646"
+    }
+  }
+}

--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import meson from "meson";
+import ninja from "ninja";
+import cmake from "cmake";
+import libcap from "libcap";
+import nushell from "nushell";
+
+export const project = {
+  name: "bubblewrap",
+  version: "0.11.0",
+};
+
+const source = Brioche.download(
+  `https://github.com/containers/bubblewrap/releases/download/v${project.version}/bubblewrap-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function bubblewrap(): std.Recipe<std.Directory> {
+  const bubblewrap = std.runBash`
+    meson setup _builddir --prefix /
+    meson compile -C _builddir
+    meson install -C _builddir --destdir "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), meson(), ninja(), cmake(), libcap())
+    .workDir(source)
+    .toDirectory();
+
+  return std.withRunnableLink(bubblewrap, "bin/bwrap");
+}
+
+export async function test() {
+  const script = std.runBash`
+    bwrap --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bubblewrap())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `bubblewrap ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/containers/bubblewrap/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a new package for [bubblewrap](https://github.com/containers/bubblewrap), a CLI tool for setting up sandboxed environments on Linux.

Bubblewrap has 3 dependencies that were added in the three most recent PRs: libcap (#373), Ninja (#374), and Meson (#375)