### PR TITLE
feat(libsodium): add package

### DIFF
--- a/packages/libsodium/brioche.lock
+++ b/packages/libsodium/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz": {
+      "type": "sha256",
+      "value": "ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19"
+    }
+  }
+}

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -1,0 +1,69 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "libsodium",
+  version: "1.0.20",
+};
+
+const source = Brioche.download(
+  `https://download.libsodium.org/libsodium/releases/libsodium-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libsodium(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libsodium | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libsodium)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://download.libsodium.org/libsodium/releases
+      | lines
+      | where {|it| ($it | str contains "libsodium") and (not ($it | str contains ".sig")) and (not ($it | str contains ".minisig")) }
+      | parse --regex '<a href="libsodium-(?<version>[^-]+)\.tar\.[^"]+">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`libsodium`](https://doc.libsodium.org): a modern, easy-to-use software library for encryption, decryption, signatures, password hashing, and more.

```bash
[container@071433f14fbe workspace]$ brioche run -e liveUpdate -p packages/libsodium/
Build finished, completed (no new jobs) in 5.69s
Running brioche-run
{
  "name": "libsodium",
  "version": "1.0.20"
}
[container@071433f14fbe workspace]$ brioche build -p packages/libsodium/ -e test
Build finished, completed (no new jobs) in 1.68s
Result: 5856b21de1eb1e62398ebd145ac3db93accac63d6d02d04fd17d33286f8db77a
```