### PR TITLE
Add live-update and test functions return type

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -62,7 +62,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.alsa-project.org/files/pub/lib
       | lines

--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -29,7 +29,7 @@ export default function alsaLib(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const src = std.file(std.indoc`
       #include <stdio.h>
       #include <stdlib.h>

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -19,7 +19,7 @@ export default function amber(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     amber --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -70,7 +70,7 @@ export default function asciinema(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   // Generate a locale which is required by asciinema to run properly
   const locale = std.runBash`
     mkdir -p "$BRIOCHE_OUTPUT"/C.UTF-8

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -101,6 +101,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -15,7 +15,7 @@ export default function awsCdk(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/cdk"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cdk --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -34,7 +34,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
 

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -123,7 +123,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/tags
       | get ref

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -104,7 +104,7 @@ export default function awsCli(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     aws --version | tr -d '\n' | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/bash_language_server/project.bri
+++ b/packages/bash_language_server/project.bri
@@ -15,7 +15,7 @@ export default function bashLanguageServer(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/bash-language-server"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     bash-language-server --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/bash_language_server/project.bri
+++ b/packages/bash_language_server/project.bri
@@ -31,7 +31,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
 

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -19,7 +19,7 @@ export default function bat(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     bat --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/bat/project.bri
+++ b/packages/bat/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -23,7 +23,7 @@ export default function biome(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     biome --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -39,7 +39,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^cli\/v(?<version>.*)$/,

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/broot/project.bri
+++ b/packages/broot/project.bri
@@ -19,7 +19,7 @@ export default function broot(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     broot --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/brotli/project.bri
+++ b/packages/brotli/project.bri
@@ -26,7 +26,7 @@ export default function brotli(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libbrotlicommon | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/brotli/project.bri
+++ b/packages/brotli/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -28,7 +28,7 @@ export default function bubblewrap(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/bwrap"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     bwrap --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/bugstalker/project.bri
+++ b/packages/bugstalker/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/bugstalker/project.bri
+++ b/packages/bugstalker/project.bri
@@ -21,7 +21,7 @@ export default function bugstalker(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     bs --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -48,7 +48,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://curl.se/docs/caextract.html
       | lines

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -28,7 +28,7 @@ export default function caCertificates(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     openssl x509 -in $SSL_CERT_FILE -noout -text | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -40,7 +40,7 @@ export default function caddy(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/caddy"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     caddy version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/caddy/project.bri
+++ b/packages/caddy/project.bri
@@ -59,6 +59,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -24,7 +24,7 @@ export default function carapace(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     carapace --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/cargo_about/project.bri
+++ b/packages/cargo_about/project.bri
@@ -19,7 +19,7 @@ export default function cargoAbout(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cargo about --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/cargo_audit/project.bri
+++ b/packages/cargo_audit/project.bri
@@ -20,7 +20,7 @@ export default function cargoAudit(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cargo audit --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -36,7 +36,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/RazrFalcon/cargo-bloat/git/matching-refs/tags
       | get ref

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -20,7 +20,7 @@ export default function cargoBloat(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cargo bloat --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/cargo_mutants/project.bri
+++ b/packages/cargo_mutants/project.bri
@@ -19,7 +19,7 @@ export default function cargoMutants(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cargo mutants --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/cargo_nextest/project.bri
+++ b/packages/cargo_nextest/project.bri
@@ -23,7 +23,7 @@ export default function cargoNextest(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cargo nextest --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -15,7 +15,7 @@ export default function claudeCode(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/claude"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     claude --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/claude_code/project.bri
+++ b/packages/claude_code/project.bri
@@ -31,7 +31,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
 

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -200,7 +200,7 @@ export function cmakeBuild(
   return result;
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     # Only retrieve the first line of the output, other lines are not relevant for the version check
     cmake --version | head -n 1 | tee "$BRIOCHE_OUTPUT"

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -217,7 +217,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }
 

--- a/packages/cmctl/project.bri
+++ b/packages/cmctl/project.bri
@@ -33,7 +33,7 @@ export default function cmctl(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cmctl version --client | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/codex/project.bri
+++ b/packages/codex/project.bri
@@ -15,7 +15,7 @@ export default function codex(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/codex"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     codex --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/codex/project.bri
+++ b/packages/codex/project.bri
@@ -31,7 +31,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
 

--- a/packages/cosign/project.bri
+++ b/packages/cosign/project.bri
@@ -40,7 +40,7 @@ export default function cosign(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     cosign version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -71,12 +71,14 @@ export default function curl(
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     curl --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(curl);
+  `
+    .dependencies(curl)
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `curl ${project.version}`;

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -90,7 +90,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/curl/curl/releases/latest
       | get tag_name

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -34,7 +34,7 @@ export default function dasel(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     dasel --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/dasel/project.bri
+++ b/packages/dasel/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/delve/project.bri
+++ b/packages/delve/project.bri
@@ -23,7 +23,7 @@ export default function delve(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     dlv version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/difftastic/project.bri
+++ b/packages/difftastic/project.bri
@@ -19,7 +19,7 @@ export default function difftastic(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     difft --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/dust/project.bri
+++ b/packages/dust/project.bri
@@ -19,7 +19,7 @@ export default function dust(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     dust --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/eks_node_viewer/project.bri
+++ b/packages/eks_node_viewer/project.bri
@@ -52,6 +52,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/eks_node_viewer/project.bri
+++ b/packages/eks_node_viewer/project.bri
@@ -33,7 +33,7 @@ export default function eksNodeViewer(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     eks-node-viewer --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -55,7 +55,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let versionUnderscore = http get https://api.github.com/repos/libexpat/libexpat/releases/latest
       | get tag_name

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -39,7 +39,7 @@ export default function expat(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion expat | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -19,7 +19,7 @@ export default function eza(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     eza --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/fd/project.bri
+++ b/packages/fd/project.bri
@@ -19,7 +19,7 @@ export default function fd(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     fd --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/fx/project.bri
+++ b/packages/fx/project.bri
@@ -19,7 +19,7 @@ export default function fx(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     fx --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/fzf/project.bri
+++ b/packages/fzf/project.bri
@@ -33,7 +33,7 @@ export default function fzf(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     fzf --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -48,7 +48,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/git/git/git/matching-refs/
       | get ref

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -32,7 +32,7 @@ export default function git(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     git --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -50,7 +50,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/cli/cli/releases/latest
 

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -34,7 +34,7 @@ export default function gh(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     gh --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/gitui/project.bri
+++ b/packages/gitui/project.bri
@@ -25,7 +25,7 @@ export default function gitui(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     gitui --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -61,7 +61,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/golang/go/git/matching-refs/
       | get ref

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -42,7 +42,7 @@ export default function go(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     go version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/go_mockery/project.bri
+++ b/packages/go_mockery/project.bri
@@ -29,7 +29,7 @@ export default function goMockery(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     mockery version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/golangci_lint/project.bri
+++ b/packages/golangci_lint/project.bri
@@ -58,7 +58,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/golangci/golangci-lint/releases/latest
 

--- a/packages/golangci_lint/project.bri
+++ b/packages/golangci_lint/project.bri
@@ -39,7 +39,7 @@ export default function golangciLint(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     golangci-lint --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/gosec/project.bri
+++ b/packages/gosec/project.bri
@@ -32,7 +32,7 @@ export default function gosec(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     gosec --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/grcov/project.bri
+++ b/packages/grcov/project.bri
@@ -19,7 +19,7 @@ export default function grcov(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     grcov --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/gron/project.bri
+++ b/packages/gron/project.bri
@@ -22,7 +22,7 @@ export default function gron(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     gron --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/htop/project.bri
+++ b/packages/htop/project.bri
@@ -24,7 +24,7 @@ export default function htop(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/htop"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     htop --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/hyperfine/project.bri
+++ b/packages/hyperfine/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/hyperfine/project.bri
+++ b/packages/hyperfine/project.bri
@@ -19,7 +19,7 @@ export default function hyperfine(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     hyperfine --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -88,7 +88,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/unicode-org/icu/releases/latest
 

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -61,7 +61,7 @@ export default function icu(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     icuinfo | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/jjui/project.bri
+++ b/packages/jjui/project.bri
@@ -23,7 +23,7 @@ export default function jjui(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     jjui --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -38,7 +38,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     # Version can either be prefixed with 'v' or not
     let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/tags

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -19,7 +19,7 @@ export default function joshuto(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     joshuto --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -42,7 +42,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^jq-(?<version>.*)$/,

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -26,7 +26,7 @@ export default function jq(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/jq"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     jq --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -38,6 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -22,7 +22,7 @@ export default function jujutsu(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     jj version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/just/project.bri
+++ b/packages/just/project.bri
@@ -19,7 +19,7 @@ export default function just(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     just --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -19,7 +19,7 @@ export default function jwtCli(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     jwt --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/jwt_cli/project.bri
+++ b/packages/jwt_cli/project.bri
@@ -38,6 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -31,7 +31,7 @@ export default function k9s(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     # Remove ANSI color codes from the output, before extracting the version
     k9s version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -27,7 +27,7 @@ export default function kmod(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     kmod --version | tee -a "$BRIOCHE_OUTPUT"
   `

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -46,7 +46,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.kernel.org/pub/linux/utils/kernel/kmod
       | lines

--- a/packages/kor/project.bri
+++ b/packages/kor/project.bri
@@ -27,7 +27,7 @@ export default function kor(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     kor version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -23,7 +23,7 @@ export default function kubent(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     kubent --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/lerc/project.bri
+++ b/packages/lerc/project.bri
@@ -25,7 +25,7 @@ export default function lerc(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion Lerc | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/lerc/project.bri
+++ b/packages/lerc/project.bri
@@ -41,6 +41,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -30,7 +30,7 @@ export default function libarchive(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libarchive | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -46,7 +46,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.libarchive.de/downloads
       | lines

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -48,7 +48,7 @@ export default function libcap(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libcap | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -64,7 +64,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://git.kernel.org/pub/scm/libs/libcap/libcap.git/refs
       | lines

--- a/packages/libdeflate/project.bri
+++ b/packages/libdeflate/project.bri
@@ -30,7 +30,7 @@ export default function libdeflate(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libdeflate | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libdeflate/project.bri
+++ b/packages/libdeflate/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -30,7 +30,7 @@ export default function libffi(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libffi | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libgit2/project.bri
+++ b/packages/libgit2/project.bri
@@ -33,7 +33,7 @@ export default function libgit2(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libgit2 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libgit2/project.bri
+++ b/packages/libgit2/project.bri
@@ -49,6 +49,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -53,7 +53,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.ijg.org/files
       | lines

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -31,7 +31,7 @@ export default function libjpeg(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libjpeg | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libjpeg_turbo/project.bri
+++ b/packages/libjpeg_turbo/project.bri
@@ -28,7 +28,7 @@ export default function libjpegTurbo(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libturbojpeg | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libjpeg_turbo/project.bri
+++ b/packages/libjpeg_turbo/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -29,7 +29,7 @@ export default function libpcap(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libpcap | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -45,7 +45,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.tcpdump.org/release
       | lines

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -30,7 +30,7 @@ export default function libpng(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libpng | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -46,7 +46,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://sourceforge.net/projects/libpng/files/libpng16
       | lines

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -30,7 +30,7 @@ export default function libPsl(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const src = std.file(std.indoc`
       #include <stdio.h>
       #include <stdlib.h>

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -63,6 +63,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -29,7 +29,7 @@ export default function libsodium(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libsodium | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -45,7 +45,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://download.libsodium.org/libsodium/releases
       | lines

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -32,7 +32,7 @@ export default function libssh2(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libssh2 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -48,7 +48,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.libssh2.org/download
       | lines

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -51,7 +51,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://sourceforge.net/projects/libtirpc/files/libtirpc
       | lines

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -35,7 +35,7 @@ export default function libtirpc(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libtirpc | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -30,7 +30,7 @@ export default function libunwind(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libunwind | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -56,7 +56,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://download.gnome.org/sources/libxml2
       | lines

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -40,7 +40,7 @@ export default function libxml2(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libxml-2.0 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -41,7 +41,7 @@ export default function libxslt(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libxslt | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -57,7 +57,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://download.gnome.org/sources/libxslt
       | lines

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -121,7 +121,7 @@ export default function linux(
     .toDirectory();
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://cdn.kernel.org/pub/linux/kernel
       | lines

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -66,7 +66,7 @@ export function llvmToolchain(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     llvm-config --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -82,7 +82,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^llvmorg-(?<version>.*)$/,

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/lurk/project.bri
+++ b/packages/lurk/project.bri
@@ -19,7 +19,7 @@ export default function lurk(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     lurk --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -19,7 +19,7 @@ export default function mdbook(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     mdbook --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -70,7 +70,7 @@ export default function meson(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     meson --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -19,7 +19,7 @@ export default function miniserve(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     miniserve --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/mitmproxy/project.bri
+++ b/packages/mitmproxy/project.bri
@@ -56,7 +56,7 @@ export default function mitmproxy(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/mitmproxy"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     mitmproxy --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -51,7 +51,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://git.joeyh.name/git/moreutils.git/refs/tags
       | lines

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -35,7 +35,7 @@ export default function moreutils(): std.Recipe<std.Directory> {
     .pipe(wrapPerlShebangs);
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     errno 13 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -26,7 +26,7 @@ export default function nasm(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     nasm --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -45,7 +45,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/netwide-assembler/nasm/git/matching-refs/tags
       | get ref

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -27,7 +27,7 @@ export default function nginx(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/nginx"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     nginx -v 2>&1 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -43,7 +43,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^release-(?<version>.*)$/,

--- a/packages/ninja/project.bri
+++ b/packages/ninja/project.bri
@@ -23,7 +23,7 @@ export default function ninja(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     ninja --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -44,7 +44,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/nodejs/node/git/matching-refs/tags
       | get ref

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -28,7 +28,7 @@ export default function nodejs(): std.Recipe<std.Directory> {
   return std.withRunnableLink(node, "bin/node");
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     node --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -81,6 +81,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -65,7 +65,7 @@ export default function nushell(): std.Recipe<std.Directory> {
   return std.merge(nushell, ...plugins);
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     nu --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/oha/project.bri
+++ b/packages/oha/project.bri
@@ -19,7 +19,7 @@ export default function oha(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     oha --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -34,7 +34,7 @@ export default function oniguruma(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     onig-config --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -56,7 +56,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^openssl-(?<version>.*)$/,

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -37,7 +37,7 @@ export default function openssl(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     openssl version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -30,7 +30,7 @@ export default function tofu(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     tofu --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -61,7 +61,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let sourceUrl = http get https://sourceforge.net/projects/pcre/files/pcre
       | lines

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -37,7 +37,7 @@ export default function pcre(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libpcre | tee -a "$BRIOCHE_OUTPUT"
     pkg-config --modversion libpcre16 | tee -a "$BRIOCHE_OUTPUT"

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -61,7 +61,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^pcre2-(?<version>.*)$/,

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -38,7 +38,7 @@ export default function pcre2(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion libpcre2-8 | tee -a "$BRIOCHE_OUTPUT"
     pkg-config --modversion libpcre2-16 | tee -a "$BRIOCHE_OUTPUT"

--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -42,7 +42,7 @@ export default function perl(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     perl --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -52,7 +52,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^php-(?<version>.*)$/,

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -33,7 +33,7 @@ export default function php(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     php --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -30,6 +30,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -14,7 +14,7 @@ export default function pnpm(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/pnpm"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pnpm --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/popeye/project.bri
+++ b/packages/popeye/project.bri
@@ -31,7 +31,7 @@ export default function popeye(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     # Remove ANSI color codes from the output, before extracting the version
     popeye version | sed -r 's/\x1B\[[0-9;]*[mK]//g' | awk '/^Version:/ { print $2 }' | tee "$BRIOCHE_OUTPUT"

--- a/packages/popeye/project.bri
+++ b/packages/popeye/project.bri
@@ -48,6 +48,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -58,7 +58,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     # Get the URL that '/ftp/latest' redirects to. The resulting URL
     # will have the version number at the end

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -42,7 +42,7 @@ export default function postgresql(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     postgres --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -41,7 +41,7 @@ export default function processCompose(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     process-compose version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -59,7 +59,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/F1bonacc1/process-compose/releases/latest
 

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -57,6 +57,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -37,7 +37,7 @@ export default function proot(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/proot"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   // No version is outputted, only the short hash of the commit version is displayed
   const script = std.runBash`
     proot --version | tee "$BRIOCHE_OUTPUT"

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -30,7 +30,7 @@ export default function pstack(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pstack --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -43,7 +43,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://ivarch.com/programs/pv.shtml
       | lines

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -24,7 +24,7 @@ export default function pv(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/pv"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pv --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -142,7 +142,7 @@ export default async function python(options: PythonOptions = {}) {
   );
 }
 
-export function test() {
+export function test(): std.Recipe<std.Directory> {
   const pythonVersions = Object.keys(
     project.extra.minorVersions,
   ) as PythonVersion[];

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -43,6 +43,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/rclone/project.bri
+++ b/packages/rclone/project.bri
@@ -25,7 +25,7 @@ export default function rclone(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     rclone --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -34,7 +34,7 @@ export default function re2c(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     re2c --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -39,6 +39,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/restic/project.bri
+++ b/packages/restic/project.bri
@@ -20,7 +20,7 @@ export default function restic(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     restic version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -19,7 +19,7 @@ export default function rip2(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     rip --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -22,7 +22,7 @@ export default function ripgrep(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     rg --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -30,7 +30,7 @@ export default function rpcsvcProto(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     rpcgen --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -36,6 +36,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ruff/project.bri
+++ b/packages/ruff/project.bri
@@ -20,7 +20,7 @@ export default function ruff(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     ruff --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -126,7 +126,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/rust-lang/rust/git/matching-refs/tags
       | get ref

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -107,7 +107,7 @@ export default async function rust(): Promise<std.Recipe<std.Directory>> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     rustc --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -71,7 +71,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/virtualsquare/s2argv-execs/git/matching-refs/tags
       | get ref

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -24,7 +24,7 @@ export default function s2argvExecs(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   // Create a simple C program that uses s2argv_execs to execute a command passed via stdin
   const src = std.file(std.indoc`
       #include <stdio.h>

--- a/packages/sccache/project.bri
+++ b/packages/sccache/project.bri
@@ -21,7 +21,7 @@ export default function sccache(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     sccache --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -26,7 +26,7 @@ export default function scdoc(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const exampleFile = std.file(std.indoc`
     SCDOC_TEST(7)
 

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -20,7 +20,7 @@ export default function seaweedfs(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     weed version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/snazy/project.bri
+++ b/packages/snazy/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/snazy/project.bri
+++ b/packages/snazy/project.bri
@@ -19,7 +19,7 @@ export default function snazy(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     snazy --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -50,7 +50,7 @@ export default function sqlite(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion sqlite3 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -38,6 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -19,7 +19,7 @@ export default function starship(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     starship --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -40,7 +40,7 @@ interface LiveUpdateFromGithubReleasesOptions {
  *   repository: "https://github.com/brioche-dev/brioche.git",
  * };
  *
- * export function liveUpdate() {
+ * export function liveUpdate(): std.Recipe<std.Directory> {
  *   return std.liveUpdateFromGithubReleases({
  *     project,
  *     matchTag: /^v(?<version>.*)$/, // Strip "v" prefix from tags

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -22,7 +22,7 @@ export default function steampipe(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     steampipe --version 2>&1 | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -24,7 +24,7 @@ export default function strace(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/strace"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     strace --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -19,7 +19,7 @@ export default function tailspin(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     tspin --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -47,7 +47,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.samba.org/ftp/talloc
       | lines

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -31,7 +31,7 @@ export default function talloc(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion talloc | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -24,7 +24,7 @@ export default function tcpdump(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/tcpdump"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     tcpdump --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -43,7 +43,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://www.tcpdump.org/release
       | lines

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -25,7 +25,7 @@ export default function tcsh(): std.Recipe<std.Directory> {
     .pipe((recipe) => std.withRunnableLink(recipe, "bin/tcsh"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     tcsh --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -44,7 +44,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://astron.com/pub/tcsh
       | lines

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -36,7 +36,7 @@ export default function terraform(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     # Only retrieve the first line of the output, other lines are not relevant for the version check
     terraform --version | head -n 1 | tee "$BRIOCHE_OUTPUT"

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -38,7 +38,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     # Version can be suffixed with '-alpha.X'
     let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/tags

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -19,7 +19,7 @@ export default function tokei(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     tokei --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/trivy/project.bri
+++ b/packages/trivy/project.bri
@@ -28,7 +28,7 @@ export default function trivy(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     trivy --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/unzip/project.bri
+++ b/packages/unzip/project.bri
@@ -29,7 +29,7 @@ export default function unzip(): std.Recipe<std.Directory> {
     .toDirectory();
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     unzip --help | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -62,7 +62,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/troydhanson/uthash/git/matching-refs/tags
       | get ref

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -17,7 +17,7 @@ export default function uthash(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   // This example has been adapted from the main documentation
   const src = std.file(std.indoc`
       #include <stdio.h>

--- a/packages/uv/project.bri
+++ b/packages/uv/project.bri
@@ -40,6 +40,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/uv/project.bri
+++ b/packages/uv/project.bri
@@ -24,7 +24,7 @@ export default function uv(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     uv --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -26,7 +26,7 @@ export default function vdeplug4(): std.Recipe<std.Directory> {
   );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const src = std.file(std.indoc`
       #include <stdio.h>
       #include <stdlib.h>

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -72,7 +72,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://api.github.com/repos/rd235/vdeplug4/git/matching-refs/tags
       | get ref

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/wasmtime/project.bri
+++ b/packages/wasmtime/project.bri
@@ -19,7 +19,7 @@ export default function wasmtime(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     wasmtime --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xcaddy/project.bri
+++ b/packages/xcaddy/project.bri
@@ -52,6 +52,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xcaddy/project.bri
+++ b/packages/xcaddy/project.bri
@@ -36,7 +36,7 @@ export default function xcaddy(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     xcaddy version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -19,7 +19,7 @@ export default function xh(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     xh --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -30,7 +30,7 @@ export default function xplr(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     xplr --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xplr/project.bri
+++ b/packages/xplr/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -19,7 +19,7 @@ export default function xsv(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     xsv --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xsv/project.bri
+++ b/packages/xsv/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -30,7 +30,7 @@ export default function xz(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion liblzma | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/yazi/project.bri
+++ b/packages/yazi/project.bri
@@ -25,12 +25,14 @@ export default function yazi(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     yazi --version | tee "$BRIOCHE_OUTPUT"
-  `.dependencies(yazi);
+  `
+    .dependencies(yazi)
+    .toFile();
 
-  const result = (await script.toFile().read()).trim();
+  const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
   const expected = `Yazi ${project.version}`;

--- a/packages/yazi/project.bri
+++ b/packages/yazi/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -46,7 +46,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://zlib.net
       | lines

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -30,7 +30,7 @@ export default function zlib(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion zlib | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -45,6 +45,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -29,7 +29,7 @@ export default function zlibNg(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     pkg-config --modversion zlib-ng | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -38,6 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/zoxide/project.bri
+++ b/packages/zoxide/project.bri
@@ -19,7 +19,7 @@ export default function zoxide(): std.Recipe<std.Directory> {
   });
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     zoxide --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -14,7 +14,7 @@ export default function zx(): std.Recipe<std.Directory> {
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/zx"));
 }
 
-export async function test() {
+export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
     zx --version | tee "$BRIOCHE_OUTPUT"
   `

--- a/packages/zx/project.bri
+++ b/packages/zx/project.bri
@@ -33,7 +33,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate() {
+export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let releaseData = http get https://registry.npmjs.org/${project.name}/latest
 


### PR DESCRIPTION
This PR introduces type annotations to the `test` and `liveUpdate` functions across packages.