### PR TITLE
feat(libtirpc): add test and autoUpdate capabilities

### DIFF
--- a/packages/libtirpc/brioche.lock
+++ b/packages/libtirpc/brioche.lock
@@ -1,8 +1,9 @@
 {
   "dependencies": {},
-  "git_refs": {
-    "git://git.linux-nfs.org/projects/steved/libtirpc.git": {
-      "libtirpc-1-3-6": "cf7441f5b90f043308cc34ae8d25127aed844c92"
+  "downloads": {
+    "https://sourceforge.net/projects/libtirpc/files/libtirpc/1.3.6/libtirpc-1.3.6.tar.bz2/download": {
+      "type": "sha256",
+      "value": "bbd26a8f0df5690a62a47f6aa30f797f3ef8d02560d1bc449a83066b5a1d3508"
     }
   }
 }

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -1,28 +1,18 @@
 import * as std from "std";
-import { gitCheckout } from "git";
+import nushell from "nushell";
 
 export const project = {
   name: "libtirpc",
   version: "1.3.6",
-  extra: {
-    versionTag: "libtirpc-1-3-6",
-  },
 };
 
-std.assert(
-  project.extra.versionTag ===
-    `libtirpc-${project.version.replaceAll(".", "-")}`,
-  `version tag '${project.extra.versionTag}' does not match version ${project.version}`,
-);
+const source = Brioche.download(
+  `https://sourceforge.net/projects/libtirpc/files/libtirpc/${project.version}/libtirpc-${project.version}.tar.bz2/download`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "git://git.linux-nfs.org/projects/steved/libtirpc.git",
-    ref: project.extra.versionTag,
-  }),
-);
-
-export default function (): std.Recipe<std.Directory> {
+export default function libtirpc(): std.Recipe<std.Directory> {
   let libtirpc = std.runBash`
     ./bootstrap
     ./configure \\
@@ -43,6 +33,52 @@ export default function (): std.Recipe<std.Directory> {
   libtirpc = makePkgConfigPathsRelative(libtirpc);
 
   return libtirpc;
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libtirpc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), libtirpc())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let sourceUrl = http get https://sourceforge.net/projects/libtirpc/files/libtirpc
+      | lines
+      | where {|it| $it | str contains 'href="/projects/libtirpc/files/libtirpc/' }
+      | parse --regex '<a href="/projects/libtirpc/files/libtirpc/(?<version>.+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    let version = http get $"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)"
+      | lines
+      | where {|it| ($it | str contains 'a href="https://sourceforge.net') and ($it | str contains '.tar.bz2') }
+      | parse --regex ($"<a href=\\"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)/libtirpc-" + '(?<version>[^"]+)\.tar\.bz2/')
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
 }
 
 // TODO: Figure out where to move this, this is copied from `std`

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -61,14 +61,14 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let versionWithoutPatch = http get https://download.gnome.org/sources/libxml2
+    let sourceUrl = http get https://download.gnome.org/sources/libxml2
       | lines
       | where {|it| $it | str contains 'href="' }
       | parse --regex '<a href="(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
-    let version = http get $"https://download.gnome.org/sources/libxml2/($versionWithoutPatch)"
+    let version = http get $"https://download.gnome.org/sources/libxml2/($sourceUrl)"
       | lines
       | where {|it| ($it | str contains 'a href="libxml2') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
       | parse --regex '<a href="libxml2-(?<version>[^"]+)\.tar\.xz"'

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -62,14 +62,14 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let versionWithoutPatch = http get https://download.gnome.org/sources/libxslt
+    let sourceUrl = http get https://download.gnome.org/sources/libxslt
       | lines
       | where {|it| $it | str contains 'href="' }
       | parse --regex '<a href="(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
-    let version = http get $"https://download.gnome.org/sources/libxslt/($versionWithoutPatch)"
+    let version = http get $"https://download.gnome.org/sources/libxslt/($sourceUrl)"
       | lines
       | where {|it| ($it | str contains 'a href="libxslt') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
       | parse --regex '<a href="libxslt-(?<version>[^"]+)\.tar\.xz"'

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -62,17 +62,17 @@ export async function test() {
 
 export function autoUpdate() {
   const src = std.file(std.indoc`
-    let versionWithoutPatch = http get https://sourceforge.net/projects/pcre/files/pcre
+    let sourceUrl = http get https://sourceforge.net/projects/pcre/files/pcre
       | lines
       | where {|it| $it | str contains 'href="/projects/pcre/files/pcre/' }
       | parse --regex '<a href="/projects/pcre/files/pcre/(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
-    let version = http get $"https://sourceforge.net/projects/pcre/files/pcre/($versionWithoutPatch)"
+    let version = http get $"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)"
       | lines
       | where {|it| ($it | str contains 'a href="https://sourceforge.net') and ($it | str contains '.tar.gz') and (not ($it | str contains '.sig')) }
-      | parse --regex ($"<a href=\\"https://sourceforge.net/projects/pcre/files/pcre/($versionWithoutPatch)/pcre-" + '(?<version>[^"]+)\.tar\.gz/')
+      | parse --regex ($"<a href=\\"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)/pcre-" + '(?<version>[^"]+)\.tar\.gz/')
       | sort-by --natural --reverse version
       | get 0.version
 


### PR DESCRIPTION
```bash
[container@f7b5cac5aa21 workspace]$ brioche build -e test -p packages/libtirpc/
6680   │ 1.3.6
 0.11s ✓ Process 6680
Build finished, completed 1 job in 2.61s
Result: 649015f1207cbf63f38810b1dc94819132640440bae6911c6c698314b34770de
[container@f7b5cac5aa21 workspace]$ brioche run -e autoUpdate -p packages/libtirpc/
Build finished, completed (no new jobs) in 2.42s
Running brioche-run
{
  "name": "libtirpc",
  "version": "1.3.6"
}
```