### PR TITLE
[std] Add utility for live-updates from GitHub releases

### DIFF
--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "amber",
   version: "0.4.0-alpha",
+  repository: "https://github.com/amber-lang/amber.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/amber-lang/amber.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/amber-lang/amber/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import python from "python";
 
 export const project = {
   name: "asciinema",
   version: "2.4.0",
+  repository: "https://github.com/asciinema/asciinema.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/asciinema/asciinema.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -97,21 +97,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/asciinema/asciinema/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
-import nushell from "nushell";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "bat",
   version: "0.25.0",
+  repository: "https://github.com/sharkdp/bat.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/sharkdp/bat.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/sharkdp/bat/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "biome",
   version: "1.9.4",
+  repository: "https://github.com/biomejs/biome.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/biomejs/biome.git",
+  repository: project.repository,
   ref: `cli/v${project.version}`,
 });
 
@@ -40,21 +40,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/biomejs/biome/releases/latest
-      | get tag_name
-      | str replace --regex '^cli/v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^cli\/v(?<version>.*)$/,
   });
 }

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
-import nushell from "nushell";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "broot",
   version: "1.46.3",
+  repository: "https://github.com/Canop/broot.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/Canop/broot.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/Canop/broot/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -3,15 +3,15 @@ import meson from "meson";
 import ninja from "ninja";
 import cmake from "cmake";
 import libcap from "libcap";
