### PR TITLE
feat(jpegturbo): add package

### DIFF
--- a/packages/libjpeg_turbo/brioche.lock
+++ b/packages/libjpeg_turbo/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libjpeg-turbo/libjpeg-turbo.git": {
+      "3.1.0": "20ade4dea9589515a69793e447a6c6220b464535"
+    }
+  }
+}

--- a/packages/libjpeg_turbo/project.bri
+++ b/packages/libjpeg_turbo/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libjpeg_turbo",
+  version: "3.1.0",
+  repository: "https://github.com/libjpeg-turbo/libjpeg-turbo.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libjpegTurbo(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      WITH_JPEG8: "1",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libturbojpeg | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libjpegTurbo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libjpeg-turbo`](https://www.libjpeg-turbo.org): a JPEG image codec that uses SIMD instructions (MMX, SSE2, AVX2, Neon, AltiVec) to accelerate baseline JPEG compression and decompression.

The name of the package was a bit hard to find, since there is also a libjpeg library.

The official website seems to refer to `libjpeg-turbo`, but Nix uses 3 different names `libjpeg-turbo`, `libjpeg8`, `libjpeg` whereas homebrew simply uses `jpeg-turbo`. Interesting enough Ubuntu uses the name `libjpeg-turbo8`.

So, I decide to choose `libjpeg_turbo` as it seems clear enough of what this package refers to.