### PR TITLE
Add `mitmproxy` package

### DIFF
--- a/packages/mitmproxy/brioche.lock
+++ b/packages/mitmproxy/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mitmproxy/mitmproxy.git": {
+      "v12.0.1": "8b41236ea485d11919c64f8eb3f718069980ffe8"
+    }
+  }
+}

--- a/packages/mitmproxy/project.bri
+++ b/packages/mitmproxy/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import python, { project as pythonProject } from "python";
+import uv from "uv";
+
+export const project = {
+  name: "mitmproxy",
+  version: "12.0.1",
+  repository: "https://github.com/mitmproxy/mitmproxy.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function mitmproxy(): std.Recipe<std.Directory> {
+  return std.runBash`
+    uv tool install mitmproxy
+  `
+    .workDir(source)
+    .dependencies(python, uv)
+    .env({
+      UV_NO_MANAGED_PYTHON: "1",
+      UV_LINK_MODE: "copy",
+      UV_LOCKED: "1",
+      UV_TOOL_DIR: std.outputPath,
+    })
+    .unsafe({ networking: true })
+    .toDirectory()
+    .pipe((recipe) => {
+      // TODO: Clean this up! We should find a way to not hardcode the
+      // list of binaries and the Python version for `$PYTHONPATH`
+      recipe = recipe.insert("brioche-run.d/python", python);
+      const binaries = [
+        "mitmproxy",
+        "mitmdump",
+        "mitmweb",
+        "mitmproxy-linux-redirector",
+      ];
+      for (const binary of binaries) {
+        recipe = std.addRunnable(recipe, `bin/${binary}`, {
+          command: { relativePath: "brioche-run.d/python/bin/python" },
+          args: [{ relativePath: `mitmproxy/bin/${binary}` }],
+          env: {
+            PYTHONPATH: [
+              {
+                relativePath: `mitmproxy/lib/python${pythonProject.extra.currentMinorVersion}/site-packages`,
+              },
+            ],
+          },
+        });
+      }
+
+      return recipe;
+    })
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/mitmproxy"));
+}
+
+export async function test() {
+  const script = std.runBash`
+    mitmproxy --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(mitmproxy)
+    .toFile();
+
+  const result = (await script.read()).trim().split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `Mitmproxy: ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
This PR adds a package for [mitmproxy](https://mitmproxy.org/), a free and open source interactive HTTPS proxy

This uses the newly-added uv package (#520). uv is _really_ slick, but using it for packaging was pretty painful. There's a lot that should probably be cleaned up. Longer term, I think it'd make sense to have a utility to package a project that uses  uv (similar to `nodejs.npmInstall()`, etc.)