-import nushell from "nushell";
 
 export const project = {
   name: "bubblewrap",
   version: "0.11.0",
+  repository: "https://github.com/containers/bubblewrap",
 };
 
 const source = Brioche.download(
-  `https://github.com/containers/bubblewrap/releases/download/v${project.version}/bubblewrap-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/v${project.version}/bubblewrap-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -46,21 +46,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/containers/bubblewrap/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "carapace",
   version: "1.3.0",
+  repository: "https://github.com/carapace-sh/carapace-bin.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/carapace-sh/carapace-bin.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -41,21 +41,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/carapace-sh/carapace-bin/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import openssl from "openssl";
 import curl from "curl";
@@ -6,10 +5,11 @@ import curl from "curl";
 export const project = {
   name: "cmake",
   version: "4.0.1",
+  repository: "https://github.com/Kitware/CMake",
 };
 
 const source = Brioche.download(
-  `https://github.com/Kitware/CMake/releases/download/v${project.version}/cmake-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/v${project.version}/cmake-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel()
@@ -216,23 +216,7 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/Kitware/CMake/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }
 
 function isCMakeVariableValue(

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -1,10 +1,10 @@
-import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
 
 export const project = {
   name: "dasel",
   version: "2.8.1",
+  repository: "https://github.com/TomWright/dasel.git",
 };
 
 const majorVersion = "2";
@@ -14,7 +14,7 @@ std.assert(
 );
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/TomWright/dasel.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -48,21 +48,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/TomWright/dasel/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "dust",
   version: "1.2.0",
+  repository: "https://github.com/bootandy/dust.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/bootandy/dust.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/bootandy/dust/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/eks_node_viewer/project.bri
+++ b/packages/eks_node_viewer/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
@@ -6,10 +5,11 @@ import { goBuild } from "go";
 export const project = {
   name: "eks_node_viewer",
   version: "0.7.4",
+  repository: "https://github.com/awslabs/eks-node-viewer.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/awslabs/eks-node-viewer.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = gitCheckout(gitRef);
@@ -53,21 +53,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/awslabs/eks-node-viewer/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "eza",
   version: "0.21.2",
+  repository: "https://github.com/eza-community/eza.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/eza-community/eza.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -48,21 +48,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/eza-community/eza/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "fd",
   version: "10.2.0",
+  repository: "https://github.com/sharkdp/fd.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/sharkdp/fd.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/sharkdp/fd/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
 
 export const project = {
   name: "fx",
   version: "35.0.0",
+  repository: "https://github.com/antonmedv/fx.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/antonmedv/fx.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/antonmedv/fx/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import cmake from "cmake";
 import git from "git";
@@ -7,10 +6,11 @@ import { cargoBuild } from "rust";
 export const project = {
   name: "gitui",
   version: "0.27.0",
+  repository: "https://github.com/extrawurst/gitui.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/extrawurst/gitui.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -45,21 +45,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/extrawurst/gitui/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/htop/project.bri
+++ b/packages/htop/project.bri
@@ -1,13 +1,13 @@
 import * as std from "std";
-import nushell from "nushell";
 
 export const project = {
   name: "htop",
   version: "3.4.1",
+  repository: "https://github.com/htop-dev/htop",
 };
 
 const source = Brioche.download(
-  `https://github.com/htop-dev/htop/releases/download/${project.version}/htop-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/${project.version}/htop-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -44,20 +44,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/htop-dev/htop/releases/latest
-      | get tag_name
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "jq",
   version: "1.7.1",
+  repository: "https://github.com/jqlang/jq",
 };
 
 const source = Brioche.download(
-  `https://github.com/jqlang/jq/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/jq-${project.version}/jq-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -43,21 +43,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/jqlang/jq/releases/latest
-      | get tag_name
-      | str replace --regex '^jq-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^jq-(?<version>.*)$/,
   });
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -1,15 +1,15 @@
 import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "jujutsu",
   version: "0.28.2",
+  repository: "https://github.com/martinvonz/jj.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/martinvonz/jj.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -39,21 +39,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/jj-vcs/jj/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "just",
   version: "1.40.0",
+  repository: "https://github.com/casey/just.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/casey/just.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/casey/just/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "jwt_cli",
   version: "6.2.0",
+  repository: "https://github.com/mike-engel/jwt-cli.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/mike-engel/jwt-cli.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -39,21 +39,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/mike-engel/jwt-cli/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
@@ -6,10 +5,11 @@ import { goBuild } from "go";
 export const project = {
   name: "k9s",
   version: "0.50.4",
+  repository: "https://github.com/derailed/k9s.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/derailed/k9s.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = gitCheckout(gitRef);
@@ -47,21 +47,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/derailed/k9s/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
 
 export const project = {
   name: "kubent",
   version: "0.7.3",
+  repository: "https://github.com/doitintl/kube-no-trouble.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/doitintl/kube-no-trouble.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -43,21 +43,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/doitintl/kube-no-trouble/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -4,10 +4,11 @@ import * as std from "std";
 export const project = {
   name: "libffi",
   version: "3.4.8",
+  repository: "https://github.com/libffi/libffi",
 };
 
 const source = Brioche.download(
-  `https://github.com/libffi/libffi/releases/download/v${project.version}/libffi-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/v${project.version}/libffi-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -46,21 +47,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/libffi/libffi/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
-import nushell from "nushell";
 import python from "python";
 
 export const project = {
   name: "libpsl",
   version: "0.21.5",
+  repository: "https://github.com/rockdaboot/libpsl",
 };
 
 const source = Brioche.download(
-  `https://github.com/rockdaboot/libpsl/releases/download/${project.version}/libpsl-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/${project.version}/libpsl-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -63,21 +63,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/rockdaboot/libpsl/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "libunwind",
   version: "1.8.1",
+  repository: "https://github.com/libunwind/libunwind",
 };
 
 const source = Brioche.download(
-  `https://github.com/libunwind/libunwind/releases/download/v${project.version}/libunwind-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/v${project.version}/libunwind-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -46,21 +46,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/libunwind/libunwind/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -1,15 +1,15 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
 import python from "python";
-import nushell from "nushell";
 
 export const project = {
   name: "llvm",
   version: "20.1.4",
+  repository: "https://github.com/llvm/llvm-project.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/llvm/llvm-project.git",
+  repository: project.repository,
   ref: `llvmorg-${project.version}`,
 });
 
@@ -86,23 +86,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/llvm/llvm-project/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^llvmorg-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^llvmorg-(?<version>.*)$/,
   });
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -5,10 +5,11 @@ import { cargoBuild } from "rust";
 export const project = {
   name: "lurk",
   version: "0.3.9",
+  repository: "https://github.com/JakWai01/lurk.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/JakWai01/lurk.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +37,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/JakWai01/lurk/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "mdbook",
   version: "0.4.48",
+  repository: "https://github.com/rust-lang/mdBook.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/rust-lang/mdBook.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -38,21 +38,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/rust-lang/mdBook/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import python from "python";
-import nushell from "nushell";
 
 export const project = {
   name: "meson",
   version: "1.8.0",
+  repository: "https://github.com/mesonbuild/meson.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/mesonbuild/meson.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -84,21 +84,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/mesonbuild/meson/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "miniserve",
   version: "0.29.0",
+  repository: "https://github.com/svenstaro/miniserve.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/svenstaro/miniserve.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/svenstaro/miniserve/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import pcre2 from "pcre2";
-import nushell from "nushell";
 
 export const project = {
   name: "nginx",
   version: "1.28.0",
+  repository: "https://github.com/nginx/nginx",
 };
 
 const source = Brioche.download(
-  `https://github.com/nginx/nginx/releases/download/release-${project.version}/nginx-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/release-${project.version}/nginx-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -47,23 +47,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/nginx/nginx/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^release-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>.*)$/,
   });
 }

--- a/packages/ninja/project.bri
+++ b/packages/ninja/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import nushell from "nushell";
 
 export const project = {
   name: "ninja",
   version: "1.12.1",
+  repository: "https://github.com/ninja-build/ninja.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/ninja-build/ninja.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -40,21 +40,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/ninja-build/ninja/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -5,10 +5,11 @@ import { cargoBuild } from "rust";
 export const project = {
   name: "nushell",
   version: "0.104.0",
+  repository: "https://github.com/nushell/nushell.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/nushell/nushell.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -37,21 +38,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/nushell/nushell/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "oha",
   version: "1.8.0",
+  repository: "https://github.com/hatoo/oha.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/hatoo/oha.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/hatoo/oha/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "oniguruma",
   version: "6.9.10",
+  repository: "https://github.com/kkos/oniguruma.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/kkos/oniguruma.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -50,21 +50,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/kkos/oniguruma/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -1,13 +1,13 @@
 import * as std from "std";
-import nushell from "nushell";
 
 export const project = {
   name: "openssl",
   version: "3.5.0",
+  repository: "https://github.com/openssl/openssl",
 };
 
 const source = Brioche.download(
-  `https://github.com/openssl/openssl/releases/download/openssl-${project.version}/openssl-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/openssl-${project.version}/openssl-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -56,21 +56,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/openssl/openssl/releases/latest
-      | get tag_name
-      | str replace --regex '${project.name}-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^openssl-(?<version>.*)$/,
   });
 }

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
 
 export const project = {
   name: "opentofu",
   version: "1.9.1",
+  repository: "https://github.com/opentofu/opentofu.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/opentofu/opentofu.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -45,21 +45,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/opentofu/opentofu/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "pcre2",
   version: "10.45",
+  repository: "https://github.com/PCRE2Project/pcre2.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/PCRE2Project/pcre2.git",
+  repository: project.repository,
   ref: `pcre2-${project.version}`,
   options: {
     submodules: true,
@@ -61,21 +61,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/PCRE2Project/pcre2/releases/latest
-      | get tag_name
-      | str replace --regex '^pcre2-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^pcre2-(?<version>.*)$/,
   });
 }

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -1,11 +1,11 @@
 import * as std from "std";
-import nushell from "nushell";
 import libxml2 from "libxml2";
 import sqlite from "sqlite";
 
 export const project = {
   name: "php",
   version: "8.4.6",
+  repository: "https://github.com/php/php-src",
 };
 
 const source = Brioche.download(
@@ -52,23 +52,8 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/php/php-src/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^php-' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^php-(?<version>.*)$/,
   });
 }

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -1,10 +1,10 @@
-import nushell from "nushell";
 import * as std from "std";
 import { npmInstallGlobal } from "nodejs";
 
 export const project = {
   name: "pnpm",
   version: "10.10.0",
+  repository: "https://github.com/pnpm/pnpm",
 };
 
 export default function pnpm(): std.Recipe<std.Directory> {
@@ -33,18 +33,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/pnpm/pnpm/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project | from json | update version $version | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/popeye/project.bri
+++ b/packages/popeye/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
@@ -6,10 +5,11 @@ import { goBuild } from "go";
 export const project = {
   name: "popeye",
   version: "0.22.1",
+  repository: "https://github.com/derailed/popeye.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/derailed/popeye.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = gitCheckout(gitRef);
@@ -47,21 +47,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/derailed/popeye/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import git, { gitCheckout } from "git";
 import talloc from "talloc";
@@ -8,10 +7,11 @@ import uthash from "uthash";
 export const project = {
   name: "proot",
   version: "5.4.0",
+  repository: "https://github.com/proot-me/proot.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/proot-me/proot.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = std.recipeFn(() => {
@@ -61,21 +61,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/proot-me/proot/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -1,4 +1,3 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cmakeBuild } from "cmake";
 import { gitCheckout } from "git";
@@ -6,10 +5,11 @@ import { gitCheckout } from "git";
 export const project = {
   name: "pstack",
   version: "2.10",
+  repository: "https://github.com/peadar/pstack.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/peadar/pstack.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -47,21 +47,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/peadar/pstack/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -1,15 +1,15 @@
 import * as std from "std";
 import git from "git";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "rclone",
   version: "1.69.1",
+  repository: "https://github.com/rclone/rclone.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/rclone/rclone.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -44,21 +44,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/rclone/rclone/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
-import nushell from "nushell";
 import python from "python";
 
 export const project = {
   name: "re2c",
   version: "4.2",
+  repository: "https://github.com/skvadrik/re2c",
 };
 
 const source = Brioche.download(
-  `https://github.com/skvadrik/re2c/releases/download/${project.version}/re2c-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/${project.version}/re2c-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -50,23 +50,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/skvadrik/re2c/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "restic",
   version: "0.18.0",
+  repository: "https://github.com/restic/restic.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/restic/restic.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -40,21 +40,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/restic/restic/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "rip2",
   version: "0.9.4",
+  repository: "https://github.com/MilesCranmer/rip2.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/MilesCranmer/rip2.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -38,21 +38,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/MilesCranmer/rip2/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "ripgrep",
   version: "14.1.1",
+  repository: "https://github.com/BurntSushi/ripgrep.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/BurntSushi/ripgrep.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -41,21 +41,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/BurntSushi/ripgrep/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "ruff",
   version: "0.11.7",
+  repository: "https://github.com/astral-sh/ruff.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/astral-sh/ruff.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -37,21 +37,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/astral-sh/ruff/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "seaweedfs",
   version: "3.86",
+  repository: "https://github.com/seaweedfs/seaweedfs.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/seaweedfs/seaweedfs.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -42,21 +42,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/seaweedfs/seaweedfs/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "starship",
   version: "1.23.0",
+  repository: "https://github.com/starship/starship.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/starship/starship.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -39,21 +39,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/starship/starship/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -6,5 +6,6 @@ export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
+export * from "./live_update_from_github_releases.bri";
 
 import "./extra_global.bri";

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -1,0 +1,126 @@
+import * as std from "/core";
+import { withRunnable } from "./runnable.bri";
+import type {} from "nushell";
+
+// HACK: The `import type` line above is a workaround for this issue:
+// https://github.com/brioche-dev/brioche/issues/242
+
+// The default regex used for matching tags. Strips an optional "v" prefix,
+// then matches the rest if it looks like a version number (either semver or
+// a semver-like version)
+const DEFAULT_REGEX_MATCH_TAG =
+  /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
+
+interface LiveUpdateFromGithubReleasesOptions {
+  project: { version: string; repository: string };
+  matchTag?: RegExp;
+}
+
+/**
+ * Return a runnable recipe to live-update a project based on the latest release
+ * tag from a GitHub repository. The project's version will be set based on a
+ * regex match against the latest tag name. The repository is inferrred from the
+ * `repository` field of the project.
+ *
+ * ## Options
+ *
+ * - `project`: The project export that should be updated. Must include a
+ *   `repository` property containing a GitHub repository URL.
+ * - `matchTag`: A regex value (`/.../`) to extract the version number from
+ *   a tag name. The regex must include a group named "version". If not
+ *   provided, an optional "v" prefix will be stripped and the rest of the
+ *   tag will be checked if it's a semver or semver-like version number.
+ *
+ * ## Example
+ *
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   repository: "https://github.com/brioche-dev/brioche.git",
+ * };
+ *
+ * export function liveUpdate() {
+ *   return std.liveUpdateFromGithubReleases({
+ *     project,
+ *     matchTag: /^v(?<version>.*)$/, // Strip "v" prefix from tags
+ *   });
+ * }
+ * ```
+ */
+export function liveUpdateFromGithubReleases(
+  options: LiveUpdateFromGithubReleasesOptions,
+): std.Recipe<std.Directory> {
+  const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
+  const matchTag = options.matchTag ?? DEFAULT_REGEX_MATCH_TAG;
+
+  return std.recipeFn(async () => {
+    const { default: nushell } = await import("nushell");
+
+    const src = std.file(std.indoc`
+      let tagName = http get $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+        | get tag_name
+
+      let parsedTagName = $tagName | parse --regex $env.matchTag
+      if ($parsedTagName | length) == 0 {
+        error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
+      }
+
+      let version = $parsedTagName.0.version?
+      if version == null {
+        error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
+      }
+
+      $env.project
+        | from json
+        | update version $version
+        | to json
+    `);
+
+    return withRunnable(std.directory(), {
+      command: "nu",
+      args: [src],
+      env: {
+        project: JSON.stringify(options.project),
+        repoOwner,
+        repoName,
+        matchTag: matchTag.source,
+      },
+      dependencies: [nushell()],
+    });
+  });
+}
+
+interface GithubRepoInfo {
+  repoOwner: string;
+  repoName: string;
+}
+
+function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
+  const match = repo.match(
+    /^(?:https?:\/\/)?(www\.)?(?:github\.com\/)?(?<repoOwner>[\w\.-]+)\/(?<repoName>[\w\.-]+)\/?$/,
+  );
+
+  const { repoOwner, repoName: matchedRepoName } = match?.groups ?? {};
+  if (repoOwner == null || matchedRepoName == null) {
+    return null;
+  }
+
+  let repoName = matchedRepoName;
+  if (repoName.endsWith(".git")) {
+    repoName = repoName.slice(0, -4);
+  }
+
+  return { repoOwner, repoName };
+}
+
+function parseGithubRepo(repo: string): GithubRepoInfo {
+  const info = tryParseGithubRepo(repo);
+  if (info == null) {
+    throw new Error(
+      `Could not parse repo name and owner from ${JSON.stringify(repo)}`,
+    );
+  }
+
+  return info;
+}

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "steampipe",
   version: "1.1.1",
+  repository: "https://github.com/turbot/steampipe.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/turbot/steampipe.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -39,21 +39,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/turbot/steampipe/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -1,13 +1,13 @@
 import * as std from "std";
-import nushell from "nushell";
 
 export const project = {
   name: "strace",
   version: "6.14",
+  repository: "https://github.com/strace/strace",
 };
 
 const source = Brioche.download(
-  `https://github.com/strace/strace/releases/download/v${project.version}/strace-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/v${project.version}/strace-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -46,23 +46,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/strace/strace/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "tailspin",
   version: "5.4.2",
+  repository: "https://github.com/bensadeh/tailspin.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/bensadeh/tailspin.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/bensadeh/tailspin/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { goBuild } from "go";
 
 export const project = {
   name: "terraform",
   version: "1.11.4",
+  repository: "https://github.com/hashicorp/terraform.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/hashicorp/terraform.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -49,21 +49,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/hashicorp/terraform/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "wasmtime",
   version: "32.0.0",
+  repository: "https://github.com/bytecodealliance/wasmtime.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/bytecodealliance/wasmtime.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 
 export const project = {
   name: "xh",
   version: "0.24.0",
+  repository: "https://github.com/ducaale/xh.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/ducaale/xh.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -38,21 +38,5 @@ export async function test() {
 }
 
 export async function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/ducaale/xh/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -1,15 +1,15 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "xplr",
   version: "1.0.0",
+  repository: "https://github.com/sayanarijit/xplr.git",
 };
 
 const source = (() => {
   let source = Brioche.gitCheckout({
-    repository: "https://github.com/sayanarijit/xplr.git",
+    repository: project.repository,
     ref: `v${project.version}`,
   });
 
@@ -47,21 +47,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/sayanarijit/xplr/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "xsv",
   version: "0.13.0",
+  repository: "https://github.com/BurntSushi/xsv.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/BurntSushi/xsv.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -36,21 +36,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/BurntSushi/xsv/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "xz",
   version: "5.8.1",
+  repository: "https://github.com/tukaani-project/xz",
 };
 
 const source = Brioche.download(
-  `https://github.com/tukaani-project/xz/releases/download/v${project.version}/xz-${project.version}.tar.gz`,
+  `${project.repository}/releases/download/v${project.version}/xz-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -46,21 +46,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/tukaani-project/xz/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/yazi/project.bri
+++ b/packages/yazi/project.bri
@@ -1,15 +1,15 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
 import { gitCheckout } from "git";
-import nushell from "nushell";
 
 export const project = {
   name: "yazi",
   version: "25.4.8",
+  repository: "https://github.com/sxyazi/yazi.git",
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/sxyazi/yazi.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = gitCheckout(gitRef);
@@ -43,18 +43,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/sxyazi/yazi/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project | from json | update version $version | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -1,13 +1,13 @@
-import nushell from "nushell";
 import * as std from "std";
 
 export const project = {
   name: "zlib_ng",
   version: "2.2.4",
+  repository: "https://github.com/zlib-ng/zlib-ng.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/zlib-ng/zlib-ng.git",
+  repository: project.repository,
   ref: project.version,
 });
 
@@ -45,21 +45,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/zlib-ng/zlib-ng/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -1,14 +1,14 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "zoxide",
   version: "0.9.7",
+  repository: "https://github.com/ajeetdsouza/zoxide.git",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/ajeetdsouza/zoxide.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -39,21 +39,5 @@ export async function test() {
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/ajeetdsouza/zoxide/releases/latest
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell()],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }


### PR DESCRIPTION
This PR adds the new function `std.liveUpdateFromGithubReleases()`. It uses the `nushell` package to create a runnable recipe that checks for the latest release from GitHub, then updates the `project` JSON based on the latest tag name. Effectively, wraps the `liveUpdate` function code we've been using for a while into a single, reusable function.

- By default, the tag name is matched against a (fairly complicated) regex. It basically removes an optional `v` prefix then validates the rest of the tag "looks like" a version number (I started from the [SemVer regex](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string), but tweaked it to allow a few non-SemVer verisons). You can also pass in a custom regex to match against.
- It gets the GitHub repo name and owner by parsing the field `project.repository`. So, for all the packages that use this new function, I went through and set this field properly.
  - In some cases, the URL ends in `.git` and in some cases it doesn't, based on whatever was easier for each package
  - I also wrote a generic `parseGithubRepo` function, which is pretty forgiving with how the URL is specified. It'll even work with a plain string like `<repo>/<owner>`
- Since this uses nushell under the hood, the regex isn't handled by the JS side, but by the nushell side. I'm sure there are a few differences between how the two handle regexes, so hopefully this isn't too confusing...
- I updated all the packages I could. There were a few left over that set extra fields on `project` which I ended up skipping.