### PR TITLE
Add brotli support to cURL

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -61,7 +61,7 @@ export default function cmake(): std.Recipe<std.Directory> {
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain, openssl, curl)
+    .dependencies(std.toolchain, openssl, curl({ minimal: true }))
     .toDirectory()
     .pipe(
       (recipe) =>

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -15,20 +15,47 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
-export default function curl(): std.Recipe<std.Directory> {
+interface CurlOptions {
+  minimal?: boolean;
+}
+
+/**
+ * Builds the curl package. By default, this will build with all the optional
+ * dependencies enabled.
+ *
+ * ## Options
+ *
+ * - `minimal`: If set, will only build with the minimum required dependencies.
+ */
+export default function curl(
+  options: CurlOptions = {},
+): std.Recipe<std.Directory> {
+  const { minimal = false } = options;
+
+  const curlDependencies = [std.toolchain, openssl];
+  const curlBuildFlags = ["--with-openssl"];
+  if (!minimal) {
+    curlDependencies.push(libpsl, libssh2);
+    curlBuildFlags.push("--with-libssh2");
+  } else {
+    curlBuildFlags.push("--without-libpsl");
+  }
+
   return std.runBash`
     ./configure \\
       --prefix=/ \\
-      --with-openssl \\
-      --with-libssh2 \\
       --without-ca-bundle \\
       --without-ca-path \\
-      --with-ca-fallback
+      --with-ca-fallback \\
+      $buildFlags
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain, openssl, libpsl, libssh2)
+    .dependencies(...curlDependencies)
+    .env({
+      buildFlags: curlBuildFlags.join(" "),
+    })
     .toDirectory()
     .pipe(
       (recipe) =>

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -1,4 +1,5 @@
 import * as std from "std";
+import brotli from "brotli";
 import libpsl from "libpsl";
 import libssh2 from "libssh2";
 import nushell from "nushell";
@@ -35,7 +36,7 @@ export default function curl(
   const curlDependencies = [std.toolchain, openssl];
   const curlBuildFlags = ["--with-openssl"];
   if (!minimal) {
-    curlDependencies.push(libpsl, libssh2);
+    curlDependencies.push(brotli, libpsl, libssh2);
     curlBuildFlags.push("--with-libssh2");
   } else {
     curlBuildFlags.push("--without-libpsl");

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -20,7 +20,7 @@ export default function git(): std.Recipe<std.Directory> {
     make prefix=/ install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain, openssl, curl)
+    .dependencies(std.toolchain, openssl, curl({ minimal: true }))
     .toDirectory()
     .pipe(
       (recipe) =>


### PR DESCRIPTION
This pull request introduces a new `minimal` build option for the `curl` package and updates its dependencies accordingly. The `minimal` option allows building `curl` with only the essential dependencies, which is then utilized in the `cmake` and `git` packages. Additionally, the `brotli` library is added as a dependency for `curl` when the `minimal` option is not enabled.

As display below, cURL still supports SCP, and now supports brotli when building it normally (aka not a minimal version).

```bash
99821  │ curl 8.13.0 (x86_64-pc-linux-gnu) libcurl/8.13.0 OpenSSL/3.5.0 zlib/1.2.13 brotli/1.1.0 zstd/1.5.5 libpsl/0.21.5 libssh2/1.11.1
       │ Release-Date: 2025-04-02
       │ Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
       │ Features: alt-svc AsynchDNS brotli HSTS HTTPS-proxy IPv6 Largefile libz NTLM PSL SSL threadsafe TLS-SRP UnixSockets zstd
```