### PR TITLE
Disable legacy registry sync

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -34,7 +34,6 @@ jobs:
             echo "::endgroup::"
           done
         env:
-          BRIOCHE_LEGACY_REGISTRY_SYNC: "true"
           BRIOCHE_REGISTRY_PASSWORD: ${{ secrets.BRIOCHE_REGISTRY_PASSWORD }}
           BRIOCHE_CACHE_URL: ${{ vars.BRIOCHE_CACHE_URL }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CACHE_AWS_ACCESS_KEY_ID }}
@@ -55,7 +54,6 @@ jobs:
             fi
           done
         env:
-          BRIOCHE_LEGACY_REGISTRY_SYNC: "true"
           BRIOCHE_REGISTRY_PASSWORD: ${{ secrets.BRIOCHE_REGISTRY_PASSWORD }}
           BRIOCHE_CACHE_URL: ${{ vars.BRIOCHE_CACHE_URL }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CACHE_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to disable the legacy registry sync.

[As noted in the Brioche v0.1.5 announcement](https://brioche.dev/blog/announcing-brioche-v0-1-5/#psa-sunsetting-support-for-older-versions-of-brioche), I'm removing support for Brioche v0.1.4 and earlier from the registry. The final step will be the removal of several registry API endpoints.

This PR covers the first step, which is to stop the workflows in this repo from syncing to the legacy endpoint. This is done by un-setting the env var `$BRIOCHE_LEGACY_REGISTRY_SYNC`.