### PR TITLE
feat(gosec): add package

### DIFF
--- a/packages/gosec/brioche.lock
+++ b/packages/gosec/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/securego/gosec.git": {
+      "v2.22.4": "6decf96c3d272d5a8bbdcf9fddb5789d0be16a8d"
+    }
+  }
+}

--- a/packages/gosec/project.bri
+++ b/packages/gosec/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "gosec",
+  version: "2.22.4",
+  repository: "https://github.com/securego/gosec.git",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function gosec(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.Version=${project.version}`,
+        "-X",
+        `main.GitTag=${gitRef.commit}`,
+      ],
+    },
+    path: "./cmd/gosec",
+    runnable: "bin/gosec",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    gosec --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gosec)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package `gosec`: inspects source code for security problems by scanning the Go AST and SSA code representation.

```bash
[container@ab3f489dbbf1 workspace]$ blu packages/gosec/
Build finished, completed (no new jobs) in 4.69s
Running brioche-run
{
  "name": "gosec",
  "version": "2.22.4",
  "repository": "https://github.com/securego/gosec.git"
}
[container@ab3f489dbbf1 workspace]$ bt packages/gosec/
Build finished, completed (no new jobs) in 1.67s
Result: b72dff9b3641e5520a650996aa30aa3d7e28a9a37e9a0be57fdea50be614203c
```