### PR TITLE
feat(yazi): add package

### DIFF
--- a/packages/yazi/brioche.lock
+++ b/packages/yazi/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sxyazi/yazi.git": {
+      "v25.4.8": "99ea3b74c4260a724b43af812df0f68ef59395b7"
+    }
+  }
+}

--- a/packages/yazi/project.bri
+++ b/packages/yazi/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+import nushell from "nushell";
+
+export const project = {
+  name: "yazi",
+  version: "25.4.8",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: "https://github.com/sxyazi/yazi.git",
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function yazi(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/yazi",
+    path: "yazi-fm",
+    env: {
+      VERGEN_GIT_SHA: gitRef.commit,
+    },
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    yazi --version | tee "$BRIOCHE_OUTPUT"
+  `.dependencies(yazi());
+
+  const result = (await script.toFile().read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Yazi ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/sxyazi/yazi/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project | from json | update version $version | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`yazi`](https://github.com/sxyazi/yazi): a blazing fast terminal file manager written in Rust, based on async I/O.

```bash
[container@05f6a78d0dc4 workspace]$ brioche run -e liveUpdate -p packages/yazi
Build finished, completed (no new jobs) in 2.43s
Running brioche-run
{
  "name": "yazi",
  "version": "25.4.8"
}
[container@05f6a78d0dc4 workspace]$ brioche build -e test -p packages/yazi
Build finished, completed (no new jobs) in 2.39s
Result: 25710b63dae75ac6a5c2e8bbf3a8cf27ae86810a8b6c6374859be719eee0c887
```