### PR TITLE
feat(tflint): add package

### DIFF
--- a/packages/tflint/brioche.lock
+++ b/packages/tflint/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/terraform-linters/tflint.git": {
+      "v0.58.0": "65effd5f53a9247b550ede916c626b4ba20935c5"
+    }
+  }
+}

--- a/packages/tflint/project.bri
+++ b/packages/tflint/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "tflint",
+  version: "0.58.0",
+  repository: "https://github.com/terraform-linters/tflint.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function tflint(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/tflint",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    tflint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(tflint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `TFLint version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package `[tflint](https://github.com/terraform-linters/tflint)`: a Pluggable Terraform Linter

```bash
[container@178f927a158d workspace]$ bt packages/tflint/
13146  │ TFLint version 0.58.0
       │ + ruleset.terraform (0.12.0-bundled)
 0.50s ✓ Process 13146
Build finished, completed 1 job in 3.36s
Result: fe98bed24459bf04c985458b2b54f35148c113104553eaf33b516b739d343a4a
[container@178f927a158d workspace]$ blu packages/tflint/
 0.07s ✓ Process 13220
Build finished, completed 1 job in 5.28s
Running brioche-run
{
  "name": "tflint",
  "version": "0.58.0",
  "repository": "https://github.com/terraform-linters/tflint.git"
}
```