### PR TITLE
feat(delve): add package

### DIFF
--- a/packages/delve/brioche.lock
+++ b/packages/delve/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/go-delve/delve.git": {
+      "v1.24.2": "f0cc62bfcaa18b9f2cd01cebd818fad537ee93ec"
+    }
+  }
+}

--- a/packages/delve/project.bri
+++ b/packages/delve/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "delve",
+  version: "1.24.2",
+  repository: "https://github.com/go-delve/delve.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function delve(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    path: "./cmd/dlv",
+    runnable: "bin/dlv",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    dlv version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(delve)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`delve`](https://github.com/go-delve/delve): a debugger for the Go programming language.

```bash
[container@395d2febf6a6 workspace]$ bt packages/delve
Build finished, completed (no new jobs) in 1.65s
Result: 6b33097ec4a4d1705dd7d176e46a0568b7f6f1f4bf1c6c74ca77d5dec5109160
[container@395d2febf6a6 workspace]$ blu packages/delve/
Build finished, completed (no new jobs) in 4.11s
Running brioche-run
{
  "name": "delve",
  "version": "1.24.2",
  "repository": "https://github.com/go-delve/delve.git"
}
```