### PR TITLE
feat(cargoabout): add package

### DIFF
--- a/packages/cargo_about/brioche.lock
+++ b/packages/cargo_about/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/EmbarkStudios/cargo-about.git": {
+      "0.7.1": "7ea949142cb071a60d4361ca8e0c3ff4f35f5ab9"
+    }
+  }
+}

--- a/packages/cargo_about/project.bri
+++ b/packages/cargo_about/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_about",
+  version: "0.7.1",
+  repository: "https://github.com/EmbarkStudios/cargo-about.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function cargoAbout(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-about",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cargo about --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoAbout)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-about ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_about`](https://github.com/EmbarkStudios/cargo-about): a cargo plugin to generate list of all licenses for a crate 

```bash
[container@1a7e3f630874 workspace]$ blu packages/cargo_about/
Build finished, completed (no new jobs) in 3.97s
Running brioche-run
{
  "name": "cargo_about",
  "version": "0.7.1",
  "repository": "https://github.com/EmbarkStudios/cargo-about.git"
}
[container@1a7e3f630874 workspace]$ bt packages/cargo_about/
Build finished, completed (no new jobs) in 2.23s
Result: 78432915bfe845ba398ce346e621aed23506da5d124d8c4de921d7a93b59393c
```