### PR TITLE
feat(jjui): add package

### DIFF
--- a/packages/jjui/brioche.lock
+++ b/packages/jjui/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/idursun/jjui.git": {
+      "v0.8.8": "e9af1d7be4b0f20fa808e5083b8cc22806a9a0e6"
+    }
+  }
+}

--- a/packages/jjui/project.bri
+++ b/packages/jjui/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "jjui",
+  version: "0.8.8",
+  repository: "https://github.com/idursun/jjui.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function jjui(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.Version=${project.version}`],
+    },
+    path: "./cmd/jjui",
+    runnable: "bin/jjui",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    jjui --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(jjui)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`jjui`](https://github.com/idursun/jjui): a Text User Interface (TUI) designed for interacting with the Jujutsu version control system.

Thanks to the [PR](https://github.com/idursun/jjui/pull/81), we can now set the ld flags to correctly report the version of jjui. See the discussion [here](https://github.com/idursun/jjui/discussions/80).

```bash
[container@6957380374c0 workspace]$ bt packages/jjui
Build finished, completed (no new jobs) in 1.85s
Result: 6390c6b2f3842bf7836817efe2c88b7016a010b085ead57acb06d2a03b6f9ff1
[container@6957380374c0 workspace]$ blu packages/jjui
Build finished, completed (no new jobs) in 6.05s
Running brioche-run
{
  "name": "jjui",
  "version": "0.8.8",
  "repository": "https://github.com/idursun/jjui.git"
}
```