### PR TITLE
feat(tailspin): add package

### DIFF
--- a/packages/tailspin/brioche.lock
+++ b/packages/tailspin/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/bensadeh/tailspin.git": {
+      "5.4.2": "4428757281da1ca63ca9beaa7095ab97d2e80a40"
+    }
+  }
+}

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -1,0 +1,59 @@
+import nushell from "nushell";
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "tailspin",
+  version: "5.4.2",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/bensadeh/tailspin.git",
+    ref: project.version,
+  }),
+);
+
+export default function tailspin(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/tspin",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    tspin --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(tailspin())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `tspin ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/bensadeh/tailspin/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`tailspin`](https://github.com/bensadeh/tailspin): a log file highlighter

```bash
[container@868094031ec6 workspace]$ brioche build -e test -p packages/tailspin
Build finished, completed (no new jobs) in 2.55s
Result: 7b04939f2831fda628a40480bd11c06793240f39fa9690aacc8300eb8082aea9
[container@868094031ec6 workspace]$ brioche run -e liveUpdate -p packages/tailspin/
Build finished, completed (no new jobs) in 2.46s
Running brioche-run
{
  "name": "tailspin",
  "version": "5.4.2"
}
```