### PR TITLE
feat(expat): add package 

### DIFF
--- a/packages/expat/brioche.lock
+++ b/packages/expat/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libexpat/libexpat/releases/download/R_2_7_1/expat-2.7.1.tar.xz": {
+      "type": "sha256",
+      "value": "354552544b8f99012e5062f7d570ec77f14b412a3ff5c7d8d0dae62c0d217c30"
+    }
+  }
+}

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -1,0 +1,79 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "expat",
+  version: "2.7.1",
+  extra: {
+    versionUnderscore: "2_7_1",
+  },
+};
+
+std.assert(
+  project.extra.versionUnderscore === project.version.replaceAll(".", "_"),
+  `expected 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
+);
+
+const source = Brioche.download(
+  `https://github.com/libexpat/libexpat/releases/download/R_${project.extra.versionUnderscore}/expat-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function expat(): std.Recipe<std.Directory> {
+  const expat = std.runBash`
+    ls
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain())
+    .toDirectory();
+
+  return std.setEnv(expat, {
+    CPATH: { append: [{ path: "include" }] },
+    LIBRARY_PATH: { append: [{ path: "lib" }] },
+    PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion expat | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain(), expat())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let versionUnderscore = http get https://api.github.com/repos/libexpat/libexpat/releases/latest
+      | get tag_name
+      | str replace --regex '^R_' ''
+
+    let version = $versionUnderscore
+      | str replace --all '_' '.'
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.versionUnderscore $versionUnderscore
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell()],
+  });
+}

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -11,12 +11,12 @@ export const project = {
 };
 
 std.assert(
-  project.extra.versionDash === project.version.replace(".", "-"),
-  `expected ICU 'project.extra.versionDash' field '${project.extra.versionDash}' to match version '${project.version}'`,
+  project.extra.versionDash === project.version.replaceAll(".", "-"),
+  `expected 'project.extra.versionDash' field '${project.extra.versionDash}' to match version '${project.version}'`,
 );
 std.assert(
-  project.extra.versionUnderscore === project.version.replace(".", "_"),
-  `expected ICU 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
+  project.extra.versionUnderscore === project.version.replaceAll(".", "_"),
+  `expected 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
 );
 
 const source = Brioche.download(


### PR DESCRIPTION
Add a new package [`expat`](https://github.com/libexpat/libexpat): Fast streaming XML parser written in C99 with >90% test coverage

```bash
[container@29ec39c53957 workspace]$ brioche build -e test -p packages/expat/
Build finished, completed (no new jobs) in 1.82s
Result: 52749c83cf924961ed2fdd9f3f22bde15d4f725f80311b169a73de90eb9a82a7
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/expat
Build finished, completed (no new jobs) in 2.44s
Running brioche-run
{
  "name": "expat",
  "version": "2.7.1",
  "extra": {
    "versionUnderscore": "2_7_1"
  }
}
```