### PR TITLE
feat(libgit2): add package

### DIFF
--- a/packages/libgit2/brioche.lock
+++ b/packages/libgit2/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libgit2/libgit2.git": {
+      "v1.9.0": "338e6fb681369ff0537719095e22ce9dc602dbf0"
+    }
+  }
+}

--- a/packages/libgit2/project.bri
+++ b/packages/libgit2/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import libssh2 from "libssh2";
+import openssl from "openssl";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libgit2",
+  version: "1.9.0",
+  repository: "https://github.com/libgit2/libgit2.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libgit2(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libssh2, openssl],
+    set: {
+      USE_SSH: "ON",
+      BUILD_EXAMPLES: "OFF",
+      BUILD_TESTS: "OFF",
+    },
+  }).pipe(
+    (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib64/pkgconfig" }] },
+      }),
+    (recipe) => std.withRunnableLink(recipe, "bin/git2"),
+  );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libgit2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libgit2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/libgit2/project.bri
+++ b/packages/libgit2/project.bri
@@ -27,7 +27,7 @@ export default function libgit2(): std.Recipe<std.Directory> {
     (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
-        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        LIBRARY_PATH: { append: [{ path: "lib64" }] },
         PKG_CONFIG_PATH: { append: [{ path: "lib64/pkgconfig" }] },
       }),
     (recipe) => std.withRunnableLink(recipe, "bin/git2"),

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -15,7 +15,9 @@ const source = Brioche.download(
 
 export default function libssh2(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./configure --prefix=/
+    ./configure \\
+      --prefix=/ \\
+      --disable-examples-build
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)


### PR DESCRIPTION
Add a new package [`libgit2`](https://github.com/libgit2/libgit2/tree/main): A cross-platform, linkable library implementation of Git that you can use in your application.

```bash
[container@4a5f69ac8e1d workspace]$ brioche build -e test -p packages/libgit2/
Build finished, completed (no new jobs) in 2.31s
Result: a4efe75acf03d41668cad95bbb27ab66d69bb649782bb321825d242e2be8de9d
[container@4a5f69ac8e1d workspace]$ brioche run -e liveUpdate -p packages/libgit2/
Build finished, completed (no new jobs) in 5.76s
Running brioche-run
{
  "name": "libgit2",
  "version": "1.9.0",
  "repository": "https://github.com/libgit2/libgit2.git"
}
```