### PR TITLE
feat(cargoudeps): add package

### DIFF
--- a/packages/cargo_udeps/brioche.lock
+++ b/packages/cargo_udeps/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/est31/cargo-udeps.git": {
+      "v0.1.55": "6bd5e29ec6ea95cf48b4039499918c0782c41335"
+    }
+  }
+}

--- a/packages/cargo_udeps/project.bri
+++ b/packages/cargo_udeps/project.bri
@@ -1,0 +1,42 @@
+import * as std from "std";
+import openssl from "openssl";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_udeps",
+  version: "0.1.55",
+  repository: "https://github.com/est31/cargo-udeps.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoUdeps(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-udeps",
+    dependencies: [openssl],
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo udeps --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoUdeps)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-udeps ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_udeps`](https://github.com/est31/cargo-udeps): Find unused dependencies in Cargo.toml 

```bash
[container@178f927a158d workspace]$ blu packages/cargo_udeps/
Build finished, completed (no new jobs) in 4.25s
Running brioche-run
{
  "name": "cargo_udeps",
  "version": "0.1.55",
  "repository": "https://github.com/est31/cargo-udeps.git"
}
[container@178f927a158d workspace]$ bt packages/cargo_udeps/
Build finished, completed (no new jobs) in 2.36s
Result: 2f29c1e61a09b3dc4c411a1378378dfa5626ec561fbb078b27c823a77c6d463a
```