### PR TITLE
[std] Implement `Brioche.gitCheckout()` global function

### DIFF
--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import { cargoBuild } from "rust";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.4.0-alpha",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/amber-lang/amber.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/amber-lang/amber.git",
+  ref: project.version,
+});
 
 export default function amber(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import python from "python";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "asciinema",
   version: "2.4.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/asciinema/asciinema.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/asciinema/asciinema.git",
+  ref: `v${project.version}`,
+});
 
 const pipDependencies = std.directory({
   "setuptools-75.1.0-py3-none-any.whl": Brioche.download(

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import python from "python";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -9,12 +8,10 @@ export const project = {
 };
 
 const source = std.recipeFn(() => {
-  const source = gitCheckout(
-    Brioche.gitRef({
-      repository: "https://github.com/aws/aws-cli.git",
-      ref: project.version,
-    }),
-  );
+  const source = Brioche.gitCheckout({
+    repository: "https://github.com/aws/aws-cli.git",
+    ref: project.version,
+  });
   const patch = Brioche.includeFile("resolved-lockfiles.patch");
 
   // Patch the source to fix unresolvable `packaging` dependencies

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -1,19 +1,16 @@
 import * as std from "std";
 import nushell from "nushell";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "bat",
   version: "0.25.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/sharkdp/bat.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/sharkdp/bat.git",
+  ref: `v${project.version}`,
+});
 
 export default function bat(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "biome",
   version: "1.9.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/biomejs/biome.git",
-    ref: `cli/v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/biomejs/biome.git",
+  ref: `cli/v${project.version}`,
+});
 
 export default function biome(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -1,19 +1,16 @@
 import * as std from "std";
 import nushell from "nushell";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "broot",
   version: "1.46.3",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/Canop/broot.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/Canop/broot.git",
+  ref: `v${project.version}`,
+});
 
 export default function broot(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import go, { goBuild } from "go";
 import nushell from "nushell";
 
@@ -48,12 +47,10 @@ export default function caddy(): std.Recipe<std.Directory> {
 }
 
 function xcaddy(): std.Recipe<std.Directory> {
-  const source = gitCheckout(
-    Brioche.gitRef({
-      repository: "https://github.com/caddyserver/xcaddy.git",
-      ref: `v${project.extra.xcaddy.version}`,
-    }),
-  );
+  const source = Brioche.gitCheckout({
+    repository: "https://github.com/caddyserver/xcaddy.git",
+    ref: `v${project.extra.xcaddy.version}`,
+  });
 
   return goBuild({
     source,

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 import nushell from "nushell";
 
@@ -8,12 +7,10 @@ export const project = {
   version: "1.3.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/carapace-sh/carapace-bin.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/carapace-sh/carapace-bin.git",
+  ref: `v${project.version}`,
+});
 
 export default function carapace(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import openssl from "openssl";
 import curl from "curl";
 
@@ -16,18 +15,14 @@ function patch(): std.Recipe<std.File> {
   // to stay up-to-date, but it's not clear if this is the right approach...
 
   return std.recipeFn(() => {
-    const base = gitCheckout(
-      Brioche.gitRef({
-        repository: "https://github.com/brioche-dev/CMake.git",
-        ref: "base/brioche-patches",
-      }),
-    );
-    const patched = gitCheckout(
-      Brioche.gitRef({
-        repository: "https://github.com/brioche-dev/CMake.git",
-        ref: "brioche-patches",
-      }),
-    );
+    const base = Brioche.gitCheckout({
+      repository: "https://github.com/brioche-dev/CMake.git",
+      ref: "base/brioche-patches",
+    });
+    const patched = Brioche.gitCheckout({
+      repository: "https://github.com/brioche-dev/CMake.git",
+      ref: "brioche-patches",
+    });
 
     return std.runBash`
       diff -ru base patched > "$BRIOCHE_OUTPUT" || true

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
@@ -14,12 +13,10 @@ std.assert(
   `Dasel major version ${majorVersion} does not match version number ${project.version}`,
 );
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/TomWright/dasel.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/TomWright/dasel.git",
+  ref: `v${project.version}`,
+});
 
 export default function dasel(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "dust",
   version: "1.2.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/bootandy/dust.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/bootandy/dust.git",
+  ref: `v${project.version}`,
+});
 
 export default function dust(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.21.2",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/eza-community/eza.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/eza-community/eza.git",
+  ref: `v${project.version}`,
+});
 
 export default function eza(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "fd",
   version: "10.2.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/sharkdp/fd.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/sharkdp/fd.git",
+  ref: `v${project.version}`,
+});
 
 export default function fd(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "35.0.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/antonmedv/fx.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/antonmedv/fx.git",
+  ref: project.version,
+});
 
 export default function fx(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -81,7 +81,7 @@ interface GitCheckoutInit {
   options?: GitCheckoutOptions;
 }
 
-interface GitCheckoutOptions {
+export interface GitCheckoutOptions {
   submodules?: boolean;
 }
 

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -97,7 +97,8 @@ interface GitCheckoutOptions {
  *
  * - `repository`: The URL of the git repository to checkout.
  * - `commit`: The full commit hash to checkout.
- * - `submodules`: Set to true to recursively checkout git submodules too.
+ * - `options`: Extra options for the checkout.
+ *   - `submodules`: Set to true to recursively checkout git submodules too.
  *
  * ## Example
  *

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import nushell from "nushell";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
@@ -9,12 +8,10 @@ export const project = {
   latestBuildDate: "2025-04-24",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/cli/cli.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/cli/cli.git",
+  ref: `v${project.version}`,
+});
 
 export default function gh(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -1,7 +1,7 @@
 import nushell from "nushell";
 import * as std from "std";
 import cmake from "cmake";
-import git, { gitCheckout } from "git";
+import git from "git";
 import { cargoBuild } from "rust";
 
 export const project = {
@@ -9,12 +9,10 @@ export const project = {
   version: "0.27.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/extrawurst/gitui.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/extrawurst/gitui.git",
+  ref: `v${project.version}`,
+});
 
 export default function gitui(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "joshuto",
   version: "0.9.8",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/kamiyaa/joshuto.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/kamiyaa/joshuto.git",
+  ref: `v${project.version}`,
+});
 
 // Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
 // from the `Cargo.lock` from this commit in Joshuto:

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -9,12 +8,10 @@ export const project = {
   version: "0.28.2",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/martinvonz/jj.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/martinvonz/jj.git",
+  ref: `v${project.version}`,
+});
 
 export default function jujutsu(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "just",
   version: "1.40.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/casey/just.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/casey/just.git",
+  ref: project.version,
+});
 
 export default function just(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "jwt_cli",
   version: "6.2.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/mike-engel/jwt-cli.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/mike-engel/jwt-cli.git",
+  ref: project.version,
+});
 
 export default function jwtCli(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.7.3",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/doitintl/kube-no-trouble.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/doitintl/kube-no-trouble.git",
+  ref: project.version,
+});
 
 export default function kubent(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import jq from "jq";
 import nushell from "nushell";
 
@@ -9,12 +8,10 @@ export const project = {
 };
 
 const source = std.recipeFn(() => {
-  const source = gitCheckout(
-    Brioche.gitRef({
-      repository: `https://git.kernel.org/pub/scm/libs/libcap/libcap.git/`,
-      ref: `v${project.version}`,
-    }),
-  );
+  const source = Brioche.gitCheckout({
+    repository: `https://git.kernel.org/pub/scm/libs/libcap/libcap.git/`,
+    ref: `v${project.version}`,
+  });
 
   return std.runBash`
     sed -i 's|#!/bin/bash|#!/usr/bin/env bash|' "$BRIOCHE_OUTPUT/progs/mkcapshdoc.sh"

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import { gitCheckout } from "git";
 import python from "python";
 import nushell from "nushell";
 
@@ -9,12 +8,10 @@ export const project = {
   version: "20.1.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/llvm/llvm-project.git",
-    ref: `llvmorg-${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/llvm/llvm-project.git",
+  ref: `llvmorg-${project.version}`,
+});
 
 export default function llvm(): std.Recipe<std.Directory> {
   let llvm = cmakeBuild({

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "lurk",
   version: "0.3.9",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/JakWai01/lurk.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/JakWai01/lurk.git",
+  ref: `v${project.version}`,
+});
 
 export default function lurk(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.4.48",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/rust-lang/mdBook.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/rust-lang/mdBook.git",
+  ref: `v${project.version}`,
+});
 
 export default function mdbook(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import python from "python";
 import nushell from "nushell";
 
@@ -8,12 +7,10 @@ export const project = {
   version: "1.8.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/mesonbuild/meson.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/mesonbuild/meson.git",
+  ref: project.version,
+});
 
 const pipDependencies = std.directory({
   "setuptools-75.1.0-py3-none-any.whl": Brioche.download(

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "miniserve",
   version: "0.29.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/svenstaro/miniserve.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/svenstaro/miniserve.git",
+  ref: `v${project.version}`,
+});
 
 export default function miniserve(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 import perl from "perl";
 import libxml2 from "libxml2";
@@ -10,12 +9,10 @@ export const project = {
   version: "0.70",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "git://git.joeyh.name/moreutils",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "git://git.joeyh.name/moreutils",
+  ref: project.version,
+});
 
 export default function moreutils(): std.Recipe<std.Directory> {
   let moreutils = std.runBash`

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -1,18 +1,15 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "nasm",
   version: "2.16.03",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/netwide-assembler/nasm.git",
-    ref: `nasm-${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/netwide-assembler/nasm.git",
+  ref: `nasm-${project.version}`,
+});
 
 export default function nasm(): std.Recipe<std.Directory> {
   return std.runBash`

--- a/packages/ninja/project.bri
+++ b/packages/ninja/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "1.12.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/ninja-build/ninja.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/ninja-build/ninja.git",
+  ref: `v${project.version}`,
+});
 
 export default function ninja(): std.Recipe<std.Directory> {
   return cmakeBuild({

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -1,19 +1,16 @@
 import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "nushell",
   version: "0.104.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/nushell/nushell.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/nushell/nushell.git",
+  ref: project.version,
+});
 
 export default function nushell(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "oha",
   version: "1.8.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/hatoo/oha.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/hatoo/oha.git",
+  ref: `v${project.version}`,
+});
 
 export default function oha(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -1,18 +1,15 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "oniguruma",
   version: "6.9.10",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/kkos/oniguruma.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/kkos/oniguruma.git",
+  ref: `v${project.version}`,
+});
 
 export default function oniguruma(): std.Recipe<std.Directory> {
   let oniguruma = std.runBash`

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "opentofu",
   version: "1.9.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/opentofu/opentofu.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/opentofu/opentofu.git",
+  ref: `v${project.version}`,
+});
 
 export default function tofu(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -1,19 +1,17 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "pcre2",
   version: "10.45",
 };
 
-const gitRef = await Brioche.gitRef({
+const source = Brioche.gitCheckout({
   repository: "https://github.com/PCRE2Project/pcre2.git",
   ref: `pcre2-${project.version}`,
-});
-
-const source = gitCheckout(gitRef, {
-  submodules: true,
+  options: {
+    submodules: true,
+  },
 });
 
 export default function pcre2(): std.Recipe<std.Directory> {

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import git, { gitCheckout } from "git";
+import git from "git";
 import { goBuild } from "go";
 import nushell from "nushell";
 
@@ -8,12 +8,10 @@ export const project = {
   version: "1.69.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/rclone/rclone.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/rclone/rclone.git",
+  ref: `v${project.version}`,
+});
 
 export default function rclone(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { goBuild } from "go";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.18.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/restic/restic.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/restic/restic.git",
+  ref: `v${project.version}`,
+});
 
 export default function restic(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.9.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/MilesCranmer/rip2.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/MilesCranmer/rip2.git",
+  ref: `v${project.version}`,
+});
 
 export default function rip2(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "14.1.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/BurntSushi/ripgrep.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/BurntSushi/ripgrep.git",
+  ref: project.version,
+});
 
 export default function ripgrep(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "ruff",
   version: "0.11.7",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/astral-sh/ruff.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/astral-sh/ruff.git",
+  ref: project.version,
+});
 
 export default function ruff(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -1,6 +1,5 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 import { cmakeBuild } from "cmake";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "1.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/virtualsquare/s2argv-execs.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/virtualsquare/s2argv-execs.git",
+  ref: project.version,
+});
 
 export default function s2argvExecs(): std.Recipe<std.Directory> {
   let s2argv_execs = cmakeBuild({

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { goBuild } from "go";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "3.86",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/seaweedfs/seaweedfs.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/seaweedfs/seaweedfs.git",
+  ref: project.version,
+});
 
 export default function seaweedfs(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "starship",
   version: "1.23.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/starship/starship.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/starship/starship.git",
+  ref: `v${project.version}`,
+});
 
 export default function starship(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -9,7 +9,7 @@ import { BRIOCHE_VERSION } from "./runtime.bri";
 import { semverMatches } from "./semver.bri";
 import { assert } from "./utils.bri";
 
-interface GitRefOptions {
+export interface GitRefOptions {
   repository: string;
   ref: string;
 }

--- a/packages/std/extra/extra_global.bri
+++ b/packages/std/extra/extra_global.bri
@@ -1,7 +1,7 @@
 import { type Recipe, type Directory, recipeFn } from "/core/recipes";
 import { source } from "/core/source.bri";
 import type { GitRefOptions } from "/core/global.bri";
-import { gitCheckout, type GitCheckoutOptions } from "git";
+import type { GitCheckoutOptions } from "git";
 
 interface GitCheckoutInit extends GitRefOptions {
   options?: GitCheckoutOptions;
@@ -57,6 +57,12 @@ declare global {
   }
 
   return recipeFn(async () => {
+    // Import `git` dynamically to avoid issues with execution order. Note this
+    // only works because we have a top-level `import type ... from "git"`,
+    // which means git is already found as a dependency. See:
+    // https://github.com/brioche-dev/brioche/issues/242
+    const { gitCheckout } = await import("git");
+
     const result = await (
       globalThis as any
     ).Deno.core.ops.op_brioche_get_static(sourceFrame.fileName, {

--- a/packages/std/extra/extra_global.bri
+++ b/packages/std/extra/extra_global.bri
@@ -1,0 +1,82 @@
+import { type Recipe, type Directory, recipeFn } from "/core/recipes";
+import { source } from "/core/source.bri";
+import type { GitRefOptions } from "/core/global.bri";
+import { gitCheckout, type GitCheckoutOptions } from "git";
+
+interface GitCheckoutInit extends GitRefOptions {
+  options?: GitCheckoutOptions;
+}
+
+declare global {
+  // eslint-disable-next-line
+  namespace Brioche {
+    /**
+     * Checkout a git repository from a specific git ref. The repository
+     * will be cloned without any history. This function must be called with
+     * constant strings for both the repository and ref. The commit hash
+     * will be saved in the lockfile, so the same commit hash will be used
+     * until the lockfile is updated.
+     *
+     * See also the function `Brioche.gitRef`, which directly returns the
+     * resolved commit hash instead.
+     *
+     * ## Options
+     *
+     * - `repository`: A git repository URL.
+     * - `ref`: A git ref, such as a branch or tag name. Example: `main`
+     * - `options`: Extra options for the checkout. See the `gitCheckout`
+     *   function from the `git` package for all available extra options.
+     *
+     * ## Example
+     *
+     * ```typescript
+     * import * as std from "std";
+     *
+     * // Check out the main branch from the Brioche repository. The commit
+     * // hash will be locked when first run, and will not change until the
+     * // lockfile is updated
+     * const source = Brioche.gitCheckout({
+     *   repository: "https://github.com/brioche-dev/brioche.git",
+     *   ref: "main",
+     * });
+     * ```
+     */
+    function gitCheckout(options: GitCheckoutInit): Recipe<Directory>;
+  }
+}
+
+(globalThis as any).Brioche ??= {};
+(globalThis as any).Brioche.gitCheckout ??= (
+  init: GitCheckoutInit,
+): Recipe<Directory> => {
+  const sourceFrame = source({ depth: 1 }).at(0);
+  if (sourceFrame === undefined) {
+    throw new Error(
+      `Could not find source file to resolve git ref '${init.ref}' from repository '${init.repository}'`,
+    );
+  }
+
+  return recipeFn(async () => {
+    const result = await (
+      globalThis as any
+    ).Deno.core.ops.op_brioche_get_static(sourceFrame.fileName, {
+      type: "git_ref",
+      repository: init.repository,
+      ref: init.ref,
+    });
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      typeof result.repository !== "string" ||
+      typeof result.commit !== "string"
+    ) {
+      throw new Error("failed to parse git ref result");
+    }
+
+    return gitCheckout({
+      repository: result.repository,
+      commit: result.commit,
+      options: init.options,
+    });
+  });
+};

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -5,3 +5,5 @@ export * from "./runnable.bri";
 export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
+
+import "./extra_global.bri";

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { gitCheckout } from "git";
 import { goBuild } from "go";
 import nushell from "nushell";
 
@@ -8,12 +7,10 @@ export const project = {
   version: "1.1.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/turbot/steampipe.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/turbot/steampipe.git",
+  ref: `v${project.version}`,
+});
 
 export default function steampipe(): std.Recipe<std.Directory> {
   return goBuild({

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "tailspin",
   version: "5.4.2",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/bensadeh/tailspin.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/bensadeh/tailspin.git",
+  ref: project.version,
+});
 
 export default function tailspin(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "terraform",
   version: "1.11.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/hashicorp/terraform.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/hashicorp/terraform.git",
+  ref: `v${project.version}`,
+});
 
 export default function terraform(): std.Recipe<std.Directory> {
   const patchedSource = std.runBash`

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "12.1.2",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/XAMPPRocky/tokei.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/XAMPPRocky/tokei.git",
+  ref: `v${project.version}`,
+});
 
 export default function tokei(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -1,18 +1,15 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "uthash",
   version: "2.3.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/troydhanson/uthash.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/troydhanson/uthash.git",
+  ref: `v${project.version}`,
+});
 
 export default function uthash(): std.Recipe<std.Directory> {
   return std.setEnv(source, {

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -1,7 +1,6 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import { gitCheckout } from "git";
 import s2argvExecs from "s2argv_execs";
 
 export const project = {
@@ -9,12 +8,10 @@ export const project = {
   version: "4.0.1",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/rd235/vdeplug4.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/rd235/vdeplug4.git",
+  ref: `v${project.version}`,
+});
 
 export default function vdeplug4(): std.Recipe<std.Directory> {
   let vdeplug = cmakeBuild({

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "wasmtime",
   version: "32.0.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/bytecodealliance/wasmtime.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/bytecodealliance/wasmtime.git",
+  ref: `v${project.version}`,
+});
 
 export default function wasmtime(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 import nushell from "nushell";
 
 export const project = {
@@ -8,12 +7,10 @@ export const project = {
   version: "0.24.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/ducaale/xh.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/ducaale/xh.git",
+  ref: `v${project.version}`,
+});
 
 export default function xh(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -1,7 +1,6 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "xplr",
@@ -9,12 +8,10 @@ export const project = {
 };
 
 const source = (() => {
-  let source = gitCheckout(
-    Brioche.gitRef({
-      repository: "https://github.com/sayanarijit/xplr.git",
-      ref: `v${project.version}`,
-    }),
-  );
+  let source = Brioche.gitCheckout({
+    repository: "https://github.com/sayanarijit/xplr.git",
+    ref: `v${project.version}`,
+  });
 
   // HACK: Workaround for https://github.com/LukeMathWalker/cargo-chef/issues/295#issuecomment-2619963413
   source = std.runBash`

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "xsv",
   version: "0.13.0",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/BurntSushi/xsv.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/BurntSushi/xsv.git",
+  ref: project.version,
+});
 
 export default function xsv(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -1,18 +1,15 @@
 import nushell from "nushell";
 import * as std from "std";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "zlib_ng",
   version: "2.2.4",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/zlib-ng/zlib-ng.git",
-    ref: project.version,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/zlib-ng/zlib-ng.git",
+  ref: project.version,
+});
 
 export default function zlibNg(): std.Recipe<std.Directory> {
   const zlibNg = std.runBash`

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -1,19 +1,16 @@
 import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "zoxide",
   version: "0.9.7",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: "https://github.com/ajeetdsouza/zoxide.git",
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/ajeetdsouza/zoxide.git",
+  ref: `v${project.version}`,
+});
 
 export default function zoxide(): std.Recipe<std.Directory> {
   return cargoBuild({


### PR DESCRIPTION
This PR updates `std` to add the global function `Brioche.gitCheckout()`, and additionally replaces most uses of `git.gitCheckout` with `Brioche.gitCheckout`.

`Brioche.gitCheckout` is a new [static](https://brioche.dev/docs/core-concepts/statics/) (documentation pending), and runtime support was added in Brioche v0.1.5. From the runtime's perspective, it behaves just like `Brioche.gitRef()`, so it takes a repository URL and a git ref, and saves the commit of the git ref in the lockfile. But the implementation is just like `git.gitCheckout()`, so it returns a recipe containing a clone of the repository at that commit.

```typescript
// Previously:
// const source = gitCheckout(
//   Brioche.gitRef({
//     repository: "https://github.com/brioche-dev/brioche.git",
//     ref: "main",
//   }),
// );

// Now:
const source = Brioche.gitCheckout({
  repository: "https://github.com/brioche-dev/brioche.git",
  ref: "main",
});
```

Implementation-wise, `Brioche.gitCheckout()` just imports and calls `git.gitCheckout()`! I originally didn't think this would work, but now that we have cyclic imports, this works without too much friction.

I also updated all the packages I could. There were a handful that used the output from `Brioche.gitRef` directly, so I didn't think it made sense to change those (at least for now... but it might be possible if we added some extra mixin methods on the returned recipe or something?)