### PR TITLE
[std] Add `std.applyPatch` utility

### DIFF
--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -16,13 +16,11 @@ const source = std.recipeFn(() => {
 
   // Patch the source to fix unresolvable `packaging` dependencies
   // across `requirements*.txt` files
-  return std.runBash`
-    cd "$BRIOCHE_OUTPUT"
-    patch -p1 < $patch
-  `
-    .outputScaffold(source)
-    .env({ patch })
-    .toDirectory();
+  return std.applyPatch({
+    source,
+    patch,
+    strip: 1,
+  });
 });
 
 export default function awsCli(): std.Recipe<std.Directory> {

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -7,21 +7,18 @@ export const project = {
   version: "2.27.4",
 };
 
-const source = std.recipeFn(() => {
-  const source = Brioche.gitCheckout({
-    repository: "https://github.com/aws/aws-cli.git",
-    ref: project.version,
-  });
-  const patch = Brioche.includeFile("resolved-lockfiles.patch");
-
+const source = Brioche.gitCheckout({
+  repository: "https://github.com/aws/aws-cli.git",
+  ref: project.version,
+}).pipe((source) =>
   // Patch the source to fix unresolvable `packaging` dependencies
   // across `requirements*.txt` files
-  return std.applyPatch({
+  std.applyPatch({
     source,
-    patch,
+    patch: Brioche.includeFile("resolved-lockfiles.patch"),
     strip: 1,
-  });
-});
+  }),
+);
 
 export default function awsCli(): std.Recipe<std.Directory> {
   // Create a venv

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -8,6 +8,20 @@ export const project = {
   version: "4.0.1",
 };
 
+const source = Brioche.download(
+  `https://github.com/Kitware/CMake/releases/download/v${project.version}/cmake-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Apply patch file
+    std.applyPatch({
+      source,
+      patch: patch(),
+      strip: 1,
+    }),
+  );
+
 function patch(): std.Recipe<std.File> {
   // Instead of directly using a fork of CMake, we instead grab the branch
   // `brioche-patches`, diff it from `base/brioche-patches`, then apply it
@@ -36,23 +50,6 @@ function patch(): std.Recipe<std.File> {
       .toFile();
   });
 }
-
-const source = (() => {
-  let source = Brioche.download(
-    `https://github.com/Kitware/CMake/releases/download/v${project.version}/cmake-${project.version}.tar.gz`,
-  )
-    .unarchive("tar", "gzip")
-    .peel();
-
-  // Apply patch file
-  source = std.applyPatch({
-    source,
-    patch: patch(),
-    strip: 1,
-  });
-
-  return source;
-})();
 
 export default function cmake(): std.Recipe<std.Directory> {
   let cmake = std.runBash`

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -45,14 +45,11 @@ const source = (() => {
     .peel();
 
   // Apply patch file
-  source = std
-    .process({
-      command: "patch",
-      args: ["-p1", "-i", patch(), "-d", std.outputPath],
-      outputScaffold: source,
-      dependencies: [std.tools()],
-    })
-    .toDirectory();
+  source = std.applyPatch({
+    source,
+    patch: patch(),
+    strip: 1,
+  });
 
   return source;
 })();

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -18,13 +18,11 @@ const source = Brioche.gitCheckout({
 const patch = Brioche.includeFile("joshuto-v0.9.8.patch");
 
 export default function joshuto(): std.Recipe<std.Directory> {
-  const patchedSource = std.runBash`
-    cd "$BRIOCHE_OUTPUT"
-    patch -p1 < $patch
-  `
-    .outputScaffold(source)
-    .env({ patch })
-    .toDirectory();
+  const patchedSource = std.applyPatch({
+    source,
+    patch,
+    strip: 1,
+  });
 
   return cargoBuild({
     source: patchedSource,

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -10,22 +10,20 @@ export const project = {
 const source = Brioche.gitCheckout({
   repository: "https://github.com/kamiyaa/joshuto.git",
   ref: `v${project.version}`,
-});
-
-// Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
-// from the `Cargo.lock` from this commit in Joshuto:
-// https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
-const patch = Brioche.includeFile("joshuto-v0.9.8.patch");
+}).pipe((source) =>
+  // Patch `Cargo.lock` to fix builds with Rust >= 1.80. This patch is derived
+  // from the `Cargo.lock` from this commit in Joshuto:
+  // https://github.com/kamiyaa/joshuto/commit/1245124fcd264e25becfd75258840708d7b8b4bb
+  std.applyPatch({
+    source,
+    patch: Brioche.includeFile("joshuto-v0.9.8.patch"),
+    strip: 1,
+  }),
+);
 
 export default function joshuto(): std.Recipe<std.Directory> {
-  const patchedSource = std.applyPatch({
-    source,
-    patch,
-    strip: 1,
-  });
-
   return cargoBuild({
-    source: patchedSource,
+    source,
     runnable: "bin/joshuto",
   });
 }

--- a/packages/std/extra/apply_patch.bri
+++ b/packages/std/extra/apply_patch.bri
@@ -1,0 +1,48 @@
+import * as std from "/core";
+import { tools } from "/toolchain";
+
+interface ApplyPatchOptions {
+  source: std.AsyncRecipe<std.Directory>;
+  patch: std.AsyncRecipe<std.File>;
+  strip: number | null;
+}
+
+/**
+ * Create a recipe that applies a patch to the provided directory.
+ *
+ * ## Options
+ *
+ * - `source`: The input directory recipe to patch
+ * - `patch`: The patch file to apply
+ * - `strip`: The number of components to strip from the patch's path.
+ * Corresponds to the `-p` (`--strip`) flag of the `patch` command. Using
+ * `null` corresponds to leaving the `-p` flag off.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * const source = Brioche.gitCheckout({
+ *   repository: "https://github.com/kamiyaa/joshuto.git",
+ *   ref: `v${project.version}`,
+ * });
+ * const patch = Brioche.includeFile("changes.patch");
+ * const patchedSource = std.applyPatch({
+ *   source,
+ *   patch,
+ *   strip: 1
+ * });
+ * ```
+ */
+export function applyPatch(opts: ApplyPatchOptions): std.Recipe<std.Directory> {
+  return std
+    .process({
+      command: tools().get("bin/patch"),
+      args: [
+        ...(opts.strip != null ? [`-p${opts.strip}`] : []),
+        std.tpl`--input=${opts.patch}`,
+      ],
+      currentDir: std.outputPath,
+      outputScaffold: opts.source,
+    })
+    .toDirectory();
+}

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -5,5 +5,6 @@ export * from "./runnable.bri";
 export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
+export * from "./apply_patch.bri";
 
 import "./extra_global.bri";


### PR DESCRIPTION
This PR adds a new `std.applyPatch` function. It's a simple wrapper around the `patch` CLI utility from `std.tools()`, which was added to clean up a few places in the code where we need to apply source patches.

I decided to make the `strip` option explicit to start with (the `-p` / `--strip` CLI option). I don't think I've ever needed to apply a patch without `-p1`, so it might be nice to at least set a default of 1 as a follow-up?