### PR TITLE
feat(linux): add live update capability

### DIFF
--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -1,6 +1,7 @@
 import * as std from "std";
 import kmod from "kmod";
 import openssl from "openssl";
+import nushell from "nushell";
 
 export const project = {
   name: "linux",
@@ -118,6 +119,40 @@ export default function linux(
       ...env,
     })
     .toDirectory();
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let sourceUrl = http get https://cdn.kernel.org/pub/linux/kernel
+      | lines
+      | parse --regex '<a href="v(?<version>.+)/">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    let version = http get $"https://cdn.kernel.org/pub/linux/kernel/v($sourceUrl)"
+      | lines
+      | where {|it| ($it | str contains 'linux') and ($it | str contains '.tar.xz') }
+      | parse --regex '<a href="linux-(?<version>[^"]+)\.tar\.xz"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    let majorVersion = $version
+      | split words
+      | get 0
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.majorVersion $majorVersion
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
 }
 
 type LinuxUpdateConfigValue =


### PR DESCRIPTION
```bash
[container@071433f14fbe workspace]$ brioche run -e liveUpdate -p packages/linux/
Build finished, completed (no new jobs) in 5.92s
Running brioche-run
{
  "name": "linux",
  "version": "6.14.5",
  "extra": {
    "majorVersion": "6"
  }
}
```