### PR TITLE
feat(sniffnet): add package

### DIFF
--- a/packages/sniffnet/brioche.lock
+++ b/packages/sniffnet/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/GyulyVGC/sniffnet.git": {
+      "v1.3.1": "ecb20f62d3475112105b4210b2cba5a652a08f16"
+    }
+  }
+}

--- a/packages/sniffnet/project.bri
+++ b/packages/sniffnet/project.bri
@@ -1,0 +1,62 @@
+import nushell from "nushell";
+import * as std from "std";
+import alsa_lib from "alsa_lib";
+import libpcap from "libpcap";
+import { gitCheckout } from "git";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "sniffnet",
+  version: "1.3.1",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/GyulyVGC/sniffnet.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function sniffnet(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [alsa_lib(), libpcap()],
+    runnable: "bin/sniffnet",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    sniffnet --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(sniffnet())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sniffnet ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/GyulyVGC/sniffnet/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR introduces a new package for the `sniffnet` tool, including functionality for building, testing, and auto-updating the package.

```bash
[container@f7b5cac5aa21 workspace]$ brioche run -e autoUpdate -p packages/sniffnet/
 0.07s ✓ Process 22170
Build finished, completed 1 job in 3.52s
Running brioche-run
{
  "name": "sniffnet",
  "version": "1.3.2"
}
[container@f7b5cac5aa21 workspace]$ brioche build -e test -p packages/sniffnet
Build finished, completed (no new jobs) in 2.39s
Result: f7e5c19fcb48e2a1706a000fdeca2aba968cb8349637ddeb061e5caf09857e57
```