### PR TITLE
feat(kmod): add test and autoUpdate capabilities

### DIFF
--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import scdoc from "scdoc";
 import openssl from "openssl";
+import nushell from "nushell";
 
 export const project = {
   name: "kmod",
@@ -31,13 +32,49 @@ export default function kmod(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export function test() {
-  return std.runBash`
+export async function test() {
+  const script = std.runBash`
     depmod --version | tee -a "$BRIOCHE_OUTPUT"
     insmod --version | tee -a "$BRIOCHE_OUTPUT"
-    lsmod | tee -a "$BRIOCHE_OUTPUT"
     modinfo --version | tee -a "$BRIOCHE_OUTPUT"
     modprobe --version | tee -a "$BRIOCHE_OUTPUT"
     rmmod --version | tee -a "$BRIOCHE_OUTPUT"
-  `.dependencies(kmod());
+  `
+    .dependencies(kmod())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `kmod version ${project.version}`;
+  const expectedNumber = 5;
+  std.assert(
+    result.match(new RegExp(expected, "g"))?.length === expectedNumber,
+    `expected '${expected}' ${expectedNumber} times, got '${result}'`,
+  );
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://www.kernel.org/pub/linux/utils/kernel/kmod
+      | lines
+      | where {|it| ($it | str contains 'href="kmod-') and ($it | str contains '.tar.gz')}
+      | parse --regex '<a href="kmod-(?<version>.+).tar.gz"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }


### PR DESCRIPTION
```bash
[container@f7b5cac5aa21 workspace]$ brioche build -e test -p packages/kmod
Build finished, completed (no new jobs) in 1.64s
Result: 00eb145456427418ccc1d0bc8215d2236c90c00b06f0b593f30a0cfb4c3b440c
[container@f7b5cac5aa21 workspace]$ brioche run -e autoUpdate -p packages/kmod
20.54s ✓ Cache     100% Fetch artifact: 40.8 MiB
 0.07s ✓ Process 142
Build finished, completed 2 jobs in 25.04s
Running brioche-run
{
  "name": "kmod",
  "version": "34.2"
}
```