### PR TITLE
feat(cargomsrv): add package

### DIFF
--- a/packages/cargo_msrv/brioche.lock
+++ b/packages/cargo_msrv/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/foresterre/cargo-msrv.git": {
+      "v0.18.4": "2dd72a1b998fcf91177a386cb13a1aca73bd24b0"
+    }
+  }
+}

--- a/packages/cargo_msrv/project.bri
+++ b/packages/cargo_msrv/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_msrv",
+  version: "0.18.4",
+  repository: "https://github.com/foresterre/cargo-msrv.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoMsrv(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-mrsv",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo msrv --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoMsrv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-msrv ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_msrv`](https://github.com/foresterre/cargo-msrv): find the minimum supported Rust version (MSRV) for your project.

```bash
[container@178f927a158d workspace]$ blu packages/cargo_msrv/
Build finished, completed (no new jobs) in 3.95s
Running brioche-run
{
  "name": "cargo_msrv",
  "version": "0.18.4",
  "repository": "https://github.com/foresterre/cargo-msrv.git"
}
[container@178f927a158d workspace]$ bt packages/cargo_msrv/
Build finished, completed (no new jobs) in 2.40s
Result: 3c4a358e57235b5a05afff12a05461f24f82254129eb6b73960417e03566235d
```