### PR TITLE
Add `uv` package

### DIFF
--- a/packages/uv/brioche.lock
+++ b/packages/uv/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/astral-sh/uv.git": {
+      "0.7.6": "7f3e94a091f9f65b778ccc9ba7271887fad143c8"
+    }
+  }
+}

--- a/packages/uv/project.bri
+++ b/packages/uv/project.bri
@@ -1,0 +1,42 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "uv",
+  version: "0.7.6",
+  repository: "https://github.com/astral-sh/uv.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function uv(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "crates/uv",
+    cargoChefPrepare: false,
+    runnable: "bin/uv",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    uv --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(uv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `uv ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
This PR adds a new package for [uv](https://docs.astral.sh/uv/), an extremely fast Python package and project manager, written in Rust. 