### PR TITLE
feat(sccache): add package

### DIFF
--- a/packages/sccache/brioche.lock
+++ b/packages/sccache/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mozilla/sccache.git": {
+      "v0.10.0": "e3d1ed560a28d114bd26299b0f717b372e7fc3d2"
+    }
+  }
+}

--- a/packages/sccache/project.bri
+++ b/packages/sccache/project.bri
@@ -1,0 +1,42 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import openssl from "openssl";
+
+export const project = {
+  name: "sccache",
+  version: "0.10.0",
+  repository: "https://github.com/mozilla/sccache.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function sccache(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/sccache",
+    dependencies: [openssl],
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    sccache --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(sccache)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sccache ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`sccache`](https://github.com/mozilla/sccache): a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible. Sccache has the capability to utilize caching in remote storage environments, including various cloud storage options, or alternatively, in local storage.

```bash
[container@d9c3552e7d91 workspace]$ blu packages/sccache/
Build finished, completed (no new jobs) in 3.94s
Running brioche-run
{
  "name": "sccache",
  "version": "0.10.0",
  "repository": "https://github.com/mozilla/sccache.git"
}
[container@d9c3552e7d91 workspace]$ bt packages/sccache/
Build finished, completed (no new jobs) in 2.31s
Result: b1063cf2fa912c519912da7840f33c0e75d1088e7e08ce2f3951bc1ae007eed1
```