### PR TITLE
[std] Automatically inherit host certificates in process recipes with networking

### DIFF
--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import caCertificates from "ca_certificates";
 import { gitCheckout } from "git";
 import go, { goBuild } from "go";
 import nushell from "nushell";
@@ -35,7 +34,7 @@ export default function caddy(): std.Recipe<std.Directory> {
           "--output",
           std.tpl`${std.outputPath}/bin/caddy`,
         ],
-        dependencies: [xcaddy(), go(), caCertificates()],
+        dependencies: [xcaddy(), go()],
         unsafe: {
           networking: true,
         },

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import openssl from "openssl";
 import curl from "curl";
-import caCertificates from "ca_certificates";
 import nushell from "nushell";
 
 export const project = {
@@ -139,7 +138,7 @@ export function gitCheckout(
       git fetch --depth 1 origin "$commit"
       git -c advice.detachedHead=false checkout FETCH_HEAD
     `
-      .dependencies(git(), caCertificates())
+      .dependencies(git())
       .env({
         repository,
         commit,
@@ -153,7 +152,7 @@ export function gitCheckout(
         cd "$BRIOCHE_OUTPUT"
         git submodule update --init --recursive
       `
-        .dependencies(git(), caCertificates())
+        .dependencies(git())
         .outputScaffold(repo)
         .unsafe({ networking: true })
         .toDirectory();

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import caCertificates from "ca_certificates";
 import nushell from "nushell";
 
 export const project = {
@@ -205,7 +204,7 @@ function goModDownload(
     go mod download all
   `
     .workDir(std.glob(goModule, ["**/go.mod", "**/go.sum"]))
-    .dependencies(go(), caCertificates())
+    .dependencies(go())
     .env({ GOMODCACHE: std.outputPath })
     .unsafe({ networking: true })
     .toDirectory();

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import * as TOML from "smol_toml";
 import * as t from "typer";
-import caCertificates from "ca_certificates";
 import nushell from "nushell";
 
 export const project = {
@@ -397,7 +396,7 @@ export function vendorCrate(
     # vendored dependencies
     cargo vendor --locked >> .cargo/config.toml
   `
-    .dependencies(rust(), caCertificates())
+    .dependencies(rust())
     .outputScaffold(skeletonCrate)
     .unsafe({ networking: true })
     .toDirectory();

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -268,6 +268,7 @@ const PROCESS_TEMPLATE_SYMBOL_KINDS = [
   "homeDir",
   "workDir",
   "tempDir",
+  "caCertificateBundlePath",
 ] as const;
 
 type ProcessTemplateSymbolKind = (typeof PROCESS_TEMPLATE_SYMBOL_KINDS)[number];
@@ -340,6 +341,18 @@ export const tempDir = {
 } as TempDir;
 type TempDir = ProcessTemplateSymbol<"tempDir">;
 
+/**
+ * Expands to a file path containing trusted CA certificates (PEM-encoded).
+ * Can only be used in a process recipe when the `networking` unsafe option
+ * is enabled. Equivalent to the default environment variable `$SSL_CERT_FILE`.
+ */
+// eslint-disable-next-line
+export const caCertificateBundlePath = {
+  componentType: "symbol",
+  symbol: "caCertificateBundlePath",
+} as CaCertificateBundlePath;
+type CaCertificateBundlePath = ProcessTemplateSymbol<"caCertificateBundlePath">;
+
 function isProcessTemplateSymbol(
   value: unknown,
 ): value is ProcessTemplateSymbol {
@@ -395,6 +408,8 @@ export class ProcessTemplate {
                 return [{ type: "work_dir" }];
               case "tempDir":
                 return [{ type: "temp_dir" }];
+              case "caCertificateBundlePath":
+                return [{ type: "ca_certificate_bundle_path" }];
               default:
                 return unreachable(component.symbol);
             }

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -110,12 +110,14 @@ export interface ProcessUtils {
  * ```
  */
 export function process(options: ProcessOptions): Process {
+  const { networking = false, ...unknownUnsafeOptions } = options.unsafe ?? {};
   const env: Record<string, ProcessTemplateLike> = {
     BRIOCHE_OUTPUT: outputPath,
     BRIOCHE_RESOURCE_DIR: resourceDir,
     BRIOCHE_INPUT_RESOURCE_DIRS: inputResourceDirs,
     HOME: homeDir,
     TMPDIR: tempDir,
+    ...(networking ? { SSL_CERT_FILE: caCertificateBundlePath } : {}),
     ...options.env,
   };
 
@@ -127,8 +129,6 @@ export function process(options: ProcessOptions): Process {
   const recipe = createRecipe(["file", "directory", "symlink"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
-      const { networking = false, ...unknownUnsafeOptions } =
-        options.unsafe ?? {};
       const unknownUnsafeKeys = Object.keys(unknownUnsafeOptions);
       if (unknownUnsafeKeys.length > 0) {
         throw new Error(

--- a/packages/std/core/runtime.bri
+++ b/packages/std/core/runtime.bri
@@ -255,7 +255,8 @@ export type ProcessTemplateComponent =
   | { type: "input_resource_dirs" }
   | { type: "home_dir" }
   | { type: "work_dir" }
-  | { type: "temp_dir" };
+  | { type: "temp_dir" }
+  | { type: "ca_certificate_bundle_path" };
 
 export function isHex(s: string): s is HexString {
   return /^([0-9a-fA-F]{2})*$/.test(s);


### PR DESCRIPTION
This PR updates the `std` package to inherit the host's CA certificates when running a process recipe that has networking enabled (`.unsafe({ networking: true })`). This is the `std` change for https://github.com/brioche-dev/brioche/issues/156, which was released as part of Brioche v0.1.5.

This PR includes 3 core changes:

1. Add new `std.caCertificateBundlePath` value. When used in a process template, it resolves to a file path that contains all of the CA certificates trusted by the host. **Using the value in a process without networking will result in an error!**
2. Update `std.process()` to set `$SSL_CERT_FILE` when `unsafe.networking` is enabled
3. Refactor existing packages to avoid `ca_certificates` (since the host's CA certificates are used instead by default)