### PR TITLE
feat(bugstalker): add package

### DIFF
--- a/packages/bugstalker/brioche.lock
+++ b/packages/bugstalker/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/godzie44/BugStalker.git": {
+      "v0.3.0": "b3aa00ceb16adf487506f576ba9c6e55631f52bc"
+    }
+  }
+}

--- a/packages/bugstalker/project.bri
+++ b/packages/bugstalker/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import libunwind from "libunwind";
+import { cargoBuild } from "rust";
+import { gitCheckout } from "git";
+
+export const project = {
+  name: "bugstalker",
+  version: "0.3.0",
+  repository: "https://github.com/godzie44/BugStalker.git",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: project.repository,
+    ref: `v${project.version}`,
+  }),
+);
+
+export default function bugstalker(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/bs",
+    dependencies: [libunwind],
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    bs --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bugstalker)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `bugstalker ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/bugstalker/project.bri
+++ b/packages/bugstalker/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import libunwind from "libunwind";
 import { cargoBuild } from "rust";
-import { gitCheckout } from "git";
 
 export const project = {
   name: "bugstalker",
@@ -9,12 +8,10 @@ export const project = {
   repository: "https://github.com/godzie44/BugStalker.git",
 };
 
-const source = gitCheckout(
-  Brioche.gitRef({
-    repository: project.repository,
-    ref: `v${project.version}`,
-  }),
-);
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
 
 export default function bugstalker(): std.Recipe<std.Directory> {
   return cargoBuild({


### PR DESCRIPTION
Add a new package [`bugstalker`](https://github.com/godzie44/bugstalker): a Rust debugger for Linux x86-64.

```bash
[container@ca91eae7e26c workspace]$ brioche build -e test -p packages/bugstalker/
Build finished, completed (no new jobs) in 3.16s
Result: 4f2cb316f01914c99e74b5741f76c466940d61772db4062b450315b50106f540
[container@ca91eae7e26c workspace]$ brioche run -e liveUpdate -p packages/bugstalker/
Build finished, completed (no new jobs) in 2.94s
Running brioche-run
{
  "name": "bugstalker",
  "version": "0.3.0",
  "repository": "https://github.com/godzie44/BugStalker.git"
}
```