### PR TITLE
feat(jpeg): add package

### DIFF
--- a/packages/libjpeg/brioche.lock
+++ b/packages/libjpeg/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.ijg.org/files/jpegsrc.v9f.tar.gz": {
+      "type": "sha256",
+      "value": "04705c110cb2469caa79fb71fba3d7bf834914706e9641a4589485c1f832565b"
+    }
+  }
+}

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "libjpeg",
+  version: "9f",
+};
+
+const source = Brioche.download(
+  `https://www.ijg.org/files/jpegsrc.v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libjpeg(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion libjpeg | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libjpeg)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const versionMatch = result.match(/(\d+)\.(\d+)\.(\d+)/);
+  const [, majorVersion = null, minorVersion = null] = versionMatch ?? [];
+  const version = `${majorVersion}${String.fromCharCode(
+    96 + Number(minorVersion),
+  )}`;
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://www.ijg.org/files
+      | lines
+      | where {|it| ($it | str contains "jpegsrc.") }
+      | parse --regex '<A HREF="jpegsrc.v(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`jpeg`](https://www.ijg.org): a image manipulation library for JPEG image codec.

The name of the package was also a bit hard to find (see #480). The official website uses `jpeg `, Nix uses `libjpeg_original` and homebrew simply uses `jpeg`.

I decide to choose `libjpeg` to make it clear this is the JPEG library and this is not the Turbo JPEG library. And to have a consistency with #480 