### PR TITLE
feat(starship): add package

### DIFF
--- a/packages/starship/brioche.lock
+++ b/packages/starship/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/starship/starship.git": {
+      "v1.23.0": "661c8a2c1cc43b1c0ba1f034ee1dd17442cce815"
+    }
+  }
+}

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -1,0 +1,62 @@
+import nushell from "nushell";
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "starship",
+  version: "1.23.0",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/starship/starship.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function starship(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/starship",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    starship --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(starship())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `starship ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/starship/starship/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`starship`](https://github.com/starship/starship): The minimal, blazing-fast, and infinitely customizable prompt for any shell

```bash
[container@868094031ec6 workspace]$ brioche build -e test -p packages/starship/
Build finished, completed (no new jobs) in 2.46s
Result: 6304323e5795c1ee2ae6752a0cfe1f20e37b09aa874597aafa097563ea6a22de
[container@868094031ec6 workspace]$ brioche run -e liveUpdate -p packages/starship/
Build finished, completed (no new jobs) in 2.54s
Running brioche-run
{
  "name": "starship",
  "version": "1.23.0"
}
```