### PR TITLE
refactor: add missing return type to default functions

### DIFF
--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -8,7 +8,7 @@ export const project = {
   packageName: "aws-cdk",
 };
 
-export default function awsCdk() {
+export default function awsCdk(): std.Recipe<std.Directory> {
   const recipe = npmInstallGlobal({
     packageName: project.packageName,
     version: project.version,

--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -8,7 +8,7 @@ export const project = {
   packageName: "@anthropic-ai/claude-code",
 };
 
-export default function claudeCode() {
+export default function claudeCode(): std.Recipe<std.Directory> {
   const recipe = npmInstallGlobal({
     packageName: project.packageName,
     version: project.version,

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -130,7 +130,7 @@ interface GoBuildOptions {
  * import { goBuild } from "go";
  * import openssl from "openssl";
  *
- * export default function {
+ * export default function (): std.Recipe<std.Directory> {
  *   return goBuild({
  *     source: Brioche.glob("**\/*.go", "go.mod", "go.sum"),
  *     dependencies: [openssl()],

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -14,7 +14,7 @@ const source = gitCheckout(
   }),
 );
 
-export default function nasm() {
+export default function nasm(): std.Recipe<std.Directory> {
   return std.runBash`
     ./autogen.sh
     ./configure

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -89,7 +89,7 @@ export function autoUpdate() {
  * import * as std from "std";
  * import nodejs, { npmInstall } from "nodejs";
  *
- * export default function () {
+ * export default function (): std.Recipe<std.Directory> {
  *   // Get all the files for the NPM package
  *   const source = Brioche.glob("src", "package.lock", "package.json");
  *

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -205,7 +205,7 @@ export interface CargoBuildOptions {
  * import openssl from "openssl";
  * import { cargoBuild } from "rust";
  *
- * export default function () {
+ * export default function (): std.Recipe<std.Directory> {
  *   return cargoBuild({
  *     source: Brioche.glob("src", "Cargo.*"),
  *     runnable: "bin/hello",

--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -7,7 +7,7 @@ export const project = {
   version: "8.5.3",
 };
 
-export default function zx() {
+export default function zx(): std.Recipe<std.Directory> {
   const recipe = npmInstallGlobal({
     packageName: "zx",
     version: project.version,


### PR DESCRIPTION
This PR standardizes the return type of default export functions across some project files by explicitly specifying the `std.Recipe<std.Directory>` type.