### PR TITLE
chore: always build go binary with `-s` and `-w`

### DIFF
--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -25,6 +25,8 @@ export default function dasel(): std.Recipe<std.Directory> {
     runnable: "bin/dasel",
     buildParams: {
       ldflags: [
+        "-s",
+        "-w",
         `-X github.com/tomwright/dasel/v${majorVersion}/internal.Version=${project.version}`,
       ],
     },

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -19,6 +19,8 @@ export default function gh(): std.Recipe<std.Directory> {
     buildParams: {
       trimpath: true,
       ldflags: [
+        "-s",
+        "-w",
         `-X github.com/cli/cli/v2/internal/build.Version=${project.version}`,
         `-X github.com/cli/cli/v2/internal/build.Date=${project.latestBuildDate}`,
       ],

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -23,11 +23,11 @@ export default function processCompose(): std.Recipe<std.Directory> {
       source,
       buildParams: {
         ldflags: [
+          "-s",
+          "-w",
           `-X github.com/f1bonacc1/process-compose/src/config.Version=v${project.version}`,
           `-X github.com/f1bonacc1/process-compose/src/config.Date=${project.extra.lastModifiedDate}`,
           `-X github.com/f1bonacc1/process-compose/src/config.Commit=${gitRef.commit}`,
-          "-s",
-          "-w",
         ],
       },
       path: "./...",

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -20,7 +20,7 @@ export default function rclone(): std.Recipe<std.Directory> {
     runnable: "bin/rclone",
     buildParams: {
       // Remove `-DEV` suffix from version number
-      ldflags: ["-s", "-X", "github.com/rclone/rclone/fs.VersionSuffix="],
+      ldflags: ["-s", "-w", "-X", "github.com/rclone/rclone/fs.VersionSuffix="],
     },
   });
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -24,7 +24,7 @@ export default function terraform(): std.Recipe<std.Directory> {
   return goBuild({
     source: patchedSource,
     buildParams: {
-      ldflags: ["-w", "-s", `-X github.com/hashicorp/terraform/version.dev=no`],
+      ldflags: ["-s", "-w", `-X github.com/hashicorp/terraform/version.dev=no`],
       mod: "readonly",
     },
     runnable: "bin/terraform",


### PR DESCRIPTION
Always set the `-s` and `-w` LD flags when building go binaries:

- `-s`: This flag omits the symbol table and debug information from the binary
- `-w`: This flag omits the DWARF debugging information

Example for `eks-node-viewer`:

```bash
[container@f8fe1cf467ff workspace]$ ls -al /tmp/eks_node_viewer_without_optimizations/bin/
total 99312
drwxr-xr-x 2 container container      4096 May  5 06:54 .
drwxr-xr-x 3 container container      4096 May  5 06:54 ..
-rwxr-xr-x 1 container container 101679712 May  5 06:54 eks-node-viewer

[container@f8fe1cf467ff workspace]$ ls -al /tmp/eks_node_viewer/bin/
total 71396
drwxr-xr-x 2 container container     4096 May  5 06:51 .
drwxr-xr-x 3 container container     4096 May  5 06:51 ..
-rwxr-xr-x 1 container container 73097400 May  5 06:51 eks-node-viewer
```