### PR TITLE
feat(cmctl): add package

### DIFF
--- a/packages/cmctl/brioche.lock
+++ b/packages/cmctl/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/cert-manager/cmctl.git": {
+      "v2.2.0": "b222de33a335dcff615f08ea760c896fbeba8184"
+    }
+  }
+}

--- a/packages/cmctl/project.bri
+++ b/packages/cmctl/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "cmctl",
+  version: "2.2.0",
+  repository: "https://github.com/cert-manager/cmctl.git",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function cmctl(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        "github.com/cert-manager/cmctl/v2/pkg/build.name=cmctl",
+        "-X",
+        `github.com/cert-manager/cert-manager/pkg/util.AppVersion=${project.version}`,
+        "-X",
+        `github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=${gitRef.commit}`,
+      ],
+    },
+    runnable: "bin/cmctl",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cmctl version --client | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cmctl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `GitVersion:"${project.version}"`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cmctl`](https://github.com/cert-manager/cmctl): a command line utility that makes cert-manager'ing easier.

```bash
[container@6957380374c0 workspace]$ blu packages/cmctl/
Build finished, completed (no new jobs) in 4.85s
Running brioche-run
{
  "name": "cmctl",
  "version": "2.2.0",
  "repository": "https://github.com/cert-manager/cmctl.git"
}
[container@6957380374c0 workspace]$ bt packages/cmctl/
Build finished, completed (no new jobs) in 1.90s
Result: d11268dc3729c0f32d2acdf7c712a0b37cbb697c544b1e0478e4910d665c03ad
```