### PR TITLE
feat(brotli): add package

### DIFF
--- a/packages/brotli/brioche.lock
+++ b/packages/brotli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/brotli.git": {
+      "v1.1.0": "ed738e842d2fbdf2d6459e39267a633c4a9b2f5d"
+    }
+  }
+}

--- a/packages/brotli/project.bri
+++ b/packages/brotli/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "brotli",
+  version: "1.1.0",
+  repository: "https://github.com/google/brotli.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function brotli(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    runnable: "bin/brotli",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libbrotlicommon | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, brotli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`brotli`](https://github.com/google/brotli): a generic-purpose lossless compression algorithm that compresses data 

```bash
[container@071433f14fbe workspace]$ brioche build -p packages/brotli/ -e test
33412  │ 1.1.0
 0.10s ✓ Process 33412
Build finished, completed 1 job in 3.44s
Result: 6e1a5a6c04063b682cf187d47ac05560f45a8a5708eccd6d535adb92fbb99206
[container@071433f14fbe workspace]$ brioche run -e liveUpdate -p packages/brotli/
Build finished, completed (no new jobs) in 5.87s
Running brioche-run
{
  "name": "brotli",
  "version": "1.1.0",
  "repository": "https://github.com/google/brotli.git"
}
```