### PR TITLE
feat(bashlanguageserver): add package

### DIFF
--- a/packages/bash_language_server/brioche.lock
+++ b/packages/bash_language_server/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/bash_language_server/project.bri
+++ b/packages/bash_language_server/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "bash_language_server",
+  version: "5.6.0",
+  packageName: "bash-language-server",
+};
+
+export default function bashLanguageServer(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/bash-language-server"));
+}
+
+export async function test() {
+  const script = std.runBash`
+    bash-language-server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bashLanguageServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`bash_language_server`](https://github.com/bash-lsp/bash-language-server): a language server for Bash

```bash
[container@30423e35af26 workspace]$ blu packages/bash_language_server/
Build finished, completed (no new jobs) in 3.98s
Running brioche-run
{
  "name": "bash_language_server",
  "version": "5.6.0",
  "packageName": "bash-language-server"
}
[container@30423e35af26 workspace]$ bt packages/bash_language_server/
Build finished, completed (no new jobs) in 4.25s
Result: 36e0a1276abfab6dbd9f09a64a25e4b53bca383801f5d854ba96d7a68c927217
```