### PR TITLE
Optionally authenticate requests in `std.liveUpdateFromGithubReleases`

### DIFF
--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Check packages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish packages
     needs: [build]
     if: github.repository == 'brioche-dev/brioche-packages' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   live-update-packages:
     name: Live-update packages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -41,6 +41,9 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Update packages
+        env:
+          # Authenticate for GitHub API requests for increased rate limits
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git_head="$(git rev-parse HEAD)"
 

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -58,7 +58,13 @@ export function liveUpdateFromGithubReleases(
     const { default: nushell } = await import("nushell");
 
     const src = std.file(std.indoc`
-      let tagName = http get $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+      # Include GitHub Token if present (for increased rate limits)
+      mut gh_headers = []
+      if ($env.GITHUB_TOKEN? | default "") != "" {
+        $gh_headers ++= [Authorization $'Bearer $($env.GITHUB_TOKEN)']
+      }
+
+      let tagName = http get --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
         | get tag_name
 
       let parsedTagName = $tagName | parse --regex $env.matchTag


### PR DESCRIPTION
This PR updates the Nushell script for `std.liveUpdateFromGithubReleases()` to authenticate the GitHub API request if the `$GITHUB_TOKEN` env var is set. GitHub recently announced that they were adding more restrictive rate limits for unauthenticated requests: https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/

Experimentally, the endpoint `https://api.github.com/repos/{owner}/{repo}/releases/latest` has a rate limit of 60 when unauthenticated, and resets on the hour (which can be seen with the `x-ratelimit-limit` and `x-ratelimit-reset` response headers). When using a token, the rate limit increases to 5,000 tokens (but seems to reset _after an hour_, not _on the hour_). We've got >100 packages, and we've already seen some live-update runs fail. #487 will help so failures are more evenly spread out, and this change works in tandem to reduce the number of failures-- at least when using `std.liveUpdateFromGithubReleases()`

---

Oh, and based on https://github.com/brioche-dev/brioche-packages/pull/487#issuecomment-2882494860, I also included a change to bump the Ubuntu runners to 24.04