### PR TITLE
feat(cargomutants): add package

### DIFF
--- a/packages/cargo_mutants/brioche.lock
+++ b/packages/cargo_mutants/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sourcefrog/cargo-mutants.git": {
+      "v25.0.1": "d246b932390479d0f3c004f35df961256c968c01"
+    }
+  }
+}

--- a/packages/cargo_mutants/project.bri
+++ b/packages/cargo_mutants/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_mutants",
+  version: "25.0.1",
+  repository: "https://github.com/sourcefrog/cargo-mutants.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoMutants(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-mutants",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cargo mutants --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoMutants)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-mutants ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_mutants`](https://github.com/sourcefrog/cargo-mutants): inject bugs and see if your tests catch them!

```bash
[container@fad58cc35c32 workspace]$ bt packages/cargo_mutants/
Build finished, completed (no new jobs) in 2.39s
Result: 5e399c39b79c96aa9b7f80baaf1568405869fe46aeac2b7a3bc93db3d825d559
[container@fad58cc35c32 workspace]$ blu packages/cargo_mutants/
Build finished, completed (no new jobs) in 4.39s
Running brioche-run
{
  "name": "cargo_mutants",
  "version": "25.0.1",
  "repository": "https://github.com/sourcefrog/cargo-mutants.git"
}
```