### PR TITLE
Don't sync `std.tools` / `std.toolchain` as tarballs anymore

### DIFF
--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -161,8 +161,6 @@ export const tools = std.memo(async (): Promise<std.Recipe<std.Directory>> => {
     MAGIC: { append: [{ path: "share/misc/magic.mgc" }] },
   });
 
-  tools = syncTarball(tools);
-
   return tools;
 });
 
@@ -311,10 +309,7 @@ export const toolchain = std.memo(
     });
 
     toolchain = fixShebangs(toolchain);
-
     toolchain = makePkgConfigPathsRelative(toolchain);
-
-    toolchain = syncTarball(toolchain);
 
     return toolchain;
   },
@@ -429,37 +424,4 @@ function makePkgConfigPathsRelative(
       outputScaffold: recipe,
     })
     .toDirectory();
-}
-
-/**
- * Sync a recipe by creating an archive of it, then unarchiving it. When
- * fetched from the registry, the recipe will be downloaded as a single
- * compressed tarball, which may be faster than syncing lots of individual
- * files.
- */
-function syncTarball(
-  recipe: std.AsyncRecipe<std.Directory>,
-): std.Recipe<std.Directory> {
-  recipe = std.collectReferences(std.directory({ recipe }));
-
-  const tarredRecipe = std
-    .process({
-      command: "tar",
-      args: [
-        "--zstd",
-        "-cf",
-        std.outputPath,
-        "--hard-dereference",
-        "-C",
-        recipe,
-        ".",
-      ],
-      dependencies: [tar(), zstd()],
-    })
-    .toFile();
-
-  let untarredRecipe = tarredRecipe.unarchive("tar", "zstd");
-  untarredRecipe = std.attachResources(untarredRecipe);
-
-  return std.castToDirectory(untarredRecipe.get("recipe"));
 }


### PR DESCRIPTION
Closes #245

This PR rolls back the change introduced in #147. We started wrapping the recipes `std.tools()` and `std.toolchain()` into `.tar.zst` archives, which helped speed up artifact fetches on versions of Brioche prior to v0.1.5.

Now that Brioche v0.1.5 is live with the new cache (https://github.com/brioche-dev/brioche/pull/179), this change no longer helps with sync times (and if anything, using a compressed archive likely leads to storing more data in the cache due to how chunking works). We've also [past the point where the registry was still supporting Brioche v0.1.4 and earlier](https://brioche.dev/blog/announcing-brioche-v0-1-5/#psa-sunsetting-support-for-older-versions-of-brioche), so syncing these recipes "normally" again is a net-win.