### PR TITLE
feat(libssh2): add package

### DIFF
--- a/packages/libssh2/brioche.lock
+++ b/packages/libssh2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://libssh2.org/download/libssh2-1.11.1.tar.xz": {
+      "type": "sha256",
+      "value": "9954cb54c4f548198a7cbebad248bdc87dd64bd26185708a294b2b50771e3769"
+    }
+  }
+}

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -1,0 +1,70 @@
+import * as std from "std";
+import nushell from "nushell";
+import openssl from "openssl";
+
+export const project = {
+  name: "libssh2",
+  version: "1.11.1",
+};
+
+const source = Brioche.download(
+  `https://libssh2.org/download/libssh2-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libssh2(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, openssl)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libssh2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libssh2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://www.libssh2.org/download
+      | lines
+      | where {|it| ($it | str contains "libssh2") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libssh2-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`libssh2`](https://www.libssh2.org): a Client-side C library implementing the SSH2 protocol

```bash
[container@6818e76b941a workspace]$ brioche build -e test -p packages/libssh2/
Build finished, completed (no new jobs) in 1.59s
Result: aa1601a9ed9d8582108c10c68464d84106b7ae77f5abd92c30a855983b7ef570
[container@6818e76b941a workspace]$ brioche run -e liveUpdate -p packages/libssh2/
Build finished, completed (no new jobs) in 5.63s
Running brioche-run
{
  "name": "libssh2",
  "version": "1.11.1"
}
```