### PR TITLE
feat(perl): add test capability

### DIFF
--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -42,24 +42,21 @@ export default function perl(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export function test() {
-  const testScript = std.file(std.indoc`
-    use strict;
-    use warnings FATAL => 'all';
-    use feature 'say';
-    use threads;
-
-    threads->create(sub {
-      say "Writing ", $ENV{BRIOCHE_OUTPUT};
-      open my $fh, '>', $ENV{BRIOCHE_OUTPUT};
-      close $fh;
-    })->join();
-  `);
-
-  return std.runBash`
-    perl --version
-    perl "$test_script"
+export async function test() {
+  const script = std.runBash`
+    perl --version | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(perl())
-    .env({ test_script: testScript });
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
 }


### PR DESCRIPTION
```bash
[container@868094031ec6 workspace]$ brioche build -e test -p packages/perl
15068  │ This is perl 5, version 40, subversion 1 (v5.40.1) built for x86_64-linux-thread-multi
       │ Copyright 1987-2025, Larry Wall
       │ Perl may be copied only under the terms of either the Artistic License or the
       │ GNU General Public License, which may be found in the Perl 5 source kit.
       │ Complete documentation for Perl, including FAQ lists, should be found on
       │ this system using "man perl" or "perldoc perl".  If you have access to the
       │ Internet, point your browser at https://www.perl.org/, the Perl Home Page.
 0.12s ✓ Process 15068
Build finished, completed 1 job in 2.68s
Result: 3fa24934d9551039cf824c023bbd49d6f24d30ed06d4d359d66e4248b0637412
```