### PR TITLE
feat(biome): add package

### DIFF
--- a/packages/biome/brioche.lock
+++ b/packages/biome/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/biomejs/biome.git": {
+      "cli/v1.9.4": "fa93a147abe64e9c85908d317a8dd1de343ad132"
+    }
+  }
+}

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -1,0 +1,63 @@
+import nushell from "nushell";
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "biome",
+  version: "1.9.4",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/biomejs/biome.git",
+    ref: `cli/v${project.version}`,
+  }),
+);
+
+export default function biome(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/biome",
+    path: "crates/biome_cli",
+    env: {
+      BIOME_VERSION: project.version,
+    },
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    biome --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(biome())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/biomejs/biome/releases/latest
+      | get tag_name
+      | str replace --regex '^cli/v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`biome`](https://github.com/biomejs/biome): A toolchain for web projects, aimed to provide functionalities to maintain them. Biome offers formatter and linter, usable via CLI. 

```bash
[container@868094031ec6 workspace]$ brioche build -e test -p packages/biome
Build finished, completed (no new jobs) in 2.50s
Result: 7fe5f990398e9a187e82e609cf2350655ece966e9452341e8e20ce11001b013f
[container@868094031ec6 workspace]$ brioche run -e liveUpdate -p packages/biome/
Build finished, completed (no new jobs) in 2.55s
Running brioche-run
{
  "name": "biome",
  "version": "1.9.4"
}
```