### PR TITLE
feat(golangcilint): add package

### DIFF
--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -5,7 +5,9 @@ import { goBuild } from "go";
 export const project = {
   name: "github_cli",
   version: "2.72.0",
-  latestBuildDate: "2025-04-30",
+  extra: {
+    releaseDate: "2025-04-30",
+  },
 };
 
 const source = Brioche.gitCheckout({
@@ -24,7 +26,7 @@ export default function gh(): std.Recipe<std.Directory> {
         "-X",
         `github.com/cli/cli/v2/internal/build.Version=${project.version}`,
         "-X",
-        `github.com/cli/cli/v2/internal/build.Date=${project.latestBuildDate}`,
+        `github.com/cli/cli/v2/internal/build.Date=${project.extra.releaseDate}`,
       ],
     },
     path: "./cmd/gh",
@@ -42,7 +44,7 @@ export async function test() {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `gh version ${project.version} (${project.latestBuildDate})\nhttps://github.com/cli/cli/releases/tag/v${project.version}`;
+  const expected = `gh version ${project.version} (${project.extra.releaseDate})\nhttps://github.com/cli/cli/releases/tag/v${project.version}`;
   std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
@@ -56,7 +58,7 @@ export function liveUpdate() {
       | get tag_name
       | str replace --regex '^v' ''
 
-    let latestBuildDate = $releaseData
+    let releaseDate = $releaseData
       | get created_at
       | into datetime
       | format date "%Y-%m-%d"
@@ -64,7 +66,7 @@ export function liveUpdate() {
     $env.project
       | from json
       | update version $version
-      | update latestBuildDate $latestBuildDate
+      | update extra.releaseDate $releaseDate
       | to json
   `);
 

--- a/packages/golangci_lint/brioche.lock
+++ b/packages/golangci_lint/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/golangci/golangci-lint.git": {
+      "v2.1.6": "eabc2638a66daf5bb6c6fb052a32fa3ef7b6600d"
+    }
+  }
+}

--- a/packages/golangci_lint/project.bri
+++ b/packages/golangci_lint/project.bri
@@ -1,0 +1,87 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+import nushell from "nushell";
+
+export const project = {
+  name: "golangci_lint",
+  version: "2.1.6",
+  repository: "https://github.com/golangci/golangci-lint.git",
+  extra: {
+    releaseDate: "2025-05-04",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+const source = gitCheckout(gitRef);
+
+export default function golangciLint(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.version=${project.version}`,
+        "-X",
+        `main.commit=${gitRef.commit}`,
+        "-X",
+        `main.date=${project.extra.releaseDate}`,
+      ],
+    },
+    path: "./cmd/golangci-lint",
+    runnable: "bin/golangci-lint",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    golangci-lint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(golangciLint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `golangci-lint has version ${project.version} built`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/golangci/golangci-lint/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    let releaseDate = $releaseData
+      | get created_at
+      | into datetime
+      | format date "%Y-%m-%d"
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.releaseDate $releaseDate
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -7,7 +7,7 @@ export const project = {
   name: "process_compose",
   version: "1.46.0",
   extra: {
-    releaseDate: "20241220221126",
+    releaseDate: "2024-12-20",
   },
 };
 
@@ -70,7 +70,7 @@ export function liveUpdate() {
     let releaseDate = $releaseData
       | get created_at
       | into datetime
-      | format date "%Y%m%d%H%M%S"
+      | format date "%Y-%m-%d"
 
     $env.project
       | from json

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -7,7 +7,7 @@ export const project = {
   name: "process_compose",
   version: "1.46.0",
   extra: {
-    lastModifiedDate: "20241220221126",
+    releaseDate: "20241220221126",
   },
 };
 
@@ -27,7 +27,7 @@ export default function processCompose(): std.Recipe<std.Directory> {
         "-X",
         `github.com/f1bonacc1/process-compose/src/config.Version=v${project.version}`,
         "-X",
-        `github.com/f1bonacc1/process-compose/src/config.Date=${project.extra.lastModifiedDate}`,
+        `github.com/f1bonacc1/process-compose/src/config.Date=${project.extra.releaseDate}`,
         "-X",
         `github.com/f1bonacc1/process-compose/src/config.Commit=${gitRef.commit}`,
       ],
@@ -67,7 +67,7 @@ export function liveUpdate() {
       | get tag_name
       | str replace --regex '^v' ''
 
-    let lastModifiedDate = $releaseData
+    let releaseDate = $releaseData
       | get created_at
       | into datetime
       | format date "%Y%m%d%H%M%S"
@@ -75,7 +75,7 @@ export function liveUpdate() {
     $env.project
       | from json
       | update version $version
-      | update extra.lastModifiedDate $lastModifiedDate
+      | update extra.releaseDate $releaseDate
       | to json
   `);
 


### PR DESCRIPTION
Add a new package [`golangci-lint`](https://github.com/golangci/golangci-lint): Fast linters runner for Go

```bash
[container@8682ebba2aec workspace]$ brioche-test packages/golangci_lint/
Build finished, completed (no new jobs) in 2.13s
Result: 796eb879fd65f900cd06a41e5c4ede85f9986f53c5853581b8acf9301910b32e
[container@8682ebba2aec workspace]$ brioche-live-update packages/golangci_lint/
Build finished, completed (no new jobs) in 5.97s
Running brioche-run
{
  "name": "golangci_lint",
  "version": "2.1.6",
  "repository": "https://github.com/golangci/golangci-lint.git",
  "extra": {
    "buildDate": "2025-05-04"
  }
}
```