### PR TITLE
feat(tcpdump): add test capability

### DIFF
--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -12,7 +12,7 @@ const source = Brioche.download(
   .unarchive("tar", "xz")
   .peel();
 
-export default function (): std.Recipe<std.Directory> {
+export default function tcpdump(): std.Recipe<std.Directory> {
   const tcpdump = std.runBash`
     ./configure --prefix=/
     make install DESTDIR="$BRIOCHE_OUTPUT"
@@ -22,4 +22,23 @@ export default function (): std.Recipe<std.Directory> {
     .toDirectory();
 
   return std.withRunnableLink(tcpdump, "bin/tcpdump");
+}
+
+export async function test() {
+  const script = std.runBash`
+    tcpdump --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(tcpdump())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `tcpdump version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
 }


### PR DESCRIPTION
```bash
[container@f7b5cac5aa21 workspace]$ brioche build -e test -p packages/tcpdump
Build finished, completed (no new jobs) in 1.61s
Result: 4faf59dea88eca43194521b7326af341bfd90751f880aa3fcce21ed6ec778ce2
```