### PR TITLE
Add `cargo_nextest` package

### DIFF
--- a/packages/cargo_nextest/brioche.lock
+++ b/packages/cargo_nextest/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nextest-rs/nextest.git": {
+      "cargo-nextest-0.9.95": "39357131c16a0fdf0e26f398558a320b357c5979"
+    }
+  }
+}

--- a/packages/cargo_nextest/project.bri
+++ b/packages/cargo_nextest/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_nextest",
+  version: "0.9.95",
+  repository: "https://github.com/nextest-rs/nextest.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `cargo-nextest-${project.version}`,
+});
+
+export default function cargoNextest(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "cargo-nextest",
+
+    // cargo-chef makes the lockfile out-of-date for cargo-nextest, see
+    // this issue:
+    // https://github.com/LukeMathWalker/cargo-chef/issues/305
+    cargoChefPrepare: false,
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cargo nextest --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoNextest)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `cargo-nextest ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^cargo-nextest-(?<version>.*)$/,
+  });
+}

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -168,6 +168,7 @@ export interface CargoBuildOptions {
   dependencies?: std.RecipeLike<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
   unsafe?: std.ProcessUnsafeOptions;
+  cargoChefPrepare?: boolean;
   buildParams?: CargoBuildParameters;
 }
 
@@ -188,6 +189,11 @@ export interface CargoBuildOptions {
  *   passing `{ networking: true }` will allow a `build.rs` script to
  *   download files during the build. You must take extra care to ensure
  *   the build is hermetic when setting these options!
+ * - `cargoChefPrepare`: Controls if the crate from `source` should get
+ *   pre-processed by `cargo chef prepare` before being built, which avoids
+ *   unnecessarily re-downloading dependencies when the source changes.
+ *   Defaults to `true` (should only be disabled when there's an upstream
+ *   issue with `cargo chef`).
  * - `buildParams`: Optional build parameters:
  *   - `features`: An array of features to enable.
  *   - `defaultFeatures`: Set to `false` to opt out of the crate's
@@ -222,7 +228,10 @@ export interface CargoBuildOptions {
  */
 export function cargoBuild(options: CargoBuildOptions) {
   // Vendor the crate's dependencies
-  const crate = vendorCrate({ source: options.source });
+  const crate = vendorCrate({
+    source: options.source,
+    cargoChefPrepare: options.cargoChefPrepare,
+  });
 
   const extraArgs: string[] = [];
   const features = options.buildParams?.features ?? [];
@@ -357,6 +366,7 @@ export function createSkeletonCrate(
 
 interface VendorCrateOptions {
   source: std.RecipeLike<std.Directory>;
+  cargoChefPrepare?: boolean;
 }
 
 /**
@@ -367,13 +377,20 @@ interface VendorCrateOptions {
  * ## Options
  *
  * - `source`: The crate to build.
+ * - `cargoChefPrepare`: Controls if the crate from `source` should get
+ *   pre-processed by `cargo chef prepare` before being built, which avoids
+ *   unnecessarily re-downloading dependencies when the source changes.
+ *   Defaults to `true` (should only be disabled when there's an upstream
+ *   issue with `cargo chef`).
  */
 export function vendorCrate(
   options: VendorCrateOptions,
 ): std.Recipe<std.Directory> {
+  const { source, cargoChefPrepare = true } = options;
+
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies
-  const skeletonCrate = createSkeletonCrate(options.source);
+  const skeletonCrate = cargoChefPrepare ? createSkeletonCrate(source) : source;
 
   // Vendor the dependencies with network access and save the Cargo config.toml
   // file, so the vendored dependencies are used
@@ -403,7 +420,9 @@ export function vendorCrate(
     .toDirectory();
 
   // Combine the original crate with the vendored dependencies
-  let crate = std.merge(vendoredSkeletonCrate, options.source);
+  let crate = cargoChefPrepare
+    ? std.merge(vendoredSkeletonCrate, source)
+    : vendoredSkeletonCrate;
 
   // Copy the updated Cargo config.toml file into the crate
   crate = crate.insert(


### PR DESCRIPTION
This PR adds a package for [cargo-nextest](https://github.com/nextest-rs/nextest), a fast Rust test runner.

For the package name, it seems like both the README/website/repo bounce between "cargo nextest" and just "nextest". Repology shows [31 repositories use cargo-nextest vs 1 for nextest](https://repology.org/projects/?search=nextest&maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=), so I based it on "cargo-nextest".

I also hit a weird build error that seemed to be caused by cargo-chef producing an out-of-date lockfile (https://github.com/LukeMathWalker/cargo-chef/issues/305). We've had issues with cargo-chef before (#189), so I decided to work around this by adding a new `cargoChefPrepare` option to `rust.cargoBuild()`, then set it to false for cargo-nextest.

I also intentionally left off the `runnable` field. cargo-nextest is meant to be called as a Cargo subcommand (`cargo nextest`) and it didn't seem to like being called directly, so I felt it was better just to leave it off.