### PR TITLE
feat(kor): add package

### DIFF
--- a/packages/kor/brioche.lock
+++ b/packages/kor/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/yonahd/kor.git": {
+      "v0.6.1": "096b9d811fc5033cfb46de10f6dc534afdf33ccf"
+    }
+  }
+}

--- a/packages/kor/project.bri
+++ b/packages/kor/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "kor",
+  version: "0.6.1",
+  repository: "https://github.com/yonahd/kor.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function kor(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/yonahd/kor/pkg/utils.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/kor",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    kor version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(kor)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `kor version: v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`kor`](https://github.com/yonahd/kor): a Golang Tool to discover unused Kubernetes Resources

```bash
[container@f4786e3b97ec workspace]$ blu packages/kor
Build finished, completed (no new jobs) in 4.18s
Running brioche-run
{
  "name": "kor",
  "version": "0.6.1",
  "repository": "https://github.com/yonahd/kor.git"
}
[container@f4786e3b97ec workspace]$ bt packages/kor
Build finished, completed (no new jobs) in 1.65s
Result: 8452674ffbf8a28816d0196f0c078c8e0ff328f155d30deded11769f210a3b40
```