### PR TITLE
feat(trivy): add package

### DIFF
--- a/packages/trivy/brioche.lock
+++ b/packages/trivy/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/aquasecurity/trivy.git": {
+      "v0.62.1": "c75ed2156c8fa801d6998016f46f6b953e8a9556"
+    }
+  }
+}

--- a/packages/trivy/project.bri
+++ b/packages/trivy/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "trivy",
+  version: "0.62.1",
+  repository: "https://github.com/aquasecurity/trivy.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function trivy(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/aquasecurity/trivy/pkg/version/app.ver=${project.version}`,
+      ],
+    },
+    path: "./cmd/trivy",
+    runnable: "bin/trivy",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    trivy --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(trivy)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`trivy`](https://github.com/aquasecurity/trivy): find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more

```bash
[container@28d2ad4a7808 workspace]$ blu packages/trivy
Build finished, completed (no new jobs) in 4.22s
Running brioche-run
{
  "name": "trivy",
  "version": "0.62.1",
  "repository": "https://github.com/aquasecurity/trivy.git"
}
[container@28d2ad4a7808 workspace]$ bt packages/trivy
Build finished, completed (no new jobs) in 1.71s
Result: 90775a409101de561cdf02ac070e9cf796503229db2c8fd6dab55f3c2f2b9872
```