### PR TITLE
feat(lerc): add package

### DIFF
--- a/packages/lerc/brioche.lock
+++ b/packages/lerc/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/esri/lerc": {
+      "v4.0.0": "fbeb481120b79d05163f8544c645e9975920526f"
+    }
+  }
+}

--- a/packages/lerc/project.bri
+++ b/packages/lerc/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "lerc",
+  version: "4.0.0",
+  repository: "https://github.com/esri/lerc",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function lerc(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test() {
+  const script = std.runBash`
+    pkg-config --modversion Lerc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lerc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`lerc`](https://github.com/Esri/lerc): a Limited Error Raster Compression

```bash
[container@e9ad9fa14b46 workspace]$ blu packages/lerc
Build finished, completed (no new jobs) in 4.19s
Running brioche-run
{
  "name": "lerc",
  "version": "4.0.0",
  "repository": "https://github.com/esri/lerc"
}
[container@e9ad9fa14b46 workspace]$ bt packages/lerc
152    │ 4.0.0
 0.13s ✓ Process 152
Build finished, completed 1 job in 3.86s
Result: 2c55deb8a67dbc4ca4d0e15497a2e4007f7051a017d1b5832d12b4d14e012502
```