### PR TITLE
Add xcaddy package

### DIFF
--- a/packages/caddy/brioche.lock
+++ b/packages/caddy/brioche.lock
@@ -3,9 +3,6 @@
   "git_refs": {
     "https://github.com/caddyserver/caddy.git": {
       "v2.10.0": "fb22a26b1a08a2fa3b2526d1852467904ee140f6"
-    },
-    "https://github.com/caddyserver/xcaddy.git": {
-      "v0.4.4": "c548f44e2d9290d6c490868336699d65f43dd36e"
     }
   }
 }

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -1,19 +1,15 @@
 import * as std from "std";
-import go, { goBuild } from "go";
-import nushell from "nushell";
+import go from "go";
+import xcaddy from "xcaddy";
 
 export const project = {
   name: "caddy",
   version: "2.10.0",
-  extra: {
-    xcaddy: {
-      version: "0.4.4",
-    },
-  },
+  repository: "https://github.com/caddyserver/caddy.git",
 };
 
 const sourceRef = Brioche.gitRef({
-  repository: "https://github.com/caddyserver/caddy.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -44,19 +40,6 @@ export default function caddy(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/caddy"));
 }
 
-function xcaddy(): std.Recipe<std.Directory> {
-  const source = Brioche.gitCheckout({
-    repository: "https://github.com/caddyserver/xcaddy.git",
-    ref: `v${project.extra.xcaddy.version}`,
-  });
-
-  return goBuild({
-    source,
-    path: "./cmd/xcaddy",
-    runnable: "bin/xcaddy",
-  });
-}
-
 export async function test() {
   const script = std.runBash`
     caddy version | tee "$BRIOCHE_OUTPUT"
@@ -66,39 +49,16 @@ export async function test() {
 
   const result = (await script.read()).trim();
 
+  // Check that the result contains the expected version
+  const expected = `v${project.version} `;
   std.assert(
-    result.startsWith(`v${project.version} `),
-    `expected '${project.version}', got '${result}'`,
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;
 }
 
 export function liveUpdate() {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/caddyserver/caddy/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let xcaddyReleaseData = http get https://api.github.com/repos/caddyserver/xcaddy/releases/latest
-
-    let xcaddyVersion = $xcaddyReleaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.xcaddy.version $xcaddyVersion
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xcaddy/brioche.lock
+++ b/packages/xcaddy/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/caddyserver/xcaddy.git": {
+      "v0.4.4": "c548f44e2d9290d6c490868336699d65f43dd36e"
+    }
+  }
+}

--- a/packages/xcaddy/inject-version-information.patch
+++ b/packages/xcaddy/inject-version-information.patch
@@ -1,0 +1,35 @@
+diff --git a/cmd/main.go b/cmd/main.go
+index 9a898d3..552ed54 100644
+--- a/cmd/main.go
++++ b/cmd/main.go
+@@ -41,6 +41,7 @@ var (
+ 	buildDebugOutput = os.Getenv("XCADDY_DEBUG") == "1"
+ 	buildFlags       = os.Getenv("XCADDY_GO_BUILD_FLAGS")
+ 	modFlags         = os.Getenv("XCADDY_GO_MOD_FLAGS")
++	Version          string
+ )
+ 
+ func Main() {
+@@ -207,21 +208,7 @@ func splitWith(arg string) (module, version, replace string, err error) {
+ 
+ // xcaddyVersion returns a detailed version string, if available.
+ func xcaddyVersion() string {
+-	mod := goModule()
+-	ver := mod.Version
+-	if mod.Sum != "" {
+-		ver += " " + mod.Sum
+-	}
+-	if mod.Replace != nil {
+-		ver += " => " + mod.Replace.Path
+-		if mod.Replace.Version != "" {
+-			ver += "@" + mod.Replace.Version
+-		}
+-		if mod.Replace.Sum != "" {
+-			ver += " " + mod.Replace.Sum
+-		}
+-	}
+-	return ver
++	return Version
+ }
+ 
+ func goModule() *debug.Module {

--- a/packages/xcaddy/project.bri
+++ b/packages/xcaddy/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "xcaddy",
+  version: "0.4.4",
+  repository: "https://github.com/caddyserver/xcaddy.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+}).pipe((source) =>
+  // Patch the source to properly inject version information
+  // Inspired from: https://github.com/NixOS/nixpkgs/blob/d89fc19e405cb2d55ce7cc114356846a0ee5e956/pkgs/by-name/xc/xcaddy/inject_version_info.diff
+  std.applyPatch({
+    source,
+    patch: Brioche.includeFile("inject-version-information.patch"),
+    strip: 1,
+  }),
+);
+
+export default function xcaddy(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/caddyserver/xcaddy/cmd.Version=${project.version}`,
+      ],
+    },
+    path: "./cmd/xcaddy",
+    runnable: "bin/xcaddy",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    xcaddy version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(xcaddy)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Extract from `caddy` the package `xcaddy`. It let us to rely on `std.liveUpdateFromGithubReleases()` for both packages now.

```bash
[container@ab3f489dbbf1 workspace]$ blu packages/xcaddy/
Build finished, completed 8 jobs in 1m 0s
Running brioche-run
{
  "name": "xcaddy",
  "version": "0.4.4",
  "repository": "https://github.com/caddyserver/xcaddy.git"
}
[container@ab3f489dbbf1 workspace]$ bt packages/xcaddy/
Build finished, completed (no new jobs) in 2.01s
Result: 2e0ddceede13e1bf3c79fdebeb98ac4ee2ed9ce05f2f22ee0b31003255a7738d
```

```bash
[container@ab3f489dbbf1 workspace]$ blu packages/caddy/
Build finished, completed (no new jobs) in 4.95s
Running brioche-run
{
  "name": "caddy",
  "version": "2.10.0",
  "repository": "https://github.com/caddyserver/caddy.git"
}
[container@ab3f489dbbf1 workspace]$ bt packages/caddy/
Build finished, completed (no new jobs) in 1.88s
Result: b779aa9cb5f0cf0442fdfa4a70be506f417aad6d8d4c7bf91671fb6ff8d526a1
```