### PR TITLE
feat(hyperfine): add package

### DIFF
--- a/packages/hyperfine/brioche.lock
+++ b/packages/hyperfine/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sharkdp/hyperfine.git": {
+      "v1.19.0": "12fec42098642a19855ead34c8cb1e0be28c8ead"
+    }
+  }
+}

--- a/packages/hyperfine/project.bri
+++ b/packages/hyperfine/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "hyperfine",
+  version: "1.19.0",
+  repository: "https://github.com/sharkdp/hyperfine.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function hyperfine(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/hyperfine",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    hyperfine --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(hyperfine)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `hyperfine ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`hyperfine`](https://github.com/sharkdp/hyperfine): A command-line benchmarking tool

```bash
[container@ca91eae7e26c workspace]$ brioche run -e liveUpdate -p packages/hyperfine/
Build finished, completed (no new jobs) in 3.31s
Running brioche-run
{
  "name": "hyperfine",
  "version": "1.19.0",
  "repository": "https://github.com/sharkdp/hyperfine.git"
}
[container@ca91eae7e26c workspace]$ brioche build -e test -p packages/hyperfine/
Build finished, completed (no new jobs) in 2.95s
Result: 088633444c420cf0f2bcb6e88a3873abe3b3514acb40e807ae50d8be91d8b42b
```