### PR TITLE
refactor: update the retrieving of version in some packages to properly parse the HTML tag `a`

### DIFF
--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -62,7 +62,7 @@ export function liveUpdate() {
 
     let version = http get $"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains 'a href="https://sourceforge.net') and ($it | str contains '.tar.bz2') }
+      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.bz2') }
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)/libtirpc-" + '(?<version>[^"]+)\.tar\.bz2/')
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -70,7 +70,7 @@ export function liveUpdate() {
 
     let version = http get $"https://download.gnome.org/sources/libxml2/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains 'a href="libxml2') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
+      | where {|it| ($it | str contains '<a href="libxml2') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
       | parse --regex '<a href="libxml2-(?<version>[^"]+)\.tar\.xz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -71,7 +71,7 @@ export function liveUpdate() {
 
     let version = http get $"https://download.gnome.org/sources/libxslt/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains 'a href="libxslt') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
+      | where {|it| ($it | str contains '<a href="libxslt') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
       | parse --regex '<a href="libxslt-(?<version>[^"]+)\.tar\.xz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -71,7 +71,7 @@ export function liveUpdate() {
 
     let version = http get $"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains 'a href="https://sourceforge.net') and ($it | str contains '.tar.gz') and (not ($it | str contains '.sig')) }
+      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.gz') and (not ($it | str contains '.sig')) }
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)/pcre-" + '(?<version>[^"]+)\.tar\.gz/')
       | sort-by --natural --reverse version
       | get 0.version


### PR DESCRIPTION
This PR updates the `liveUpdate` functions in several project files to ensure proper parsing of HTML anchor tags. The changes standardize the use of `<a href="...` in string matching conditions to align with expected HTML formatting.

```bash
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/pcre
 0.07s ✓ Process 23180
Build finished, completed 1 job in 3.60s
Running brioche-run
{
  "name": "pcre",
  "version": "8.45"
}
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/libxslt/
 0.06s ✓ Process 23216
Build finished, completed 1 job in 3.24s
Running brioche-run
{
  "name": "libxslt",
  "version": "1.1.43",
  "extra": {
    "majorVersion": "1",
    "minorVersion": "1"
  }
}
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/libxml2/
 0.06s ✓ Process 23252
Build finished, completed 1 job in 3.23s
Running brioche-run
{
  "name": "libxml2",
  "version": "2.14.2",
  "extra": {
    "majorVersion": "2",
    "minorVersion": "14"
  }
}
[container@29ec39c53957 workspace]$ brioche run -e liveUpdate -p packages/libtirpc/
 0.06s ✓ Process 23288
Build finished, completed 1 job in 3.16s
Running brioche-run
{
  "name": "libtirpc",
  "version": "1.3.6"
}
```
