### PR TITLE
feat(pnpm): add package

### DIFF
--- a/packages/pnpm/brioche.lock
+++ b/packages/pnpm/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -1,0 +1,50 @@
+import nushell from "nushell";
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "pnpm",
+  version: "10.10.0",
+};
+
+export default function pnpm(): std.Recipe<std.Directory> {
+  const recipe = npmInstallGlobal({
+    packageName: project.name,
+    version: project.version,
+  });
+
+  return std.withRunnableLink(recipe, "bin/pnpm");
+}
+
+export async function test() {
+  const script = std.runBash`
+    pnpm --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pnpm())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function autoUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/pnpm/pnpm/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR introduces a new `pnpm` package, including its installation, testing, and auto-update functionality.

```bash
[container@f7b5cac5aa21 workspace]$ brioche run -e autoUpdate -p packages/pnpm
Build finished, completed (no new jobs) in 2.67s
Running brioche-run
{
  "name": "pnpm",
  "version": "10.10.0"
}
[container@f7b5cac5aa21 workspace]$ brioche build -e test -p packages/pnpm
22532  │ 10.10.0
 1.15s ✓ Process 22532
Build finished, completed 1 job in 7.25s
Result: 04449cafde4d6b54782402ef21748e8e6a4b5d3d8fa2e407a124af03cb965e35
```