### PR TITLE
feat(grcov): add package

### DIFF
--- a/packages/grcov/brioche.lock
+++ b/packages/grcov/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mozilla/grcov.git": {
+      "v0.10.0": "ca5313f19eb7759addb0c5cf1b990678b8b68314"
+    }
+  }
+}

--- a/packages/grcov/project.bri
+++ b/packages/grcov/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "grcov",
+  version: "0.10.0",
+  repository: "https://github.com/mozilla/grcov.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function grcov(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/grcov",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    grcov --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(grcov)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `grcov ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`grcov`](https://github.com/mozilla/grcov): Rust tool to collect and aggregate code coverage data for multiple source files

```bash
[container@d9c3552e7d91 workspace]$ blu packages/grcov/
Build finished, completed (no new jobs) in 4.00s
Running brioche-run
{
  "name": "grcov",
  "version": "0.10.0",
  "repository": "https://github.com/mozilla/grcov.git"
}
[container@d9c3552e7d91 workspace]$ bt packages/grcov/
Build finished, completed (no new jobs) in 2.31s
Result: 347abb8c1f31cdc9dcfb035512008dac0ae763e8b85ec6fd503ac71f1fc674f8
```