### PR TITLE
feat(eks_node_viewer): add package

### DIFF
--- a/packages/eks_node_viewer/brioche.lock
+++ b/packages/eks_node_viewer/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/awslabs/eks-node-viewer.git": {
+      "v0.7.4": "798f9ba5059be4fe1083d535817918b9cdc2eca2"
+    }
+  }
+}

--- a/packages/eks_node_viewer/project.bri
+++ b/packages/eks_node_viewer/project.bri
@@ -1,0 +1,73 @@
+import nushell from "nushell";
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "eks_node_viewer",
+  version: "0.7.4",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: "https://github.com/awslabs/eks-node-viewer.git",
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default async function eksNodeViewer(): Promise<
+  std.Recipe<std.Directory>
+> {
+  return goBuild({
+    source,
+    buildParams: {
+      generate: true,
+      ldflags: [
+        "-s",
+        "-w",
+        `-X main.commit=${gitRef.commit}`,
+        `-X main.version=${project.version}`,
+      ],
+    },
+    path: "./cmd/eks-node-viewer",
+    runnable: "bin/eks-node-viewer",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    eks-node-viewer --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(eksNodeViewer())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `eks-node-viewer version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/awslabs/eks-node-viewer/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`eks_node_viewer`](https://github.com/awslabs/eks-node-viewer) to view EKS nodes

```bash
[container@132881fa67a6 workspace]$ brioche build -e test -p packages/eks_node_viewer/
8363   │ eks-node-viewer version 0.7.4
       │ commit: 798f9ba5059be4fe1083d535817918b9cdc2eca2
       │ built at:
       │ built by:
 0.29s ✓ Process 8363
Build finished, completed 1 job in 3.23s
Result: fc2f26afb4f297bb0ba51e6fdf836e4418ee6785d3b7c6a64bdaa194bae58dc7
[container@132881fa67a6 workspace]$ brioche run -e liveUpdate -p packages/eks_node_viewer/
Build finished, completed (no new jobs) in 2.57s
Running brioche-run
{
  "name": "eks_node_viewer",
  "version": "0.7.4"
}
```