### PR TITLE
feat(vegeta): add package

### DIFF
--- a/packages/vegeta/brioche.lock
+++ b/packages/vegeta/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/tsenart/vegeta.git": {
+      "v12.12.0": "03ca49e9b419c106db29d687827c4c823d8b8ece"
+    }
+  }
+}

--- a/packages/vegeta/project.bri
+++ b/packages/vegeta/project.bri
@@ -1,0 +1,85 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+import nushell from "nushell";
+
+export const project = {
+  name: "vegeta",
+  version: "12.12.0",
+  repository: "https://github.com/tsenart/vegeta.git",
+  extra: {
+    releaseDate: "2025-04-07",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function vegeta(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.Version=${project.version}`,
+        "-X",
+        `main.Commit=${gitRef.commit}`,
+        "-X",
+        `main.Date=${project.extra.releaseDate}`,
+      ],
+    },
+    runnable: "bin/vegeta",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    vegeta --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(vegeta)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://api.github.com/repos/tsenart/vegeta/releases/latest
+
+    let version = $releaseData
+      | get tag_name
+      | str replace --regex '^v' ''
+
+    let releaseDate = $releaseData
+      | get created_at
+      | into datetime
+      | format date "%Y-%m-%d"
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.releaseDate $releaseDate
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `[vegeta](https://github.com/tsenart/vegeta)`: a HTTP load testing tool and library

```bash
[container@178f927a158d workspace]$ bt packages/vegeta/
18689  │ Version: 12.12.0
       │ Commit: 03ca49e9b419c106db29d687827c4c823d8b8ece
       │ Runtime: go1.24.3 linux/amd64
       │ Date: 2025-04-07
 0.15s ✓ Process 18689
Build finished, completed 1 job in 3.30s
Result: dfb9e47edd91844e746dfbcbd8ffc52dd984e62836fe1c56c76f03da633b0910
[container@178f927a158d workspace]$ blu packages/vegeta/
Build finished, completed (no new jobs) in 5.25s
Running brioche-run
{
  "name": "vegeta",
  "version": "12.12.0",
  "repository": "https://github.com/tsenart/vegeta.git",
  "extra": {
    "releaseDate": "2024-07-29"
  }
}
```