### PR TITLE
Update "Live Updates" GH Actions workflow

### DIFF
--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -50,8 +50,8 @@ jobs:
               git checkout "origin/${branch_name}" || git checkout "${git_head}"
               git clean -ffdx
               if ! brioche live-update -p "$package" --locked; then
-                continue
                 echo "🔴 Failed to update $package"
+                continue
               fi
 
               if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -2,6 +2,8 @@ name: Live updates
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '17 12 * * FRI' # Every Friday at 12:17pm UTC
 
 jobs:
   live-update-packages:

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Update packages
         run: |
           git_head="$(git rev-parse HEAD)"
+          failed_packages=()
 
           for package in packages/*; do
             branch_name="live-update/$(basename "$package")"
@@ -52,6 +53,7 @@ jobs:
               if ! brioche live-update -p "$package" --locked; then
                 echo "🔴 Failed to update $package"
                 echo "::error file=$package/project.bri::Failed to update $package"
+                failed_packages+=( "$package" )
                 continue
               fi
 
@@ -69,6 +71,9 @@ jobs:
               echo "$package: no live-update found"
             fi
           done
+
+          git checkout "$git_head"
+          printf "%s\n" "${failed_packages[@]}" > failed-packages.txt
 
       - name: Configure git credentials
         run: git remote set-url origin "$auth_url"
@@ -91,3 +96,11 @@ jobs:
           run_label: "${{ github.workflow }} #${{ github.run_number}}"
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Check for failed packages
+        run: |
+          if [ -n "$(cat failed-packages.txt)" ]; then
+            echo "The following package live updates failed:"
+            cat failed-packages.txt
+            exit 1
+          fi

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -51,6 +51,7 @@ jobs:
               git clean -ffdx
               if ! brioche live-update -p "$package" --locked; then
                 echo "🔴 Failed to update $package"
+                echo "::error file=$package/project.bri::Failed to update $package"
                 continue
               fi
 


### PR DESCRIPTION
This PR makes a few updates to the "Live Updates" workflow:

- Configure the workflow to run on a schedule: every Friday at 12:17pm UTC
    - I picked a time that I'm usually asleep so builds can run overnight, and I picked an odd minute to [avoid stampeding](https://akhaerov.medium.com/why-you-should-never-schedule-cron-jobs-exactly-at-midnight-8f11650f79f8)
- Fix script not printing a message on failure
- Add error annotations for each failed package
- Update job to fail at the end if any package failed
    - This should hopefully make failures more visible. Medium-term, we'll want live-update scripts to have some kind of retry logic, and longer-term we'll probably want to ignore failures again (the best case would be if we could return an error only if a package's live-update fails for multiple weeks in a row or something, so we could either fix it or remove it)