### PR TITLE
feat(codex): add package

### DIFF
--- a/packages/codex/brioche.lock
+++ b/packages/codex/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/codex/project.bri
+++ b/packages/codex/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "codex",
+  version: "0.1.2504251709",
+  packageName: "@openai/codex",
+};
+
+export default function codex(): std.Recipe<std.Directory> {
+  const recipe = npmInstallGlobal({
+    packageName: project.packageName,
+    version: project.version,
+  });
+
+  return std.withRunnableLink(recipe, "bin/codex");
+}
+
+export async function test() {
+  const script = std.runBash`
+    codex --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(codex())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected ${expected}, got ${result}`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
This PR adds a new package from OpenAI: [codex](https://github.com/openai/codex) which is  a lightweight coding agent that runs in the terminal.

```bash
[container@748549e7edf3 workspace]$ brioche build -e test -p packages/codex
Build finished, completed (no new jobs) in 2.35s
Result: bf2d48a2dbe7379cd4cb2cc8ece97d52bd4c9cdbea7900dee6bf0057cdadff57
[container@748549e7edf3 workspace]$ brioche run -e liveUpdate -p packages/codex
Build finished, completed (no new jobs) in 2.39s
Running brioche-run
{
  "name": "codex",
  "version": "0.1.2504251709",
  "packageName": "@openai/codex"
}
```