### PR TITLE
[Breaking][std] Simplify recipes

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -18,7 +18,7 @@ export default function alsaLib(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(alsaLib, {
@@ -48,7 +48,7 @@ export async function test() {
     gcc main.c -o main -lasound
     ./main | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), alsaLib())
+    .dependencies(std.toolchain, alsaLib)
     .env({ src: src })
     .toFile();
 

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     amber --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(amber())
+    .dependencies(amber)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -71,7 +71,7 @@ export async function test() {
     mkdir -p "$BRIOCHE_OUTPUT"/C.UTF-8
     localedef -i POSIX -f UTF-8 "$BRIOCHE_OUTPUT"/C.UTF-8 || true
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .env({
       I18NPATH: std.tpl`${std.toolchain()}/share/i18n`,
     })
@@ -80,7 +80,7 @@ export async function test() {
   const script = std.runBash`
     asciinema --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(asciinema())
+    .dependencies(asciinema)
     .env({
       LOCPATH: locale,
       LANG: "C.UTF-8",

--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -21,7 +21,7 @@ export async function test() {
   const script = std.runBash`
     cdk --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(awsCdk())
+    .dependencies(awsCdk)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -103,7 +103,7 @@ export async function test() {
   const script = std.runBash`
     aws --version | tr -d '\n' | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(awsCli())
+    .dependencies(awsCli)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     bat --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(bat())
+    .dependencies(bat)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -27,7 +27,7 @@ export async function test() {
   const script = std.runBash`
     biome --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(biome())
+    .dependencies(biome)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     broot --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(broot())
+    .dependencies(broot)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -22,7 +22,7 @@ export default function bubblewrap(): std.Recipe<std.Directory> {
     meson compile -C _builddir
     meson install -C _builddir --destdir "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), meson(), ninja(), cmake(), libcap())
+    .dependencies(std.toolchain, meson, ninja, cmake, libcap)
     .workDir(source)
     .toDirectory();
 
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     bwrap --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(bubblewrap())
+    .dependencies(bubblewrap)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -32,7 +32,7 @@ export async function test() {
   const script = std.runBash`
     openssl x509 -in $SSL_CERT_FILE -noout -text | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(caCertificates(), openssl())
+    .dependencies(caCertificates, openssl)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -18,7 +18,7 @@ const sourceRef = Brioche.gitRef({
 });
 
 export default function caddy(): std.Recipe<std.Directory> {
-  let caddy = std.recipeFn(async () => {
+  let caddy = std.recipe(async () => {
     const commit = (await sourceRef).commit;
 
     // Build Caddy using `xcaddy build`. This is the officially-recommended

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -63,7 +63,7 @@ export async function test() {
   const script = std.runBash`
     caddy version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(caddy())
+    .dependencies(caddy)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -28,7 +28,7 @@ export async function test() {
   const script = std.runBash`
     carapace --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(carapace())
+    .dependencies(carapace)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -21,7 +21,7 @@ export async function test() {
   const script = std.runBash`
     claude --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(claudeCode())
+    .dependencies(claudeCode)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -28,7 +28,7 @@ function patch(): std.Recipe<std.File> {
   // to whichever version of CMake we're building. This may make it easier
   // to stay up-to-date, but it's not clear if this is the right approach...
 
-  return std.recipeFn(() => {
+  return std.recipe(() => {
     const base = Brioche.gitCheckout({
       repository: "https://github.com/brioche-dev/CMake.git",
       ref: "base/brioche-patches",

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -80,9 +80,9 @@ export default function cmake(): std.Recipe<std.Directory> {
 }
 
 export interface CMakeBuildInstallOptions {
-  source: std.AsyncRecipe<std.Directory>;
+  source: std.RecipeLike<std.Directory>;
   path?: string;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  dependencies?: std.RecipeLike<std.Directory>[];
   config?: string;
   env?: Record<string, std.ProcessTemplateLike>;
   set?: Record<string, CMakeVariable>;

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
     // Apply patch file
     std.applyPatch({
       source,
-      patch: patch(),
+      patch,
       strip: 1,
     }),
   );
@@ -61,7 +61,7 @@ export default function cmake(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), openssl(), curl())
+    .dependencies(std.toolchain, openssl, curl)
     .toDirectory();
 
   cmake = cmake.insert("libexec/cmake/runtime-utils", std.runtimeUtils());
@@ -180,7 +180,7 @@ export function cmakeBuild(
       ln -s lib64 "$BRIOCHE_OUTPUT/lib"
     fi
   `
-    .dependencies(...dependencies, cmake())
+    .dependencies(...dependencies, cmake)
     .env({
       ...options.env,
       source,
@@ -203,7 +203,7 @@ export async function test() {
     # Only retrieve the first line of the output, other lines are not relevant for the version check
     cmake --version | head -n 1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(cmake())
+    .dependencies(cmake)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/codex/project.bri
+++ b/packages/codex/project.bri
@@ -21,7 +21,7 @@ export async function test() {
   const script = std.runBash`
     codex --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(codex())
+    .dependencies(codex)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -26,7 +26,7 @@ export default function curl(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), openssl(), libpsl())
+    .dependencies(std.toolchain, openssl, libpsl)
     .toDirectory();
 
   curl = std.setEnv(curl, {
@@ -43,7 +43,7 @@ export default function curl(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     curl --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(curl());
+  `.dependencies(curl);
 
   const result = (await script.toFile().read()).trim();
 

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -35,7 +35,7 @@ export async function test() {
   const script = std.runBash`
     dasel --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(dasel())
+    .dependencies(dasel)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     dust --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(dust())
+    .dependencies(dust)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/eks_node_viewer/project.bri
+++ b/packages/eks_node_viewer/project.bri
@@ -37,7 +37,7 @@ export async function test() {
   const script = std.runBash`
     eks-node-viewer --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(eksNodeViewer())
+    .dependencies(eksNodeViewer)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -28,7 +28,7 @@ export default function expat(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(expat, {
@@ -42,7 +42,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion expat | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), expat())
+    .dependencies(std.toolchain, expat)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     eza --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(eza())
+    .dependencies(eza)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     fd --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(fd())
+    .dependencies(fd)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     fx --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(fx())
+    .dependencies(fx)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -120,7 +120,7 @@ export function gitCheckout(
   init: std.Awaitable<GitCheckoutInit>,
   options: GitCheckoutOptions = {},
 ): std.Recipe<std.Directory> {
-  return std.recipeFn(async () => {
+  return std.recipe(async () => {
     const { commit, repository, options: initOptions } = await init;
     options = { ...initOptions, ...options };
 

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -20,7 +20,7 @@ export default function git(): std.Recipe<std.Directory> {
     make prefix=/ install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), openssl(), curl())
+    .dependencies(std.toolchain, openssl, curl)
     .toDirectory();
 
   git = std.setEnv(git, {
@@ -36,7 +36,7 @@ export async function test() {
   const script = std.runBash`
     git --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(git())
+    .dependencies(git)
     .toFile();
 
   const result = (await script.read()).trim();
@@ -139,7 +139,7 @@ export function gitCheckout(
       git fetch --depth 1 origin "$commit"
       git -c advice.detachedHead=false checkout FETCH_HEAD
     `
-      .dependencies(git())
+      .dependencies(git)
       .env({
         repository,
         commit,
@@ -153,7 +153,7 @@ export function gitCheckout(
         cd "$BRIOCHE_OUTPUT"
         git submodule update --init --recursive
       `
-        .dependencies(git())
+        .dependencies(git)
         .outputScaffold(repo)
         .unsafe({ networking: true })
         .toDirectory();

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -32,7 +32,7 @@ export async function test() {
   const script = std.runBash`
     gh --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(gh())
+    .dependencies(gh)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     gitui --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(gitui())
+    .dependencies(gitui)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -96,8 +96,8 @@ interface GoBuildParameters {
 }
 
 interface GoBuildOptions {
-  source: std.AsyncRecipe<std.Directory>;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  source: std.RecipeLike<std.Directory>;
+  dependencies?: std.RecipeLike<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
   buildParams?: GoBuildParameters;
   path?: string;
@@ -198,7 +198,7 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
 }
 
 function goModDownload(
-  goModule: std.AsyncRecipe<std.Directory>,
+  goModule: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   return std.runBash`
     go mod download all

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -44,7 +44,7 @@ export async function test() {
   const script = std.runBash`
     go version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(go())
+    .dependencies(go)
     .toFile();
 
   const result = (await script.read()).trim();
@@ -177,7 +177,7 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
     go install "\${goargs[@]}" "$package_path"
   `
     .workDir(options.source)
-    .dependencies(go(), ...(options.dependencies ?? []))
+    .dependencies(go, ...(options.dependencies ?? []))
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,
@@ -204,7 +204,7 @@ function goModDownload(
     go mod download all
   `
     .workDir(std.glob(goModule, ["**/go.mod", "**/go.sum"]))
-    .dependencies(go())
+    .dependencies(go)
     .env({ GOMODCACHE: std.outputPath })
     .unsafe({ networking: true })
     .toDirectory();

--- a/packages/hello_world/project.bri
+++ b/packages/hello_world/project.bri
@@ -11,6 +11,6 @@ export default function (): std.Recipe<std.Directory> {
     ln -s bin/hello-world "$BRIOCHE_OUTPUT/brioche-run"
   `
     .workDir(Brioche.glob("src"))
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 }

--- a/packages/htop/project.bri
+++ b/packages/htop/project.bri
@@ -18,7 +18,7 @@ export default function htop(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     htop --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(htop())
+    .dependencies(htop)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -32,7 +32,7 @@ export default function icu(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   icu = std.setEnv(icu, {
@@ -65,7 +65,7 @@ export async function test() {
   const script = std.runBash`
     icuinfo | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(icu())
+    .dependencies(icu)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -32,7 +32,7 @@ export async function test() {
   const script = std.runBash`
     joshuto --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(joshuto())
+    .dependencies(joshuto)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -21,7 +21,7 @@ export default function jq(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
   return std.withRunnableLink(jq, "bin/jq");
 }
@@ -30,7 +30,7 @@ export async function test() {
   const script = std.runBash`
     jq --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(jq())
+    .dependencies(jq)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -26,7 +26,7 @@ export async function test() {
   const script = std.runBash`
     jj version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(jujutsu())
+    .dependencies(jujutsu)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     just --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(just())
+    .dependencies(just)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     jwt --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(jwtCli())
+    .dependencies(jwtCli)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -34,7 +34,7 @@ export async function test() {
     # Remove ANSI color codes from the output, before extracting the version
     k9s version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(k9s())
+    .dependencies(k9s)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -23,7 +23,7 @@ export default function kmod(): std.Recipe<std.Directory> {
     DESTDIR="$BRIOCHE_OUTPUT" meson install -C build
   `
     .workDir(source)
-    .dependencies(std.toolchain(), meson(), ninja(), scdoc(), openssl())
+    .dependencies(std.toolchain, meson, ninja, scdoc, openssl)
     .toDirectory();
 }
 
@@ -31,7 +31,7 @@ export async function test() {
   const script = std.runBash`
     kmod --version | tee -a "$BRIOCHE_OUTPUT"
   `
-    .dependencies(kmod())
+    .dependencies(kmod)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -27,7 +27,7 @@ export async function test() {
   const script = std.runBash`
     kubent --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(kubent())
+    .dependencies(kubent)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -19,7 +19,7 @@ export default function libarchive(): std.Recipe<std.Directory> {
     make install
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   libarchive = std.setEnv(libarchive, {
@@ -35,7 +35,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libarchive | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libarchive())
+    .dependencies(std.toolchain, libarchive)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -126,7 +126,7 @@ function briocheObjcopy(): std.Recipe<std.Directory> {
 }
 
 function fixSharedObjects(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // `libcap` compiles its shared libraries with extra flags so they also work
   // as executables. `brioche-ld` therefore treats them like executables, which
@@ -161,7 +161,7 @@ function fixSharedObjects(
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -7,7 +7,7 @@ export const project = {
   version: "1.2.76",
 };
 
-const source = std.recipeFn(() => {
+const source = std.recipe(() => {
   const source = Brioche.gitCheckout({
     repository: `https://git.kernel.org/pub/scm/libs/libcap/libcap.git/`,
     ref: `v${project.version}`,

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -52,7 +52,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libcap | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libcap())
+    .dependencies(std.toolchain, libcap)
     .toFile();
 
   const result = (await script.read()).trim();
@@ -154,7 +154,7 @@ function fixSharedObjects(
           --pack "$new_pack"
       done
   `
-    .dependencies(jq(), std.runtimeUtils())
+    .dependencies(jq, std.runtimeUtils)
     .outputScaffold(recipe)
     .toDirectory();
 }

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -19,7 +19,7 @@ export default function libffi(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(libffi, {
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libffi | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libffi())
+    .dependencies(std.toolchain, libffi)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -18,7 +18,7 @@ export default function libpcap(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(libpcap, {
@@ -32,7 +32,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libpcap | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libpcap())
+    .dependencies(std.toolchain, libpcap)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -19,7 +19,7 @@ export default function libPsl(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), python())
+    .dependencies(std.toolchain, python)
     .toDirectory();
 
   return std.setEnv(libpsl, {
@@ -49,7 +49,7 @@ export async function test() {
     gcc main.c -o main -lpsl
     ./main | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libPsl())
+    .dependencies(std.toolchain, libPsl)
     .env({ src: src })
     .toFile();
 

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -22,7 +22,7 @@ export default function libtirpc(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   libtirpc = std.setEnv(libtirpc, {
@@ -39,7 +39,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libtirpc | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libtirpc())
+    .dependencies(std.toolchain, libtirpc)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -83,7 +83,7 @@ export function liveUpdate() {
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -19,7 +19,7 @@ export default function libunwind(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(libunwind, {
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libunwind | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libunwind())
+    .dependencies(std.toolchain, libunwind)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -29,7 +29,7 @@ export default function libxml2(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), python())
+    .dependencies(std.toolchain, python)
     .toDirectory();
 
   libxml2 = makePkgConfigPathsRelative(libxml2);
@@ -47,7 +47,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libxml-2.0 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libxml2())
+    .dependencies(std.toolchain, libxml2)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -100,7 +100,7 @@ export function liveUpdate() {
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -101,7 +101,7 @@ export function liveUpdate() {
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -30,7 +30,7 @@ export default function libxslt(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), python(), libxml2())
+    .dependencies(std.toolchain, python, libxml2)
     .toDirectory();
 
   libxslt = makePkgConfigPathsRelative(libxslt);
@@ -48,7 +48,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion libxslt | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libxslt())
+    .dependencies(std.toolchain, libxslt)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -45,7 +45,7 @@ export function linuxDefconfig(
     make defconfig
   `
     .workDir(source)
-    .dependencies(...dependencies, ldWrapper(), std.toolchain())
+    .dependencies(...dependencies, ldWrapper, std.toolchain)
     .env({
       ...env,
       KCONFIG_CONFIG: std.outputPath,
@@ -102,13 +102,7 @@ export default function linux(
     make modules_install
   `
     .workDir(source)
-    .dependencies(
-      ...dependencies,
-      openssl(),
-      kmod(),
-      ldWrapper(),
-      std.toolchain(),
-    )
+    .dependencies(...dependencies, openssl, kmod, ldWrapper, std.toolchain)
     .env({
       INSTALL_MOD_PATH: std.outputPath,
 
@@ -216,7 +210,7 @@ function distClean(
     cd "$BRIOCHE_OUTPUT"
     make distclean
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .outputScaffold(source)
     .toDirectory();
 }

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -28,7 +28,7 @@ export function linuxSource(): std.Recipe<std.Directory> {
 
 interface LinuxDefconfigOptions {
   env?: Record<string, std.ProcessTemplateLike>;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  dependencies?: std.RecipeLike<std.Directory>[];
 }
 
 /**
@@ -54,8 +54,8 @@ export function linuxDefconfig(
 }
 
 interface LinuxOptions {
-  config?: std.AsyncRecipe<std.File>;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  config?: std.RecipeLike<std.File>;
+  dependencies?: std.RecipeLike<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
 }
 
@@ -170,7 +170,7 @@ type LinuxUpdateConfigValue =
  *
  */
 export function linuxUpdateConfig(
-  config: std.AsyncRecipe<std.File>,
+  config: std.RecipeLike<std.File>,
   values: Record<string, LinuxUpdateConfigValue>,
 ): std.Recipe<std.File> {
   const args = Object.entries(values).flatMap(([key, value]) => {
@@ -210,7 +210,7 @@ export function linuxUpdateConfig(
 }
 
 function distClean(
-  source: std.AsyncRecipe<std.Directory>,
+  source: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   return std.runBash`
     cd "$BRIOCHE_OUTPUT"

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -73,7 +73,7 @@ export async function test() {
   const script = std.runBash`
     llvm-config --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(llvm())
+    .dependencies(llvm)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     lurk --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(lurk())
+    .dependencies(lurk)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     mdbook --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(mdbook())
+    .dependencies(mdbook)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -69,7 +69,7 @@ export async function test() {
   const script = std.runBash`
     meson --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(meson())
+    .dependencies(meson)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     miniserve --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(miniserve())
+    .dependencies(miniserve)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -103,7 +103,7 @@ const docbookXsl = Brioche.download(
 function wrapPerlShebangs(
   recipe: std.Recipe<std.Directory>,
 ): std.Recipe<std.Directory> {
-  return std.recipeFn(async () => {
+  return std.recipe(async () => {
     // Add Perl in the recipe
     recipe = recipe.insert(".local/libexec/moreutils/perl", perlEnv());
 

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -19,7 +19,7 @@ export default function moreutils(): std.Recipe<std.Directory> {
     make
     make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), libxml2(), libxslt())
+    .dependencies(std.toolchain, libxml2, libxslt)
     .workDir(source)
     .env({
       // XML catalog for DocBook. The moreutils build validates some XML
@@ -42,7 +42,7 @@ export async function test() {
   const script = std.runBash`
     errno 13 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(moreutils())
+    .dependencies(moreutils)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -21,7 +21,7 @@ export default function nasm(): std.Recipe<std.Directory> {
     cp nasm "$BRIOCHE_OUTPUT/bin/nasm"
     ln -s "bin/nasm" "$BRIOCHE_OUTPUT/brioche-run"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 }
@@ -30,7 +30,7 @@ export async function test() {
   const script = std.runBash`
     nasm --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(nasm())
+    .dependencies(nasm)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -22,7 +22,7 @@ export default function nginx(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), pcre2())
+    .dependencies(std.toolchain, pcre2)
     .toDirectory();
 
   nginx = std.withRunnableLink(nginx, "bin/nginx");
@@ -34,7 +34,7 @@ export async function test() {
   const script = std.runBash`
     nginx -v 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(nginx())
+    .dependencies(nginx)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/ninja/project.bri
+++ b/packages/ninja/project.bri
@@ -27,7 +27,7 @@ export async function test() {
   const script = std.runBash`
     ninja --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(ninja())
+    .dependencies(ninja)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -159,7 +159,7 @@ const BinList = typer.array(
 export function npmInstallGlobal(
   options: NpmInstallGlobalOptions,
 ): std.Recipe<std.Directory> {
-  return std.recipeFn(async () => {
+  return std.recipe(async () => {
     const { packageName, version, wrapBins = true } = options;
 
     let recipe = std.runBash`

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -36,7 +36,7 @@ export async function test() {
   const script = std.runBash`
     node --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(nodejs())
+    .dependencies(nodejs)
     .toFile();
 
   const result = (await script.read()).trim();
@@ -102,7 +102,7 @@ export function liveUpdate() {
  *     mv dist "$BRIOCHE_OUTPUT"
  *   `
  *     .workDir(npmPackage)
- *     .dependencies(nodejs());
+ *     .dependencies(nodejs);
  * };
  * ```
  */
@@ -113,7 +113,7 @@ export function npmInstall(
     cd "$BRIOCHE_OUTPUT"
     npm clean-install
   `
-    .dependencies(nodejs())
+    .dependencies(nodejs)
     .outputScaffold(options.source)
     .unsafe({ networking: true })
     .toDirectory();
@@ -170,7 +170,7 @@ export function npmInstallGlobal(
 
       npm install --global "\${package_name}@\${version}"
     `
-      .dependencies(nodejs())
+      .dependencies(nodejs)
       .outputScaffold(std.directory())
       .env({
         package_name: packageName,

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -29,7 +29,7 @@ function nodejs(): std.Recipe<std.Directory> {
 export default nodejs;
 
 interface NpmInstallOptions {
-  source: std.AsyncRecipe<std.Directory>;
+  source: std.RecipeLike<std.Directory>;
 }
 
 export async function test() {

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -25,7 +25,7 @@ export async function test() {
   const script = std.runBash`
     nu --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(nushell())
+    .dependencies(nushell)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     oha --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(oha())
+    .dependencies(oha)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -20,7 +20,7 @@ export default function oniguruma(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -37,7 +37,7 @@ export async function test() {
   const script = std.runBash`
     onig-config --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(oniguruma())
+    .dependencies(oniguruma)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -21,7 +21,7 @@ export default function openssl(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -40,7 +40,7 @@ export async function test() {
   const script = std.runBash`
     openssl version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(openssl())
+    .dependencies(openssl)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     tofu --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(tofu())
+    .dependencies(tofu)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -25,7 +25,7 @@ export default function pcre(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -44,7 +44,7 @@ export async function test() {
     pkg-config --modversion libpcrecpp | tee -a "$BRIOCHE_OUTPUT"
     pkg-config --modversion libpcreposix | tee -a "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), pcre())
+    .dependencies(std.toolchain, pcre)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -26,7 +26,7 @@ export default function pcre2(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -44,7 +44,7 @@ export async function test() {
     pkg-config --modversion libpcre2-32 | tee -a "$BRIOCHE_OUTPUT"
     pkg-config --modversion libpcre2-posix | tee -a "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), pcre2())
+    .dependencies(std.toolchain, pcre2)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -18,7 +18,7 @@ export default function perl(): std.Recipe<std.Directory> {
     mkdir -p "$BRIOCHE_OUTPUT"/C.UTF-8
     localedef -i POSIX -f UTF-8 "$BRIOCHE_OUTPUT"/C.UTF-8 || true
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .env({
       I18NPATH: std.tpl`${std.toolchain()}/share/i18n`,
     })
@@ -34,7 +34,7 @@ export default function perl(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .env({
       LOCPATH: locale,
       LANG: "C.UTF-8",
@@ -46,7 +46,7 @@ export async function test() {
   const script = std.runBash`
     perl --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(perl())
+    .dependencies(perl)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -20,7 +20,7 @@ export default function php(): std.Recipe<std.Directory> {
     make -j16
     make install
   `
-    .dependencies(std.toolchain(), libxml2(), sqlite())
+    .dependencies(std.toolchain, libxml2, sqlite)
     .workDir(source)
     .toDirectory();
 
@@ -36,7 +36,7 @@ export async function test() {
   const script = std.runBash`
     php --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(php())
+    .dependencies(php)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -20,7 +20,7 @@ export async function test() {
   const script = std.runBash`
     pnpm --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(pnpm())
+    .dependencies(pnpm)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/popeye/project.bri
+++ b/packages/popeye/project.bri
@@ -34,7 +34,7 @@ export async function test() {
     # Remove ANSI color codes from the output, before extracting the version
     popeye version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(popeye())
+    .dependencies(popeye)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -87,7 +87,7 @@ export function liveUpdate() {
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -31,7 +31,7 @@ export default function postgresql(): std.Recipe<std.Directory> {
     make install-world-bin DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), icu(), openssl(), libxml(), libxslt())
+    .dependencies(std.toolchain, icu, openssl, libxml, libxslt)
     .toDirectory();
 
   postgresql = makePkgConfigPathsRelative(postgresql);
@@ -49,7 +49,7 @@ export async function test() {
   const script = std.runBash`
     postgres --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(postgresql())
+    .dependencies(postgresql)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -50,7 +50,7 @@ export async function test() {
   const script = std.runBash`
     process-compose version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(processCompose())
+    .dependencies(processCompose)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -18,7 +18,7 @@ const gitRef = await Brioche.gitRef({
 const source = gitCheckout(gitRef);
 
 export default function processCompose(): std.Recipe<std.Directory> {
-  let processCompose = std.recipeFn(async () =>
+  let processCompose = std.recipe(async () =>
     goBuild({
       source,
       buildParams: {

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -32,7 +32,7 @@ export default function proot(): std.Recipe<std.Directory> {
     make -C src install PREFIX="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), git(), talloc(), uthash(), libarchive())
+    .dependencies(std.toolchain, git, talloc, uthash, libarchive)
     .toDirectory();
 
   proot = std.withRunnableLink(proot, "bin/proot");
@@ -45,7 +45,7 @@ export async function test() {
   const script = std.runBash`
     proot --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(proot())
+    .dependencies(proot)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -14,7 +14,7 @@ const gitRef = await Brioche.gitRef({
   repository: project.repository,
   ref: `v${project.version}`,
 });
-const source = std.recipeFn(() => {
+const source = std.recipe(() => {
   const source = gitCheckout(gitRef);
 
   return std.runBash`

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -34,7 +34,7 @@ export async function test() {
   const script = std.runBash`
     pstack --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(pstack())
+    .dependencies(pstack)
     .toFile();
 
   const version = (await script.read()).trim();

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -19,7 +19,7 @@ export default function pv(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.withRunnableLink(pv, "bin/pv");
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     pv --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(pv())
+    .dependencies(pv)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -67,7 +67,7 @@ export default async function python(options: PythonOptions = {}) {
     python3 -m ensurepip --default-pip
   `
     .workDir(source)
-    .dependencies(std.toolchain(), libffi(), openssl(), sqlite())
+    .dependencies(std.toolchain, libffi, openssl, sqlite)
     .toDirectory();
 
   // Get all the native Python modules

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -231,7 +231,7 @@ async function fixShebangs(
 
 // TODO: Figure out where to move this, this is copied from `std`
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     rclone --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(rclone())
+    .dependencies(rclone)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -20,7 +20,7 @@ export default function re2c(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), python())
+    .dependencies(std.toolchain, python)
     .workDir(source)
     .toDirectory();
 
@@ -37,7 +37,7 @@ export async function test() {
   const script = std.runBash`
     re2c --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(re2c())
+    .dependencies(re2c)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -24,7 +24,7 @@ export async function test() {
   const script = std.runBash`
     restic version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(restic())
+    .dependencies(restic)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     rip --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(rip2())
+    .dependencies(rip2)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -26,7 +26,7 @@ export async function test() {
   const script = std.runBash`
     rg --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(ripgrep())
+    .dependencies(ripgrep)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -18,7 +18,7 @@ export default function (): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   rpcsvcProto = std.setEnv(rpcsvcProto, {

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -24,7 +24,7 @@ export async function test() {
   const script = std.runBash`
     ruff --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(ruff())
+    .dependencies(ruff)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -110,7 +110,7 @@ export async function test() {
   const script = std.runBash`
     rustc --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(rust())
+    .dependencies(rust)
     .toFile();
 
   const result = (await script.read()).trim();
@@ -341,14 +341,14 @@ export function createSkeletonCrate(
   const recipe = std.runBash`
     cargo chef prepare --recipe-path "$BRIOCHE_OUTPUT"
   `
-    .dependencies(rust(), cargoChef())
+    .dependencies(rust, cargoChef)
     .workDir(crate)
     .toFile();
   return std.runBash`
     cd "$BRIOCHE_OUTPUT"
     cargo chef cook --recipe-path "$recipe" --no-build
   `
-    .dependencies(rust(), cargoChef())
+    .dependencies(rust, cargoChef)
     .env({ recipe })
     .outputScaffold(std.directory())
     .toDirectory();
@@ -396,7 +396,7 @@ export function vendorCrate(
     # vendored dependencies
     cargo vendor --locked >> .cargo/config.toml
   `
-    .dependencies(rust())
+    .dependencies(rust)
     .outputScaffold(skeletonCrate)
     .unsafe({ networking: true })
     .toDirectory();

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -161,10 +161,10 @@ interface CargoBuildParameters {
 }
 
 export interface CargoBuildOptions {
-  source: std.AsyncRecipe<std.Directory>;
+  source: std.RecipeLike<std.Directory>;
   path?: string;
   runnable?: string;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  dependencies?: std.RecipeLike<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
   unsafe?: std.ProcessUnsafeOptions;
   buildParams?: CargoBuildParameters;
@@ -336,7 +336,7 @@ export function cargoBuild(options: CargoBuildOptions) {
  * to re-vendor the crates any time the source code changes!
  */
 export function createSkeletonCrate(
-  crate: std.AsyncRecipe<std.Directory>,
+  crate: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   const recipe = std.runBash`
     cargo chef prepare --recipe-path "$BRIOCHE_OUTPUT"
@@ -355,7 +355,7 @@ export function createSkeletonCrate(
 }
 
 interface VendorCrateOptions {
-  source: std.AsyncRecipe<std.Directory>;
+  source: std.RecipeLike<std.Directory>;
 }
 
 /**

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -60,7 +60,7 @@ export async function test() {
     # Output 'Hello, World!' through s2argv_execs
     echo "echo 'Hello, World!'" | ./main | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), s2argvExecs())
+    .dependencies(std.toolchain, s2argvExecs)
     .env({ src: src })
     .toFile();
 

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -17,7 +17,7 @@ export default function scdoc(): std.Recipe<std.Directory> {
     make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .env({
       // scdoc gets compiled to a static binary, so disable autopacking
       // TODO: Remove this and make it so brioche-ld handles this properly
@@ -38,7 +38,7 @@ export async function test() {
   const script = std.runBash`
     scdoc < "$example_file" | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(scdoc())
+    .dependencies(scdoc)
     .env({ example_file: exampleFile })
     .toFile();
 

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -24,7 +24,7 @@ export async function test() {
   const script = std.runBash`
     weed version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(seaweedfs())
+    .dependencies(seaweedfs)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -104,7 +104,7 @@ function encodeVersionNumber(version: string): string {
 // TODO: This is duplicated from the `std.toolchain()` build, we should
 // figure out how to generalize this
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -36,7 +36,7 @@ export default function sqlite(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   sqlite = makePkgConfigPathsRelative(sqlite);
@@ -54,7 +54,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion sqlite3 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), sqlite())
+    .dependencies(std.toolchain, sqlite)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     starship --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(starship())
+    .dependencies(starship)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/std/core/recipes/attach_resources.bri
+++ b/packages/std/core/recipes/attach_resources.bri
@@ -1,7 +1,7 @@
 import { BRIOCHE_VERSION } from "../runtime.bri";
 import { semverMatches } from "../semver.bri";
 import { assert } from "../utils.bri";
-import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
 /**
@@ -10,14 +10,16 @@ import type { Directory } from "./directory.bri";
  * a recipe that was archived using `collectReferences`.
  */
 export function attachResources(
-  recipe: AsyncRecipe<Directory>,
+  recipe: RecipeLike<Directory>,
 ): Recipe<Directory> {
   return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
       assert(semverMatches(BRIOCHE_VERSION, ">=0.1.4"));
 
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "attach_resources",

--- a/packages/std/core/recipes/cast.bri
+++ b/packages/std/core/recipes/cast.bri
@@ -1,6 +1,6 @@
 import {
-  type AsyncRecipe,
   type Recipe,
+  type RecipeLike,
   type Artifact,
   createRecipe,
 } from "./recipe.bri";
@@ -18,13 +18,15 @@ interface CastOptions {
  * runtime. The cast will be validated when the recipe is baked.
  */
 export function castToFile<T extends Artifact>(
-  recipe: AsyncRecipe<T>,
+  recipe: RecipeLike<T>,
   options: CastOptions = {},
 ): T extends File ? Recipe<T & File> : never {
   return createRecipe<File>(["file"], {
     sourceDepth: (options.sourceDepth ?? 0) + 1,
     briocheSerialize: async (meta) => {
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "cast",
@@ -41,13 +43,15 @@ export function castToFile<T extends Artifact>(
  * runtime. The cast will be validated when the recipe is baked.
  */
 export function castToDirectory<T extends Artifact>(
-  recipe: AsyncRecipe<T>,
+  recipe: RecipeLike<T>,
   options: CastOptions = {},
 ): T extends Directory ? Recipe<T & Directory> : never {
   return createRecipe<Directory>(["directory"], {
     sourceDepth: (options.sourceDepth ?? 0) + 1,
     briocheSerialize: async (meta) => {
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "cast",
@@ -64,13 +68,15 @@ export function castToDirectory<T extends Artifact>(
  * runtime. The cast will be validated when the recipe is baked.
  */
 export function castToSymlink<T extends Artifact>(
-  recipe: AsyncRecipe<T>,
+  recipe: RecipeLike<T>,
   options: CastOptions = {},
 ): T extends Symlink ? Recipe<T & Symlink> : never {
   return createRecipe<Symlink>(["symlink"], {
     sourceDepth: (options.sourceDepth ?? 0) + 1,
     briocheSerialize: async (meta) => {
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "cast",

--- a/packages/std/core/recipes/collect_references.bri
+++ b/packages/std/core/recipes/collect_references.bri
@@ -1,7 +1,7 @@
 import { BRIOCHE_VERSION } from "../runtime.bri";
 import { semverMatches } from "../semver.bri";
 import { assert } from "../utils.bri";
-import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
 /**
@@ -11,14 +11,16 @@ import type { Directory } from "./directory.bri";
  * an archive of a recipe.
  */
 export function collectReferences(
-  recipe: AsyncRecipe<Directory>,
+  recipe: RecipeLike<Directory>,
 ): Recipe<Directory> {
   return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
       assert(semverMatches(BRIOCHE_VERSION, ">=0.1.1"));
 
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "collect_references",

--- a/packages/std/core/recipes/directory.bri
+++ b/packages/std/core/recipes/directory.bri
@@ -2,8 +2,8 @@ import * as runtime from "../runtime.bri";
 import { assert } from "../utils.bri";
 import { createProxy } from "./proxy.bri";
 import {
-  type AsyncRecipe,
   type Recipe,
+  type RecipeLike,
   createRecipe,
   directoryRecipeUtils,
 } from "./recipe.bri";
@@ -23,9 +23,9 @@ import {
  * ```
  */
 export function directory(
-  entries: Record<string, AsyncRecipe> = {},
+  entries: Record<string, RecipeLike> = {},
 ): Recipe<Directory> {
-  const bEntries: Record<runtime.BString, AsyncRecipe> = {};
+  const bEntries: Record<runtime.BString, RecipeLike> = {};
   for (const [k, v] of Object.entries(entries)) {
     bEntries[runtime.bstring(k)] = v;
   }
@@ -35,10 +35,11 @@ export function directory(
     briocheSerialize: async (meta) => {
       const entries = await Promise.all(
         Object.entries(bEntries).map(
-          async ([k, v]): Promise<[runtime.BString, runtime.Recipe]> => [
-            k as runtime.BString,
-            await (await v).briocheSerialize(),
-          ],
+          async ([k, v]): Promise<[runtime.BString, runtime.Recipe]> => {
+            const recipeValue = typeof v === "function" ? await v() : await v;
+            const serializedRecipe = await recipeValue.briocheSerialize();
+            return [k as runtime.BString, serializedRecipe];
+          },
         ),
       );
       return {
@@ -55,9 +56,9 @@ export function directory(
  * takes precedence.
  */
 export function merge(
-  ...directories: AsyncRecipe<Directory>[]
+  ...directories: RecipeLike<Directory>[]
 ): Recipe<Directory> {
-  const proxyDirectories = directories.map((dir) => createProxy(dir));
+  const proxyDirectories = directories.map(createProxy);
   return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {

--- a/packages/std/core/recipes/directory.bri
+++ b/packages/std/core/recipes/directory.bri
@@ -88,10 +88,6 @@ export class Directory implements Recipe<Directory> {
     this.source = options.source;
   }
 
-  bake(): Directory {
-    return this;
-  }
-
   briocheSerialize(): runtime.Directory {
     return {
       type: "directory",

--- a/packages/std/core/recipes/file.bri
+++ b/packages/std/core/recipes/file.bri
@@ -55,10 +55,6 @@ export class File implements Recipe<File> {
     this.resources = options.resources;
   }
 
-  bake(): File {
-    return this;
-  }
-
   briocheSerialize(): runtime.File {
     return {
       type: "file",

--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -1,7 +1,7 @@
 import * as runtime from "../runtime.bri";
 import { assert } from "../utils.bri";
 import { semverMatches } from "../semver.bri";
-import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
 /**
@@ -23,7 +23,7 @@ import type { Directory } from "./directory.bri";
  * ```
  */
 export function glob(
-  recipe: AsyncRecipe<Directory>,
+  recipe: RecipeLike<Directory>,
   patterns: string[],
 ): Recipe<Directory> {
   return createRecipe<Directory>(["directory"], {
@@ -34,11 +34,13 @@ export function glob(
         "std.glob requires Brioche v0.1.2 or later",
       );
 
-      const serializedDirectory = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "glob",
-        directory: serializedDirectory,
+        directory: serializedRecipe,
         patterns: patterns.map((pattern) => runtime.bstring(pattern)),
       };
     },

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -13,7 +13,6 @@ export {
   type Process,
   type ProcessOptions,
   ProcessTemplate,
-  type ProcessTemplateComponent,
   type ProcessTemplateLike,
   type ProcessUnsafeOptions,
 } from "./process.bri";

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -26,6 +26,7 @@ export { glob } from "./glob.bri";
 export {
   type AsyncRecipe,
   type Recipe,
+  type RecipeLike,
   type Artifact,
   type ArtifactType,
   type ArtifactTypes,

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -23,7 +23,6 @@ export { collectReferences } from "./collect_references.bri";
 export { attachResources } from "./attach_resources.bri";
 export { glob } from "./glob.bri";
 export {
-  type AsyncRecipe,
   type Recipe,
   type RecipeLike,
   type Artifact,

--- a/packages/std/core/recipes/index.bri
+++ b/packages/std/core/recipes/index.bri
@@ -26,7 +26,6 @@ export { glob } from "./glob.bri";
 export {
   type AsyncRecipe,
   type Recipe,
-  type RecipeSerialization,
   type Artifact,
   type ArtifactType,
   type ArtifactTypes,

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -3,7 +3,12 @@ import * as runtime from "../runtime.bri";
 import type { File } from "./file.bri";
 import { type Directory } from "./directory.bri";
 import type { Symlink } from "./symlink.bri";
-import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
+import {
+  type Recipe,
+  type RecipeLike,
+  recipe,
+  createRecipe,
+} from "./recipe.bri";
 import { castToFile, castToDirectory, castToSymlink } from "./cast.bri";
 
 export type ProcessOptions = {
@@ -124,12 +129,20 @@ export function process(options: ProcessOptions): Process {
     ...options.env,
   };
 
-  const bEnv: Record<runtime.BString, ProcessTemplate> = {};
-  for (const [k, v] of Object.entries(env)) {
-    bEnv[runtime.bstring(k)] = processTemplate(v);
-  }
+  const envPairs = Object.entries(env).map(
+    ([key, value]) => [key, processTemplate(value)] as const,
+  );
 
-  const recipe = createRecipe(["file", "directory", "symlink"], {
+  const command = processTemplate(options.command);
+  const args = (options.args ?? []).map((arg) => processTemplate(arg));
+  const dependencies = (options.dependencies ?? []).map((dep) => recipe(dep));
+  const workDir = options.workDir != null ? recipe(options.workDir) : null;
+  const outputScaffold =
+    options.outputScaffold != null ? recipe(options.outputScaffold) : null;
+  const currentDir =
+    options.currentDir != null ? processTemplate(options.currentDir) : null;
+
+  const processRecipe = createRecipe(["file", "directory", "symlink"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
       const unknownUnsafeKeys = Object.keys(unknownUnsafeOptions);
@@ -140,48 +153,42 @@ export function process(options: ProcessOptions): Process {
       }
       const unsafe = networking;
 
-      const workDirValue =
-        typeof options.workDir === "function"
-          ? await options.workDir()
-          : await options.workDir;
-      const outputScaffoldValue =
-        typeof options.outputScaffold === "function"
-          ? await options.outputScaffold()
-          : await options.outputScaffold;
+      const [
+        workDirSerialized,
+        outputScaffoldSerialized,
+        currentDirSerialized,
+        commandSerialized,
+        argsSerialized,
+        envPairsSerialized,
+        dependenciesSerialized,
+      ] = await Promise.all([
+        workDir?.briocheSerialize(),
+        outputScaffold?.briocheSerialize(),
+        currentDir?.briocheSerialize(),
+        command.briocheSerialize(),
+        Promise.all(args.map((arg) => arg.briocheSerialize())),
+        Promise.all(
+          envPairs.map(async ([k, v]) => [
+            runtime.bstring(k),
+            await v.briocheSerialize(),
+          ]),
+        ),
+        Promise.all(dependencies.map((dep) => dep.briocheSerialize())),
+      ]);
 
       return {
         type: "process",
-        command: await processTemplate(options.command).briocheSerialize(),
-        args: await Promise.all(
-          (options.args ?? []).map(
-            async (arg) => await processTemplate(arg).briocheSerialize(),
-          ),
-        ),
-        env: Object.fromEntries(
-          await Promise.all(
-            Object.entries(env).map(async ([k, v]) => [
-              k,
-              await processTemplate(v).briocheSerialize(),
-            ]),
-          ),
-        ),
-        currentDir:
-          options.currentDir != null
-            ? await processTemplate(options.currentDir).briocheSerialize()
-            : undefined,
-        dependencies: await Promise.all(
-          (options.dependencies ?? []).map(async (dep) => {
-            const depValue =
-              typeof dep === "function" ? await dep() : await dep;
-            return depValue.briocheSerialize();
-          }),
-        ),
+        command: commandSerialized,
+        args: argsSerialized,
+        env: Object.fromEntries(envPairsSerialized),
+        currentDir: currentDirSerialized ?? undefined,
+        dependencies: dependenciesSerialized,
         platform: "x86_64-linux",
-        workDir: (await workDirValue?.briocheSerialize()) ?? {
+        workDir: workDirSerialized ?? {
           type: "create_directory",
           entries: {},
         },
-        outputScaffold: await outputScaffoldValue?.briocheSerialize(),
+        outputScaffold: outputScaffoldSerialized,
         unsafe,
         networking,
         meta,
@@ -189,7 +196,7 @@ export function process(options: ProcessOptions): Process {
     },
   });
 
-  return mixin(recipe, {
+  return mixin(processRecipe, {
     env(this: Process, values: Record<string, ProcessTemplateLike>): Process {
       return process({
         ...options,
@@ -399,6 +406,7 @@ export type ProcessTemplateLike =
 export class ProcessTemplate {
   componentType: "processTemplate" = "processTemplate";
   components: ProcessTemplateLike[];
+  #serialized: runtime.ProcessTemplate | undefined;
 
   constructor(...components: ProcessTemplateLike[]) {
     /* eslint-disable-next-line */
@@ -406,52 +414,55 @@ export class ProcessTemplate {
   }
 
   async briocheSerialize(): Promise<runtime.ProcessTemplate> {
-    const components = await Promise.all(
-      this.components.map((component) =>
-        typeof component === "function" ? component() : component,
-      ),
-    );
-    const runtimeComponents = await Promise.all(
-      components.map(
-        async (component): Promise<runtime.ProcessTemplateComponent[]> => {
-          if (component == null || component === "") {
-            return [];
-          } else if (typeof component === "string") {
-            return [{ type: "literal", value: runtime.bstring(component) }];
-          } else if (isProcessTemplateSymbol(component)) {
-            switch (component.symbol) {
-              case "outputPath":
-                return [{ type: "output_path" }];
-              case "resourceDir":
-                return [{ type: "resource_dir" }];
-              case "inputResourceDirs":
-                return [{ type: "input_resource_dirs" }];
-              case "homeDir":
-                return [{ type: "home_dir" }];
-              case "workDir":
-                return [{ type: "work_dir" }];
-              case "tempDir":
-                return [{ type: "temp_dir" }];
-              case "caCertificateBundlePath":
-                return [{ type: "ca_certificate_bundle_path" }];
-              default:
-                return unreachable(component.symbol);
+    if (this.#serialized == null) {
+      const components = await Promise.all(
+        this.components.map((component) =>
+          typeof component === "function" ? component() : component,
+        ),
+      );
+      const runtimeComponents = await Promise.all(
+        components.map(
+          async (component): Promise<runtime.ProcessTemplateComponent[]> => {
+            if (component == null || component === "") {
+              return [];
+            } else if (typeof component === "string") {
+              return [{ type: "literal", value: runtime.bstring(component) }];
+            } else if (isProcessTemplateSymbol(component)) {
+              switch (component.symbol) {
+                case "outputPath":
+                  return [{ type: "output_path" }];
+                case "resourceDir":
+                  return [{ type: "resource_dir" }];
+                case "inputResourceDirs":
+                  return [{ type: "input_resource_dirs" }];
+                case "homeDir":
+                  return [{ type: "home_dir" }];
+                case "workDir":
+                  return [{ type: "work_dir" }];
+                case "tempDir":
+                  return [{ type: "temp_dir" }];
+                case "caCertificateBundlePath":
+                  return [{ type: "ca_certificate_bundle_path" }];
+                default:
+                  return unreachable(component.symbol);
+              }
+            } else if (isProcessTemplateInstance(component)) {
+              const serialized = await component.briocheSerialize();
+              return serialized.components;
+            } else {
+              return [
+                { type: "input", recipe: await component.briocheSerialize() },
+              ];
             }
-          } else if (isProcessTemplateInstance(component)) {
-            const serialized = await component.briocheSerialize();
-            return serialized.components;
-          } else {
-            return [
-              { type: "input", recipe: await component.briocheSerialize() },
-            ];
-          }
-        },
-      ),
-    );
+          },
+        ),
+      );
 
-    return {
-      components: runtimeComponents.flat(1),
-    };
+      this.#serialized = {
+        components: runtimeComponents.flat(1),
+      };
+    }
+    return this.#serialized;
   }
 }
 

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -1,4 +1,4 @@
-import { Awaitable, mixin, unreachable } from "../utils.bri";
+import { mixin, unreachable } from "../utils.bri";
 import * as runtime from "../runtime.bri";
 import type { File } from "./file.bri";
 import { type Directory } from "./directory.bri";
@@ -389,9 +389,7 @@ function isProcessTemplateSymbol(
   );
 }
 
-export type ProcessTemplateLike = Awaitable<ProcessTemplateComponent>;
-
-export type ProcessTemplateComponent =
+export type ProcessTemplateLike =
   | string
   | ProcessTemplate
   | RecipeLike
@@ -408,7 +406,11 @@ export class ProcessTemplate {
   }
 
   async briocheSerialize(): Promise<runtime.ProcessTemplate> {
-    const components = await Promise.all(this.components);
+    const components = await Promise.all(
+      this.components.map((component) =>
+        typeof component === "function" ? component() : component,
+      ),
+    );
     const runtimeComponents = await Promise.all(
       components.map(
         async (component): Promise<runtime.ProcessTemplateComponent[]> => {
@@ -439,10 +441,9 @@ export class ProcessTemplate {
             const serialized = await component.briocheSerialize();
             return serialized.components;
           } else {
-            const recipeValue =
-              typeof component === "function" ? await component() : component;
-            const serializedRecipe = await recipeValue.briocheSerialize();
-            return [{ type: "input", recipe: serializedRecipe }];
+            return [
+              { type: "input", recipe: await component.briocheSerialize() },
+            ];
           }
         },
       ),

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -1,9 +1,9 @@
 import { Awaitable, mixin, unreachable } from "../utils.bri";
 import * as runtime from "../runtime.bri";
 import type { File } from "./file.bri";
-import { type Directory, directory } from "./directory.bri";
+import { type Directory } from "./directory.bri";
 import type { Symlink } from "./symlink.bri";
-import { type AsyncRecipe, type Recipe, createRecipe } from "./recipe.bri";
+import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import { castToFile, castToDirectory, castToSymlink } from "./cast.bri";
 
 export type ProcessOptions = {
@@ -11,9 +11,9 @@ export type ProcessOptions = {
   args?: ProcessTemplateLike[];
   env?: Record<string, ProcessTemplateLike>;
   currentDir?: ProcessTemplateLike;
-  dependencies?: AsyncRecipe<Directory>[];
-  workDir?: AsyncRecipe<Directory>;
-  outputScaffold?: AsyncRecipe | null;
+  dependencies?: RecipeLike<Directory>[];
+  workDir?: RecipeLike<Directory>;
+  outputScaffold?: RecipeLike | null;
   unsafe?: ProcessUnsafeOptions;
 };
 
@@ -35,17 +35,17 @@ export interface ProcessUtils {
    * Returns a new process with more dependencies added. The new
    * dependencies take precedence over the old ones.
    */
-  dependencies(...dependencies: AsyncRecipe<Directory>[]): Process;
+  dependencies(...dependencies: RecipeLike<Directory>[]): Process;
 
   /**
    * Returns a new process with a different working directory.
    */
-  workDir(workDir: AsyncRecipe<Directory>): Process;
+  workDir(workDir: RecipeLike<Directory>): Process;
 
   /**
    * Returns a new process with a different output scaffold.
    */
-  outputScaffold(outputScaffold: AsyncRecipe): Process;
+  outputScaffold(outputScaffold: RecipeLike): Process;
 
   /**
    * Returns a new process with unsafe options set. If unset, no unsafe
@@ -140,6 +140,15 @@ export function process(options: ProcessOptions): Process {
       }
       const unsafe = networking;
 
+      const workDirValue =
+        typeof options.workDir === "function"
+          ? await options.workDir()
+          : await options.workDir;
+      const outputScaffoldValue =
+        typeof options.outputScaffold === "function"
+          ? await options.outputScaffold()
+          : await options.outputScaffold;
+
       return {
         type: "process",
         command: await processTemplate(options.command).briocheSerialize(),
@@ -161,18 +170,18 @@ export function process(options: ProcessOptions): Process {
             ? await processTemplate(options.currentDir).briocheSerialize()
             : undefined,
         dependencies: await Promise.all(
-          (options.dependencies ?? []).map(
-            async (dep) => await (await dep).briocheSerialize(),
-          ),
+          (options.dependencies ?? []).map(async (dep) => {
+            const depValue =
+              typeof dep === "function" ? await dep() : await dep;
+            return depValue.briocheSerialize();
+          }),
         ),
         platform: "x86_64-linux",
-        workDir: await (
-          await (options.workDir ?? directory())
-        ).briocheSerialize(),
-        outputScaffold:
-          options.outputScaffold != null
-            ? await (await options.outputScaffold).briocheSerialize()
-            : null,
+        workDir: (await workDirValue?.briocheSerialize()) ?? {
+          type: "create_directory",
+          entries: {},
+        },
+        outputScaffold: await outputScaffoldValue?.briocheSerialize(),
         unsafe,
         networking,
         meta,
@@ -198,20 +207,20 @@ export function process(options: ProcessOptions): Process {
     },
     dependencies(
       this: Process,
-      ...dependencies: AsyncRecipe<Directory>[]
+      ...dependencies: RecipeLike<Directory>[]
     ): Process {
       return process({
         ...options,
         dependencies: [...dependencies, ...(options.dependencies ?? [])],
       });
     },
-    workDir(this: Process, workDir: AsyncRecipe<Directory>): Process {
+    workDir(this: Process, workDir: RecipeLike<Directory>): Process {
       return process({
         ...options,
         workDir,
       });
     },
-    outputScaffold(this: Process, outputScaffold: AsyncRecipe): Process {
+    outputScaffold(this: Process, outputScaffold: RecipeLike): Process {
       return process({
         ...options,
         outputScaffold,
@@ -385,7 +394,7 @@ export type ProcessTemplateLike = Awaitable<ProcessTemplateComponent>;
 export type ProcessTemplateComponent =
   | string
   | ProcessTemplate
-  | Recipe
+  | RecipeLike
   | ProcessTemplateSymbol
   | undefined;
 
@@ -430,9 +439,10 @@ export class ProcessTemplate {
             const serialized = await component.briocheSerialize();
             return serialized.components;
           } else {
-            return [
-              { type: "input", recipe: await component.briocheSerialize() },
-            ];
+            const recipeValue =
+              typeof component === "function" ? await component() : component;
+            const serializedRecipe = await recipeValue.briocheSerialize();
+            return [{ type: "input", recipe: serializedRecipe }];
           }
         },
       ),

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -2,8 +2,8 @@ import * as runtime from "../runtime.bri";
 import { type Equatable, jsonSerialize } from "../utils.bri";
 import {
   type Artifact,
-  type AsyncRecipe,
   type Recipe,
+  type RecipeLike,
   type ArtifactType,
   createRecipe,
 } from "./recipe.bri";
@@ -13,7 +13,7 @@ import {
  * converted to a proxy automatically (see `std.createProxy()`).
  */
 export function memo<Args extends Equatable[], Ret extends Artifact>(
-  f: (...args: Args) => AsyncRecipe<Ret>,
+  f: (...args: Args) => RecipeLike<Ret>,
 ): (...args: Args) => Recipe<Ret> {
   const proxies = new Map<string, Recipe<Ret>>();
   return (...args: Args) => {
@@ -38,14 +38,16 @@ export function memo<Args extends Equatable[], Ret extends Artifact>(
  * recipe's serialization.
  */
 export function createProxy<T extends Artifact>(
-  recipe: AsyncRecipe<T>,
+  recipe: RecipeLike<T>,
 ): Recipe<T> {
   let serialized: Promise<runtime.ProxyRecipe> | undefined;
 
   const serializeProxy = async (): Promise<runtime.ProxyRecipe> => {
     if (serialized === undefined) {
       serialized = (async () => {
-        const serializedRecipe = await (await recipe).briocheSerialize();
+        const recipeValue =
+          typeof recipe === "function" ? await recipe() : await recipe;
+        const serializedRecipe = await recipeValue.briocheSerialize();
         const proxy = await runtime.createProxy(serializedRecipe);
         return {
           ...proxy,

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -4,7 +4,6 @@ import {
   type Artifact,
   type AsyncRecipe,
   type Recipe,
-  type RecipeSerialization,
   type ArtifactType,
   briocheDeserializeAny,
   createRecipe,
@@ -63,8 +62,7 @@ export function createProxy<T extends Artifact>(
   return createRecipe(["file", "directory", "symlink"] as ArtifactType<T>[], {
     sourceDepth: 1,
     briocheSerialize: async () => {
-      const proxy = (await serializeProxy()) as unknown;
-      return proxy as RecipeSerialization<T>;
+      return await serializeProxy();
     },
     bake: async () => {
       if (baked === undefined) {

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -1,11 +1,10 @@
 import * as runtime from "../runtime.bri";
-import { type Equatable, assert, jsonSerialize } from "../utils.bri";
+import { type Equatable, jsonSerialize } from "../utils.bri";
 import {
   type Artifact,
   type AsyncRecipe,
   type Recipe,
   type ArtifactType,
-  briocheDeserializeAny,
   createRecipe,
 } from "./recipe.bri";
 
@@ -42,7 +41,6 @@ export function createProxy<T extends Artifact>(
   recipe: AsyncRecipe<T>,
 ): Recipe<T> {
   let serialized: Promise<runtime.ProxyRecipe> | undefined;
-  let baked: T | undefined;
 
   const serializeProxy = async (): Promise<runtime.ProxyRecipe> => {
     if (serialized === undefined) {
@@ -63,17 +61,6 @@ export function createProxy<T extends Artifact>(
     sourceDepth: 1,
     briocheSerialize: async () => {
       return await serializeProxy();
-    },
-    bake: async () => {
-      if (baked === undefined) {
-        const proxy = await serializeProxy();
-        const bakedArtifact = await runtime.bake(proxy);
-        baked = briocheDeserializeAny(bakedArtifact, proxy.meta?.source) as T;
-      }
-
-      /* eslint-disable-next-line */
-      assert(baked != null, "expected `bake()` to return a value");
-      return baked;
     },
   });
 }

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -45,15 +45,8 @@ export type Recipe<T extends Artifact = Artifact> = RecipeCommon &
  * delay the function call or awaiting the result until the recipe is baked.
  */
 export type RecipeLike<T extends Artifact = Artifact> =
-  | AsyncRecipe<T>
-  | (() => AsyncRecipe<T>);
-
-/**
- * A recipe that may be wrapped in a promise. An `AsyncRecipe` can be converted
- * to a `Recipe` using the `std.recipe()` function, even when not in
- * an async function.
- */
-export type AsyncRecipe<T extends Artifact = Artifact> = Awaitable<Recipe<T>>;
+  | Awaitable<Recipe<T>>
+  | (() => Awaitable<Recipe<T>>);
 
 export function briocheDeserializeAny(
   artifact: runtime.Artifact,

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -149,33 +149,18 @@ export function recipe<T extends Artifact>(recipe: RecipeLike<T>): Recipe<T> {
 }
 
 /**
- * Create a recipe from a function that returns an `AsyncRecipe`. This function
- * itself is not async, meaning it can even be called from a synchronous
- * function. Under the hood, this will defer the function call until the
- * recipe is baked (or serialized).
+ * Wrap a function that returns a `RecipeLike`, returning a new function that
+ * accepts the same arguments but returns a `Recipe`.
+ *
+ * The return result is passed to `std.recipe`, which can be more convenient for
+ * function callers, since methods from `Recipe` can be used directly.
  */
-export function recipeFn<T extends Artifact>(
-  f: () => AsyncRecipe<T>,
-): Recipe<T> {
-  let result: Recipe<T> | undefined;
-  return createRecipe<T>(
-    ["file", "directory", "symlink"] as ArtifactType<T>[],
-    {
-      sourceDepth: 1,
-      briocheSerialize: async () => {
-        if (result == null) {
-          result = await f();
-        }
-        return result.briocheSerialize();
-      },
-      bake: async () => {
-        if (result == null) {
-          result = await f();
-        }
-        return result.bake();
-      },
-    },
-  );
+export function recipeFn<T extends Artifact, Args extends [] = []>(
+  f: (...args: Args) => RecipeLike<T>,
+): (...args: Args) => Recipe<T> {
+  return (...args: Args): Recipe<T> => {
+    return recipe(f(...args));
+  };
 }
 
 export type CreateRecipeOptions<T extends Artifact> = {

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -235,7 +235,7 @@ interface DirectoryRecipeUtils extends RecipeUtils {
    * replaced. If the path descends into a non-directory, baking the recipe
    * will fail.
    */
-  insert(path: string, recipe: AsyncRecipe<Artifact>): Recipe<Directory>;
+  insert(path: string, recipe: RecipeLike<Artifact>): Recipe<Directory>;
 
   /**
    * Return a new directory with the given recipe removed at the provided
@@ -330,7 +330,7 @@ export const directoryRecipeUtils: DirectoryRecipeUtils = {
   insert(
     this: Recipe<Directory>,
     path: string,
-    recipe: AsyncRecipe<Artifact>,
+    recipe: RecipeLike<Artifact>,
   ): Recipe<Directory> {
     const proxyDirectory = createProxy(this);
     const proxyRecipe = createProxy(recipe);
@@ -338,8 +338,10 @@ export const directoryRecipeUtils: DirectoryRecipeUtils = {
     return createRecipe(["directory"], {
       sourceDepth: 1,
       briocheSerialize: async (meta) => {
-        const serializedDirectory = await proxyDirectory.briocheSerialize();
-        const serializedRecipe = await proxyRecipe.briocheSerialize();
+        const [serializedDirectory, serializedRecipe] = await Promise.all([
+          proxyDirectory.briocheSerialize(),
+          proxyRecipe.briocheSerialize(),
+        ]);
         return {
           type: "insert",
           directory: serializedDirectory,

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -22,46 +22,6 @@ export type ArtifactType<T extends Artifact> = T extends File
       ? "symlink"
       : never;
 
-export type RecipeSerialization<T extends Artifact> = runtime.WithMeta &
-  (T extends File
-    ?
-        | runtime.File
-        | runtime.DownloadRecipe
-        | runtime.ProcessRecipe
-        | runtime.CreateFileRecipe
-        | runtime.CastRecipe
-        | runtime.PeelRecipe
-        | runtime.GetRecipe
-        | runtime.SetPermissionsRecipe
-        | runtime.ProxyRecipe
-        | runtime.SyncRecipe
-    : T extends Directory
-      ?
-          | runtime.Directory
-          | runtime.UnarchiveRecipe
-          | runtime.ProcessRecipe
-          | runtime.CreateDirectoryRecipe
-          | runtime.CastRecipe
-          | runtime.MergeRecipe
-          | runtime.PeelRecipe
-          | runtime.GetRecipe
-          | runtime.InsertRecipe
-          | runtime.GlobRecipe
-          | runtime.CollectReferencesRecipe
-          | runtime.AttachResourcesRecipe
-          | runtime.ProxyRecipe
-          | runtime.SyncRecipe
-      : T extends Symlink
-        ?
-            | runtime.Symlink
-            | runtime.ProcessRecipe
-            | runtime.CastRecipe
-            | runtime.PeelRecipe
-            | runtime.GetRecipe
-            | runtime.ProxyRecipe
-            | runtime.SyncRecipe
-        : never);
-
 /**
  * A "recipe" is a type that describes how to create an artifact in Brioche.
  * When you call `brioche build`, the returned recipe is "baked" to produce
@@ -167,11 +127,11 @@ export type CreateRecipeOptions<T extends Artifact> = {
   sourceDepth?: number;
 } & (
   | {
-      briocheSerialize?(meta: runtime.Meta): Awaitable<RecipeSerialization<T>>;
+      briocheSerialize?(meta: runtime.Meta): Awaitable<runtime.Recipe>;
       bake(meta: runtime.Meta): Awaitable<T>;
     }
   | {
-      briocheSerialize(meta: runtime.Meta): Awaitable<RecipeSerialization<T>>;
+      briocheSerialize(meta: runtime.Meta): Awaitable<runtime.Recipe>;
       bake?(meta: runtime.Meta): Awaitable<T>;
     }
 );
@@ -234,7 +194,7 @@ interface RecipeCommon<T extends Artifact> extends RecipeUtils {
    * to handle. This is useful for wrapping another recipe, avoiding the need
    * to call `.bake()` when implementing custom recipes.
    */
-  briocheSerialize(): Awaitable<RecipeSerialization<T>>;
+  briocheSerialize(): Awaitable<runtime.Recipe>;
 }
 
 interface RecipeUtils {

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -71,21 +71,19 @@ export function briocheDeserializeAny(
  * baked (or serialized).
  */
 export function recipe<T extends Artifact>(recipe: RecipeLike<T>): Recipe<T> {
-  let result: Recipe<T> | undefined;
+  let serialized: runtime.Recipe | undefined;
 
   return createRecipe<T>(
     ["file", "directory", "symlink"] as ArtifactType<T>[],
     {
       sourceDepth: 1,
       briocheSerialize: async () => {
-        if (result == null) {
-          if (typeof recipe === "function") {
-            result = await recipe();
-          } else {
-            result = await recipe;
-          }
+        if (serialized == null) {
+          const recipeValue =
+            typeof recipe === "function" ? await recipe() : await recipe;
+          serialized = await recipeValue.briocheSerialize();
         }
-        return result.briocheSerialize();
+        return serialized;
       },
     },
   );

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -80,6 +80,15 @@ export type Recipe<T extends Artifact = Artifact> = RecipeCommon<T> &
           : never);
 
 /**
+ * A recipe that may be wrapped in a promise or a function call. A `RecipeLike`
+ * can be converted to a `Recipe` using the `std.recipe()` function, which will
+ * delay the function call or awaiting the result until the recipe is baked.
+ */
+export type RecipeLike<T extends Artifact = Artifact> =
+  | AsyncRecipe<T>
+  | (() => AsyncRecipe<T>);
+
+/**
  * A recipe that may be wrapped in a promise. An `AsyncRecipe` can be converted
  * to a `Recipe` using the `std.recipe()` function, even when not in
  * an async function.
@@ -103,20 +112,37 @@ export function briocheDeserializeAny(
 }
 
 /**
- * Create a recipe from an `AsyncRecipe`. This function itself is not async,
+ * Create a recipe from a `RecipeLike`. This function itself is not async,
  * meaning it can even be called from a synchronous function. Under the hood,
- * this will defer the async call until the recipe is baked (or serialized).
+ * this will delay the function call or awaiting the result until the recipe is
+ * baked (or serialized).
  */
-export function recipe<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
+export function recipe<T extends Artifact>(recipe: RecipeLike<T>): Recipe<T> {
+  let result: Recipe<T> | undefined;
+
   return createRecipe<T>(
     ["file", "directory", "symlink"] as ArtifactType<T>[],
     {
       sourceDepth: 1,
       briocheSerialize: async () => {
-        return (await recipe).briocheSerialize();
+        if (result == null) {
+          if (typeof recipe === "function") {
+            result = await recipe();
+          } else {
+            result = await recipe;
+          }
+        }
+        return result.briocheSerialize();
       },
       bake: async () => {
-        return (await recipe).bake();
+        if (result == null) {
+          if (typeof recipe === "function") {
+            result = await recipe();
+          } else {
+            result = await recipe;
+          }
+        }
+        return result.bake();
       },
     },
   );

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -28,7 +28,7 @@ export type ArtifactType<T extends Artifact> = T extends File
  * an output artifact. Recipes are lazy and won't do anything until `.bake()`
  * is called on them.
  */
-export type Recipe<T extends Artifact = Artifact> = RecipeCommon<T> &
+export type Recipe<T extends Artifact = Artifact> = RecipeCommon &
   ([T] extends [File]
     ? FileRecipeUtils
     : [T] extends [Directory]
@@ -94,16 +94,6 @@ export function recipe<T extends Artifact>(recipe: RecipeLike<T>): Recipe<T> {
         }
         return result.briocheSerialize();
       },
-      bake: async () => {
-        if (result == null) {
-          if (typeof recipe === "function") {
-            result = await recipe();
-          } else {
-            result = await recipe;
-          }
-        }
-        return result.bake();
-      },
     },
   );
 }
@@ -123,18 +113,10 @@ export function recipeFn<T extends Artifact, Args extends [] = []>(
   };
 }
 
-export type CreateRecipeOptions<T extends Artifact> = {
+export type CreateRecipeOptions = {
   sourceDepth?: number;
-} & (
-  | {
-      briocheSerialize?(meta: runtime.Meta): Awaitable<runtime.Recipe>;
-      bake(meta: runtime.Meta): Awaitable<T>;
-    }
-  | {
-      briocheSerialize(meta: runtime.Meta): Awaitable<runtime.Recipe>;
-      bake?(meta: runtime.Meta): Awaitable<T>;
-    }
-);
+  briocheSerialize(meta: runtime.Meta): Awaitable<runtime.Recipe>;
+};
 
 /**
  * Create a new recipe by providing either a list of possible output types,
@@ -145,7 +127,7 @@ export type CreateRecipeOptions<T extends Artifact> = {
  */
 export function createRecipe<T extends Artifact>(
   types: ArtifactType<T>[],
-  opts: CreateRecipeOptions<T>,
+  opts: CreateRecipeOptions,
 ): Recipe<T> {
   const source = briocheSource({ depth: (opts.sourceDepth ?? 0) + 1 });
   const meta = { source };
@@ -156,23 +138,11 @@ export function createRecipe<T extends Artifact>(
 
   return {
     briocheSerialize: async () => {
-      if (opts.briocheSerialize != null) {
-        return opts.briocheSerialize(meta);
-      } else if (opts.bake != null) {
-        return (await opts.bake(meta)).briocheSerialize();
-      } else {
-        throw new Error("bake or briocheSerialize is required");
-      }
+      return opts.briocheSerialize(meta);
     },
     bake: async () => {
-      if (opts.bake != null) {
-        return opts.bake(meta);
-      } else if (opts.briocheSerialize != null) {
-        const result = await runtime.bake(await opts.briocheSerialize(meta));
-        return briocheDeserializeAny(result, source);
-      } else {
-        throw new Error("bake or briocheSerialize is required");
-      }
+      const result = await runtime.bake(await opts.briocheSerialize(meta));
+      return briocheDeserializeAny(result, source);
     },
     ...(isFile ? fileRecipeUtils : {}),
     ...(isDirectory ? directoryRecipeUtils : {}),
@@ -180,15 +150,7 @@ export function createRecipe<T extends Artifact>(
   } as unknown as Recipe<T>;
 }
 
-interface RecipeCommon<T extends Artifact> extends RecipeUtils {
-  /**
-   * Bake a recipe, returning a promise that will contain the resulting
-   * artifact. Normally, you won't need to call this function yourself, as
-   * you can instead return a recipe directly, where the runtime will
-   * automatically bake it.
-   */
-  bake(): Awaitable<T>;
-
+interface RecipeCommon extends RecipeUtils {
   /**
    * Serialize a recipe to a plain JSON-style object for the Brioche runtime
    * to handle. This is useful for wrapping another recipe, avoiding the need
@@ -332,7 +294,14 @@ export const fileRecipeUtils: FileRecipeUtils = {
     });
   },
   async readBytes(this: Recipe<File>): Promise<Uint8Array> {
-    const artifact = await this.bake();
+    const serialized = await this.briocheSerialize();
+    const artifact = await runtime.bake(serialized);
+    if (artifact.type !== "file") {
+      throw new Error(
+        `expected artifact in '.readBytes()' call to be a file, was ${artifact.type}`,
+      );
+    }
+
     const bstring = await runtime.readBlob(artifact.contentBlob);
     return runtime.bstringToBytes(bstring);
   },

--- a/packages/std/core/recipes/symlink.bri
+++ b/packages/std/core/recipes/symlink.bri
@@ -51,9 +51,5 @@ export class Symlink implements Recipe<Symlink> {
     return new Symlink({ target: artifact.target, source });
   }
 
-  bake(): Symlink {
-    return this;
-  }
-
   pipe = symlinkRecipeUtils.pipe;
 }

--- a/packages/std/core/recipes/sync.bri
+++ b/packages/std/core/recipes/sync.bri
@@ -1,8 +1,8 @@
 import {
   type Artifact,
   type ArtifactType,
-  type AsyncRecipe,
   type Recipe,
+  type RecipeLike,
   createRecipe,
 } from "./recipe.bri";
 
@@ -11,11 +11,13 @@ import {
  * of recipes get synced normally, so this allows explicitly syncing a
  * recipe that would otherwise not be synced.
  */
-export function sync<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
+export function sync<T extends Artifact>(recipe: RecipeLike<T>): Recipe<T> {
   return createRecipe(["file", "directory", "symlink"] as ArtifactType<T>[], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
-      const serializedRecipe = await (await recipe).briocheSerialize();
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
       return {
         meta,
         type: "sync",

--- a/packages/std/core/recipes/sync.bri
+++ b/packages/std/core/recipes/sync.bri
@@ -3,7 +3,6 @@ import {
   type ArtifactType,
   type AsyncRecipe,
   type Recipe,
-  type RecipeSerialization,
   createRecipe,
 } from "./recipe.bri";
 
@@ -21,7 +20,7 @@ export function sync<T extends Artifact>(recipe: AsyncRecipe<T>): Recipe<T> {
         meta,
         type: "sync",
         recipe: serializedRecipe,
-      } satisfies RecipeSerialization<Artifact> as any as RecipeSerialization<T>;
+      };
     },
   });
 }

--- a/packages/std/extra/apply_patch.bri
+++ b/packages/std/extra/apply_patch.bri
@@ -2,8 +2,8 @@ import * as std from "/core";
 import { tools } from "/toolchain";
 
 interface ApplyPatchOptions {
-  source: std.AsyncRecipe<std.Directory>;
-  patch: std.AsyncRecipe<std.File>;
+  source: std.RecipeLike<std.Directory>;
+  patch: std.RecipeLike<std.File>;
   strip: number | null;
 }
 

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -14,7 +14,7 @@ import { runtimeUtils } from "/runtime_utils.bri";
  * provided, but not both.
  */
 export function autopack(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   options: AutopackOptions,
 ): std.Recipe<std.Directory> {
   const { config, variables } = buildAutopackConfig({
@@ -72,7 +72,7 @@ export interface AutopackOptions {
    * dependencies needed to pack a file. A dependency will not be used if
    * it isn't used by any packed files
    */
-  linkDependencies?: std.AsyncRecipe[];
+  linkDependencies?: std.RecipeLike[];
 
   /**
    * Include the recipe itself as a dependency. This is useful when a binary
@@ -164,7 +164,7 @@ interface DynamicLinkingConfig {
    * A list of directory recipes to search for libraries. Only matched libraries
    * will actually be used in the packed file
    */
-  libraryPaths?: std.AsyncRecipe<std.Directory>[];
+  libraryPaths?: std.RecipeLike<std.Directory>[];
 
   /**
    * A list of library names to exclude from packing. Even if a library is
@@ -200,7 +200,7 @@ type EnvValue =
 
 interface BuildConfigOptions {
   options: AutopackOptions;
-  defaultLinkDependencies: std.AsyncRecipe[];
+  defaultLinkDependencies: std.RecipeLike[];
   runtimeUtils: std.Recipe<std.Directory>;
 }
 
@@ -213,7 +213,7 @@ export function buildAutopackConfig(
   let variableIndex = 0;
   const addVar = (variable: {
     name?: string;
-    value: std.AsyncRecipe;
+    value: std.RecipeLike;
   }): TemplateVariable => {
     const name = variable.name ?? `var${variableIndex++}`;
     std.assert(!(name in variables), `duplicate variable name ${name}`);
@@ -420,4 +420,4 @@ interface DynamicLinkingConfigTemplate {
   skipUnknownLibraries?: boolean;
 }
 
-type AutopackConfigVariable = { type: "path"; value: std.AsyncRecipe };
+type AutopackConfigVariable = { type: "path"; value: std.RecipeLike };

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -11,7 +11,7 @@ export interface BashRunnableUtils {
    * the Bash script, you can get the path to the recipe root with the
    * `$root` environment variable.
    */
-  root(recipe: std.AsyncRecipe<std.Directory>): BashRunnable;
+  root(recipe: std.RecipeLike<std.Directory>): BashRunnable;
 
   /**
    * Set environment variables when the Bash script gets run.
@@ -22,7 +22,7 @@ export interface BashRunnableUtils {
    * Include additonal dependencies when the Bash script gets run. This
    * will set the `$PATH` environment variable.
    */
-  dependencies(...dependencies: std.AsyncRecipe<std.Directory>[]): BashRunnable;
+  dependencies(...dependencies: std.RecipeLike<std.Directory>[]): BashRunnable;
 }
 
 /**
@@ -66,9 +66,9 @@ export function bashRunnable(
 
 interface BashRunnableOptions {
   script: string;
-  root: std.AsyncRecipe<std.Directory>;
+  root: std.RecipeLike<std.Directory>;
   env: Record<string, RunnableTemplateValue>;
-  dependencies: std.AsyncRecipe<std.Directory>[];
+  dependencies: std.RecipeLike<std.Directory>[];
 }
 
 function makeBashRunnable(options: BashRunnableOptions): BashRunnable {
@@ -88,7 +88,7 @@ function makeBashRunnable(options: BashRunnableOptions): BashRunnable {
     },
 
     dependencies(
-      ...dependencies: std.AsyncRecipe<std.Directory>[]
+      ...dependencies: std.RecipeLike<std.Directory>[]
     ): BashRunnable {
       return makeBashRunnable({
         ...options,
@@ -96,7 +96,7 @@ function makeBashRunnable(options: BashRunnableOptions): BashRunnable {
       });
     },
 
-    root(recipe: std.AsyncRecipe<std.Directory>): BashRunnable {
+    root(recipe: std.RecipeLike<std.Directory>): BashRunnable {
       return makeBashRunnable({
         ...options,
         root: recipe,

--- a/packages/std/extra/extra_global.bri
+++ b/packages/std/extra/extra_global.bri
@@ -1,4 +1,4 @@
-import { type Recipe, type Directory, recipeFn } from "/core/recipes";
+import { type Recipe, type Directory, recipe } from "/core/recipes";
 import { source } from "/core/source.bri";
 import type { GitRefOptions } from "/core/global.bri";
 import type { GitCheckoutOptions } from "git";
@@ -56,7 +56,7 @@ declare global {
     );
   }
 
-  return recipeFn(async () => {
+  return recipe(async () => {
     // Import `git` dynamically to avoid issues with execution order. Note this
     // only works because we have a top-level `import type ... from "git"`,
     // which means git is already found as a dependency. See:

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -54,7 +54,7 @@ export function liveUpdateFromGithubReleases(
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_REGEX_MATCH_TAG;
 
-  return std.recipeFn(async () => {
+  return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
 
     const src = std.file(std.indoc`

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -27,7 +27,7 @@ interface OciContainerImageOptions {
 export function ociContainerImage(
   options: OciContainerImageOptions,
 ): std.Recipe<std.File> {
-  return std.recipeFn(async (): Promise<std.Recipe<std.File>> => {
+  return std.recipe(async (): Promise<std.Recipe<std.File>> => {
     const entrypoint = options.entrypoint ?? ["/brioche-run"];
 
     let imageDir = std.directory();

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -2,7 +2,7 @@ import * as std from "/core";
 import { runBash } from "./run_bash.bri";
 
 interface OciContainerImageOptions {
-  recipe: std.AsyncRecipe<std.Directory>;
+  recipe: std.RecipeLike<std.Directory>;
   entrypoint?: string[];
 }
 
@@ -157,7 +157,7 @@ interface DescribeBlobResult {
 }
 
 async function describeBlob(
-  file: std.AsyncRecipe<std.File>,
+  file: std.RecipeLike<std.File>,
 ): Promise<DescribeBlobResult> {
   const description = await runBash`
     sha256sum < "$file" > "$BRIOCHE_OUTPUT"
@@ -181,7 +181,7 @@ async function describeBlob(
 
 // TODO: Remove once Brioche v0.1.0 is no longer supported
 function collectReferences(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   if (std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.1")) {
     return std.collectReferences(recipe);
@@ -216,7 +216,7 @@ function collectReferences(
     .toDirectory();
 }
 
-function tar(recipe: std.AsyncRecipe<std.Directory>): std.Recipe<std.File> {
+function tar(recipe: std.RecipeLike<std.Directory>): std.Recipe<std.File> {
   return runBash`
     tar -cf "$BRIOCHE_OUTPUT" -C "$recipe" .
   `
@@ -224,7 +224,7 @@ function tar(recipe: std.AsyncRecipe<std.Directory>): std.Recipe<std.File> {
     .toFile();
 }
 
-function gzip(file: std.AsyncRecipe<std.File>): std.Recipe<std.File> {
+function gzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
   return runBash`
     gzip -c "$file" > "$BRIOCHE_OUTPUT"
   `

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -16,14 +16,14 @@ export interface WithRunnableUtils {
    * Include additonal dependencies when the command is run. This
    * will set the `$PATH` environment variable.
    */
-  dependencies(...dependencies: std.AsyncRecipe<std.Directory>[]): WithRunnable;
+  dependencies(...dependencies: std.RecipeLike<std.Directory>[]): WithRunnable;
 }
 
 export interface RunnableOptions {
   command: RunnableTemplateValue;
   args?: RunnableTemplateValue[];
   env?: Record<string, RunnableTemplateValue>;
-  dependencies?: std.AsyncRecipe<std.Directory>[];
+  dependencies?: std.RecipeLike<std.Directory>[];
 }
 
 /**
@@ -51,7 +51,7 @@ export interface RunnableOptions {
  * ```
  */
 export function withRunnable(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   options: RunnableOptions,
 ): WithRunnable {
   recipe = addRunnable(recipe, "brioche-run", options);
@@ -65,7 +65,7 @@ export function withRunnable(
     },
 
     dependencies(
-      ...dependencies: std.AsyncRecipe<std.Directory>[]
+      ...dependencies: std.RecipeLike<std.Directory>[]
     ): WithRunnable {
       return withRunnable(recipe, {
         ...options,
@@ -95,7 +95,7 @@ export function withRunnable(
  * ```
  */
 export function addRunnable(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   path: string,
   options: RunnableOptions,
 ): std.Recipe<std.Directory> {
@@ -186,12 +186,12 @@ export type RunnableTemplateValue =
   | string
   | undefined
   | { relativePath: string }
-  | std.AsyncRecipe
+  | std.RecipeLike
   | RunnableTemplateValue[];
 
 function buildTemplate(
   template: RunnableTemplateValue,
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   pathToRecipeRoot: string | undefined,
   n: number,
 ): [RunnableTemplate, std.Recipe<std.Directory>, number] {

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -37,7 +37,7 @@ export type EnvValue =
  * ```
  */
 export function setEnv(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   env: EnvValues,
 ): std.Recipe<std.Directory> {
   let result = std.recipe(recipe);

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -30,7 +30,7 @@ import * as std from "/core";
  * ```
  */
 export function withRunnableLink(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   runPath: string,
 ): std.Recipe<std.Directory> {
   let result = std.recipe(recipe);

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -20,7 +20,7 @@ import * as std from "/core";
  *     gcc -o "$BRIOCHE_OUTPUT/bin/hello" src/hello.c
  *   `
  *     .workDir(Brioche.glob("src"))
- *     .dependencies(std.toolchain());
+ *     .dependencies(std.toolchain);
  *
  *   // Add a symlink so that `brioche run` will run `bin/hello`
  *   program = std.withRunnableLink(program, "bin/hello");

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -316,7 +316,7 @@ export const toolchain = std.memo(
 );
 
 function autopack(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
   options: AutopackOptions,
 ): std.Recipe<std.Directory> {
   const { config, variables } = buildAutopackConfig({
@@ -350,7 +350,7 @@ function autopack(
 }
 
 function fixShebangs(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // TODO: Handle shebangs with wrapper scripts instead of just using
   // `/usr/bin/env`. This currently duplicates the fix from stage 2
@@ -400,7 +400,7 @@ function fixShebangs(
 }
 
 function makePkgConfigPathsRelative(
-  recipe: std.AsyncRecipe<std.Directory>,
+  recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with
   // relative paths (using the `${pcfiledir}` variable)

--- a/packages/std/toolchain/stage0/index.bri
+++ b/packages/std/toolchain/stage0/index.bri
@@ -4,8 +4,8 @@ import { runtimeUtils } from "../utils.bri";
 interface BootstrapRunOptions {
   script: string;
   env?: Record<string, std.ProcessTemplateLike>;
-  workDir?: std.AsyncRecipe<std.Directory>;
-  outputScaffold?: std.AsyncRecipe<std.Directory>;
+  workDir?: std.RecipeLike<std.Directory>;
+  outputScaffold?: std.RecipeLike<std.Directory>;
 }
 
 export function bootstrapRun(

--- a/packages/std/toolchain/utils.bri
+++ b/packages/std/toolchain/utils.bri
@@ -163,11 +163,11 @@ interface WrapWithScriptOptions {
   paths: string[];
   renamePrefix?: string;
   renameSuffix?: string;
-  script: std.AsyncRecipe<std.File>;
+  script: std.RecipeLike<std.File>;
 }
 
 export function wrapWithScript(
-  directory: std.AsyncRecipe<std.Directory>,
+  directory: std.RecipeLike<std.Directory>,
   options: WrapWithScriptOptions,
 ): std.Recipe<std.Directory> {
   const renamePrefix = options.renamePrefix ?? "";

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -26,7 +26,7 @@ export async function test() {
   const script = std.runBash`
     steampipe --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(steampipe())
+    .dependencies(steampipe)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -19,7 +19,7 @@ export default function strace(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   strace = std.withRunnableLink(strace, "bin/strace");
@@ -31,7 +31,7 @@ export async function test() {
   const script = std.runBash`
     strace --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(strace())
+    .dependencies(strace)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     tspin --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(tailspin())
+    .dependencies(tailspin)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -20,7 +20,7 @@ export default function talloc(): std.Recipe<std.Directory> {
     make install
   `
     .workDir(source)
-    .dependencies(std.toolchain(), python())
+    .dependencies(std.toolchain, python)
     .toDirectory();
 
   talloc = std.setEnv(talloc, {
@@ -36,7 +36,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion talloc | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), talloc())
+    .dependencies(std.toolchain, talloc)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -19,7 +19,7 @@ export default function tcpdump(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), libpcap())
+    .dependencies(std.toolchain, libpcap)
     .toDirectory();
 
   return std.withRunnableLink(tcpdump, "bin/tcpdump");
@@ -29,7 +29,7 @@ export async function test() {
   const script = std.runBash`
     tcpdump --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(tcpdump())
+    .dependencies(tcpdump)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -19,7 +19,7 @@ export default function tcsh(): std.Recipe<std.Directory> {
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 
@@ -30,7 +30,7 @@ export async function test() {
   const script = std.runBash`
     tcsh --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(tcsh())
+    .dependencies(tcsh)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -36,7 +36,7 @@ export async function test() {
     # Only retrieve the first line of the output, other lines are not relevant for the version check
     terraform --version | head -n 1 | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(terraform())
+    .dependencies(terraform)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     tokei --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(tokei())
+    .dependencies(tokei)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/unzip/project.bri
+++ b/packages/unzip/project.bri
@@ -24,7 +24,7 @@ export default function unzip(): std.Recipe<std.Directory> {
     make -f unix/Makefile install prefix="$BRIOCHE_OUTPUT"
   `
     .env({ patches })
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory();
 }
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     unzip --help | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(unzip())
+    .dependencies(unzip)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -49,7 +49,7 @@ export async function test() {
     gcc main.c -o main
     ./main | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), uthash())
+    .dependencies(std.toolchain, uthash)
     .env({ src: src })
     .toFile();
 

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -61,7 +61,7 @@ export async function test() {
     gcc main.c -o main -lvdeplug
     ./main | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), vdeplug4())
+    .dependencies(std.toolchain, vdeplug4)
     .env({ src: src })
     .toFile();
 

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     wasmtime --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(wasmtime())
+    .dependencies(wasmtime)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     xh --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(xh())
+    .dependencies(xh)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -34,7 +34,7 @@ export async function test() {
   const script = std.runBash`
     xplr --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(xplr())
+    .dependencies(xplr)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     xsv --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(xsv())
+    .dependencies(xsv)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -19,7 +19,7 @@ export default function xz(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(xz, {
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion liblzma | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), xz())
+    .dependencies(std.toolchain, xz)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/yazi/project.bri
+++ b/packages/yazi/project.bri
@@ -28,7 +28,7 @@ export default function yazi(): std.Recipe<std.Directory> {
 export async function test() {
   const script = std.runBash`
     yazi --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(yazi());
+  `.dependencies(yazi);
 
   const result = (await script.toFile().read()).trim();
 

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -19,7 +19,7 @@ export default function zlib(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(zlib, {
@@ -33,7 +33,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion zlib | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), zlib())
+    .dependencies(std.toolchain, zlib)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -18,7 +18,7 @@ export default function zlibNg(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain())
+    .dependencies(std.toolchain)
     .toDirectory();
 
   return std.setEnv(zlibNg, {
@@ -32,7 +32,7 @@ export async function test() {
   const script = std.runBash`
     pkg-config --modversion zlib-ng | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(std.toolchain(), zlibNg())
+    .dependencies(std.toolchain, zlibNg)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -23,7 +23,7 @@ export async function test() {
   const script = std.runBash`
     zoxide --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(zoxide())
+    .dependencies(zoxide)
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -20,7 +20,7 @@ export async function test() {
   const script = std.runBash`
     zx --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(zx())
+    .dependencies(zx)
     .toFile();
 
   const result = (await script.read()).trim();


### PR DESCRIPTION
This PR makes a number of changes around the `std.Recipe` type, plus related types/methods/etc. Additionally, it replaces the `std.AsyncRecipe` type with the new `std.RecipeLike` type, which accepts either a recipe or a function that returns a recipe. Here's a list of changes:

- Replace `std.AsyncRecipe` with `std.RecipeLike`. It's an alias to accept `Awaitable<Recipe>` or a function that returns `Awaitable<Recipe>`
- Update all uses of `std.AsyncRecipe` to use `std.RecipeLike` instead
- Update all packages to avoid calling functions where possible (since `std.RecipeLike` can now take the function without needing to call it first)
- Remove `Recipe.bake()` method. I thought this method would have some use by now, but it's never been used in any package outside of `std`.
- Update `std.recipe()` to support passing a recipe-returning function. It effectively combines with the old behavior of `std.recipeFn()`.
- Add new `std.recipeFn()` function (effectively a new function now, since `std.recipe()` does what the old function did). `std.recipeFn()` wraps a function, returning a function that passes through its arguments but wraps the return value with `std.recipe()`.
- Remove internal `std.RecipeSerialization<T>` type

> **Note**: Performance is a little slower on this branch, but not significantly. On my machine, running `brioche build -p packages/aws_cli` (a relatively slow package to evaluate) went from 0.77s to 0.84s, or about 70ms slower

Here's an example of what the new `std.RecipeLike` changes enable:

```typescript
export default function (): std.Recipe<std.Directory> {
  // Previous:
  // return std.runBash`...`
  //   .dependencies(std.toolchain(), meson(), ninja(), cmake(), libcap())
  //   .workDir(source)
  //   .toDirectory();

  // New:
  return std.runBash`...`
    .dependencies(std.toolchain, meson, ninja, cmake, libcap)
    .workDir(source)
    .toDirectory();
}
```