### PR TITLE
feat(cargobloat): add package

### DIFF
--- a/packages/cargo_bloat/brioche.lock
+++ b/packages/cargo_bloat/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/RazrFalcon/cargo-bloat.git": {
+      "v0.12.1": "69ccabda2b1671c4fd675e9a660af29ee985506f"
+    }
+  }
+}

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+import nushell from "nushell";
+
+export const project = {
+  name: "cargo_bloat",
+  version: "0.12.1",
+  repository: "https://github.com/RazrFalcon/cargo-bloat.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoBloat(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-bloat",
+  });
+}
+
+export async function test() {
+  const script = std.runBash`
+    cargo bloat --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoBloat)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate() {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/RazrFalcon/cargo-bloat/git/matching-refs/tags
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`cargo_bloat`](https://github.com/RazrFalcon/cargo-bloat): a tool to find out what takes most of the space in your executable.

```bash
[container@395d2febf6a6 workspace]$ blu packages/cargo_bloat/
Build finished, completed (no new jobs) in 4.05s
Running brioche-run
{
  "name": "cargo_bloat",
  "version": "0.12.1",
  "repository": "https://github.com/RazrFalcon/cargo-bloat.git"
}
[container@395d2febf6a6 workspace]$ bt packages/cargo_bloat/
Build finished, completed (no new jobs) in 2.32s
Result: 8a777a57530d5271890ec3c26acd21038a671c9fc20415db02bc4e50605170d1
```