### PR TITLE
chore(kmod): update package; switch to new build system

### DIFF
--- a/packages/kmod/brioche.lock
+++ b/packages/kmod/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-33.tar.xz": {
+    "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-34.2.tar.xz": {
       "type": "sha256",
-      "value": "dc768b3155172091f56dc69430b5481f2d76ecd9ccb54ead8c2540dbcf5ea9bc"
+      "value": "5a5d5073070cc7e0c7a7a3c6ec2a0e1780850c8b47b3e3892226b93ffcb9cb54"
     }
   }
 }

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -1,11 +1,13 @@
 import * as std from "std";
-import scdoc from "scdoc";
-import openssl from "openssl";
+import meson from "meson";
+import ninja from "ninja";
 import nushell from "nushell";
+import openssl from "openssl";
+import scdoc from "scdoc";
 
 export const project = {
   name: "kmod",
-  version: "33",
+  version: "34.2",
 };
 
 const source = Brioche.download(
@@ -16,29 +18,18 @@ const source = Brioche.download(
 
 export default function kmod(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./configure \
-      --prefix=/ \
-      --sysconfdir=/etc \
-      --with-zstd \
-      --with-xz \
-      --with-zlib \
-      --with-openssl \
-      CFLAGS="-g -O2"
-    make
-    make install DESTDIR="$BRIOCHE_OUTPUT"
+    meson setup build --prefix=/ -Dmanpages=false
+    meson compile -C build
+    DESTDIR="$BRIOCHE_OUTPUT" meson install -C build
   `
     .workDir(source)
-    .dependencies(std.toolchain(), scdoc(), openssl())
+    .dependencies(std.toolchain(), meson(), ninja(), scdoc(), openssl())
     .toDirectory();
 }
 
 export async function test() {
   const script = std.runBash`
-    depmod --version | tee -a "$BRIOCHE_OUTPUT"
-    insmod --version | tee -a "$BRIOCHE_OUTPUT"
-    modinfo --version | tee -a "$BRIOCHE_OUTPUT"
-    modprobe --version | tee -a "$BRIOCHE_OUTPUT"
-    rmmod --version | tee -a "$BRIOCHE_OUTPUT"
+    kmod --version | tee -a "$BRIOCHE_OUTPUT"
   `
     .dependencies(kmod())
     .toFile();
@@ -47,10 +38,9 @@ export async function test() {
 
   // Check that the result contains the expected version
   const expected = `kmod version ${project.version}`;
-  const expectedNumber = 5;
   std.assert(
-    result.match(new RegExp(expected, "g"))?.length === expectedNumber,
-    `expected '${expected}' ${expectedNumber} times, got '${result}'`,
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;


### PR DESCRIPTION
Supersedes https://github.com/brioche-dev/brioche-packages/pull/388

This pull request updates the `kmod` project to use the new modern build system (`meson` and `ninja`), simplifies the test logic, and updates the project version. The most important changes include replacing the old `make`-based build system, updating dependencies, and modifying the test logic to align with the new versioning.

### Build system updates:
* Replaced the `./configure` and `make`-based build system with `meson` and `ninja` for setting up, compiling, and installing the project. (`packages/kmod/project.bri`, [packages/kmod/project.briL19-R32](diffhunk://#diff-5cacea6636b972dc49565a015ff6b6d9cc1bd2dbba682e4f48222e3992a1bf21L19-R32))

### Dependency updates:
* Updated dependencies to include `meson` and `ninja` while keeping existing dependencies like `scdoc` and `openssl`. (`packages/kmod/project.bri`, [[1]](diffhunk://#diff-5cacea6636b972dc49565a015ff6b6d9cc1bd2dbba682e4f48222e3992a1bf21L2-R10) [[2]](diffhunk://#diff-5cacea6636b972dc49565a015ff6b6d9cc1bd2dbba682e4f48222e3992a1bf21L19-R32)

### Versioning and test logic:
* Updated the project version from `33` to `34.2`. (`packages/kmod/project.bri`, [packages/kmod/project.briL2-R10](diffhunk://#diff-5cacea6636b972dc49565a015ff6b6d9cc1bd2dbba682e4f48222e3992a1bf21L2-R10))
* Simplified the test logic to validate the `kmod` version output using `startsWith` instead of matching multiple occurrences with a regular expression. (`packages/kmod/project.bri`, [packages/kmod/project.briL50-R43](diffhunk://#diff-5cacea6636b972dc49565a015ff6b6d9cc1bd2dbba682e4f48222e3992a1bf21L50-R43))