### PR TITLE
feat(snazy): add package

### DIFF
--- a/packages/snazy/brioche.lock
+++ b/packages/snazy/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/chmouel/snazy.git": {
+      "0.56.0": "7ffccf7b6a517ca1d5e6836f52d3ac0e61579932"
+    }
+  }
+}

--- a/packages/snazy/project.bri
+++ b/packages/snazy/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "snazy",
+  version: "0.56.0",
+  repository: "https://github.com/chmouel/snazy.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function snazy(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/snazy",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    snazy --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(snazy)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `snazy ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`snazy`](https://github.com/chmouel/snazy): a snazzy json log viewer (with one z)

Already packaged on [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/sn/snazy/package.nix#L41) too. 

```bash
[container@ca91eae7e26c workspace]$ brioche build -e test -p packages/snazy/
Build finished, completed (no new jobs) in 3.12s
Result: 3852f8a367c5bee2d00fe4ae615e36055770b9710b2e558d667e11a23c4e743f
[container@ca91eae7e26c workspace]$ brioche run -e liveUpdate -p packages/snazy/
Build finished, completed (no new jobs) in 3.26s
Running brioche-run
{
  "name": "snazy",
  "version": "0.56.0",
  "repository": "https://github.com/chmouel/snazy.git"
}
```