### PR TITLE
feat(cargoaudit): add package

### DIFF
--- a/packages/cargo_audit/brioche.lock
+++ b/packages/cargo_audit/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rustsec/rustsec.git": {
+      "cargo-audit/v0.21.2": "18e58c28d9e6a542a167f19057c97554ec9b845f"
+    }
+  }
+}

--- a/packages/cargo_audit/project.bri
+++ b/packages/cargo_audit/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_audit",
+  version: "0.21.2",
+  repository: "https://github.com/rustsec/rustsec.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `cargo-audit/v${project.version}`,
+});
+
+export default function cargoAudit(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-audit",
+    path: "cargo-audit",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cargo audit --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoAudit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-audit-audit ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^cargo-audit\/v(?<version>.*)$/,
+  });
+}


### PR DESCRIPTION
Add a new package [`cargo_audit`](https://github.com/rustsec/rustsec): RustSec API & Tooling

```bash
[container@d994e4df4ab5 workspace]$ blu packages/cargo_audit/
Build finished, completed (no new jobs) in 4.41s
Running brioche-run
{
  "name": "cargo_audit",
  "version": "0.21.2",
  "repository": "https://github.com/rustsec/rustsec.git"
}
[container@d994e4df4ab5 workspace]$ bt packages/cargo_audit/
Build finished, completed (no new jobs) in 2.34s
Result: 36414b2e2f9227c22cae26077c60b268874e4589f51810a9d64c03d54a32f3c8
```