### PR TITLE
feat(libunwind): add package

### DIFF
--- a/packages/libunwind/brioche.lock
+++ b/packages/libunwind/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libunwind/libunwind/releases/download/v1.8.1/libunwind-1.8.1.tar.gz": {
+      "type": "sha256",
+      "value": "ddf0e32dd5fafe5283198d37e4bf9decf7ba1770b6e7e006c33e6df79e6a6157"
+    }
+  }
+}

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -1,0 +1,66 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "libunwind",
+  version: "1.8.1",
+};
+
+const source = Brioche.download(
+  `https://github.com/libunwind/libunwind/releases/download/v${project.version}/libunwind-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libunwind(): std.Recipe<std.Directory> {
+  const libunwind = std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  return std.setEnv(libunwind, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libunwind | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), libunwind())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/libunwind/libunwind/releases/latest
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}


### PR DESCRIPTION
Add a new package [`libunwind`](https://github.com/libunwind/libunwind): a portable and efficient C API for determining the current call chain of ELF program threads of execution and for resuming execution at any point in that call chain

```bash
[container@29ec39c53957 workspace]$ brioche build -e test -p packages/libunwind/
Build finished, completed (no new jobs) in 1.68s
Result: 6d80b456f624f3d42bca1969400675270116c3ea8b6eb6a783f7dc1f25d95487
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/libunwind/
Build finished, completed (no new jobs) in 2.34s
Running brioche-run
{
  "name": "libunwind",
  "version": "1.8.1"
}
```