### PR TITLE
feat(nushell): add core plugins

### DIFF
--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -13,12 +13,56 @@ const source = Brioche.gitCheckout({
   ref: project.version,
 });
 
+/**
+ * Represents a Nushell plugin.
+ *
+ * ## Options
+ *
+ * `name`: The name of the plugin.
+ * `dependencies`: The dependencies of the plugin.
+ */
+interface NushellPlugin {
+  name: string;
+  dependencies?: std.RecipeLike<std.Directory>[];
+}
+
+const nushellPlugins: NushellPlugin[] = [
+  {
+    name: "nu_plugin_formats",
+  },
+  {
+    name: "nu_plugin_gstat",
+    dependencies: [openssl],
+  },
+  {
+    name: "nu_plugin_inc",
+  },
+  {
+    name: "nu_plugin_polars",
+  },
+  {
+    name: "nu_plugin_query",
+    dependencies: [openssl],
+  },
+];
+
 export default function nushell(): std.Recipe<std.Directory> {
-  return cargoBuild({
+  const nushell = cargoBuild({
     source,
     runnable: "bin/nu",
     dependencies: [openssl],
   });
+
+  // Build the Nushell plugins
+  const plugins = nushellPlugins.map((plugin: NushellPlugin) =>
+    cargoBuild({
+      source,
+      path: `crates/${plugin.name}`,
+      dependencies: plugin.dependencies ?? [],
+    }),
+  );
+
+  return std.merge(nushell, ...plugins);
 }
 
 export async function test() {

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -75,7 +75,7 @@ export async function test() {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `${project.version}`;
+  const expected = project.version;
   std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;


### PR DESCRIPTION
Add all the [core Nushell plugins](https://www.nushell.sh/book/plugins.html#core-plugins). Contrary to the homebrew [Nushell formula](https://github.com/Homebrew/homebrew-core/blob/89bd44cf086208aeffde0bc094f1b4e81eb88d34/Formula/n/nushell.rb#L41), we only install the core plugins and not the example plugins (this is unnecessary, and doesn't add any value for most of the users).

> Nushell also ships with several plugins that serve as examples or tools for plugin developers. These include nu_plugin_example, nu_plugin_custom_values, and nu_plugin_stress_internals.

The following plugins are now installed by default (which tends to be the recommended approach per Nushell's maintainers):

- polars: Extremely fast columnar operations using DataFrames via the [Polars Library](https://github.com/pola-rs/polars).
- formats: Support for several additional data formats - EML, ICS, INI, plist, and VCF.
- gstat: Returns information on the status of a Git repository as Nushell structured data.
- query: Support for querying SQL, XML, JSON, HTML (via selector), and WebPage Metadata
- inc: Increment a value or version (e.g., semver). This plugin acts as both an end-user plugin as well as a simple developer example of how to create a plugin.

```bash
[container@ca91eae7e26c workspace]$ ls /tmp/output/bin
nu  nu_plugin_formats  nu_plugin_gstat  nu_plugin_inc  nu_plugin_polars  nu_plugin_query
```