### PR TITLE
feat(fzf): add package

### DIFF
--- a/packages/fzf/brioche.lock
+++ b/packages/fzf/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/junegunn/fzf.git": {
+      "v0.62.0": "d226d841a1f2b849b7e3efab2a44ecbb3e61a5a5"
+    }
+  }
+}

--- a/packages/fzf/project.bri
+++ b/packages/fzf/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "fzf",
+  version: "0.62.0",
+  repository: "https://github.com/junegunn/fzf.git",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+const source = gitCheckout(gitRef);
+
+export default function fzf(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.version=${project.version}`,
+        "-X",
+        `main.revision=${gitRef.commit}`,
+      ],
+    },
+    path: ".",
+    runnable: "bin/fzf",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    fzf --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(fzf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version} (${gitRef.commit})`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`fzf`](https://github.com/junegunn/fzf): A command-line fuzzy finder

```bash
[container@8682ebba2aec workspace]$ brioche-test packages/fzf/
Build finished, completed (no new jobs) in 2.26s
Result: d33d6ba1bdbdc89b4a046e2830c114d4a707e55973345ffb3cec18e6ab31a136
[container@8682ebba2aec workspace]$ brioche-live-update packages/fzf
Build finished, completed (no new jobs) in 5.85s
Running brioche-run
{
  "name": "fzf",
  "version": "0.62.0",
  "repository": "https://github.com/junegunn/fzf.git"
}
```