### PR TITLE
feat(zziplib): add package

### DIFF
--- a/packages/zziplib/brioche.lock
+++ b/packages/zziplib/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/gdraheim/zziplib.git": {
+      "v0.13.79": "c4927d0ca8e3d653c6f433dfb32e957a326a52ab"
+    }
+  }
+}

--- a/packages/zziplib/project.bri
+++ b/packages/zziplib/project.bri
@@ -1,0 +1,80 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import nushell from "nushell";
+import python from "python";
+
+export const project = {
+  name: "zziplib",
+  version: "0.13.79",
+  repository: "https://github.com/gdraheim/zziplib.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function zziplib(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, python],
+    set: {
+      ZZIP_TESTCVE: "OFF",
+      BUILD_TESTS: "OFF",
+      ZZIPSDL: "OFF",
+      ZZIPTEST: "OFF",
+      BUILDTESTS: "OFF",
+      ZZIPDOCS: "OFF",
+    },
+    runnable: "bin/unzzip",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion zzipwrap | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, zziplib)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/gdraheim/zziplib/git/matching-refs/tags
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `[zziplib](https://github.com/gdraheim/zziplib)`: provides read access on ZIP-archives and unpacked data. It features an additional simplified API following the standard Posix API for file access


```bash
[container@725c7be98007 workspace]$ blu packages/zziplib/
Build finished, completed (no new jobs) in 3.89s
Running brioche-run
{
  "name": "zziplib",
  "version": "0.13.79",
  "repository": "https://github.com/gdraheim/zziplib.git"
}
[container@725c7be98007 workspace]$ bt packages/zziplib/
Build finished, completed (no new jobs) in 1.73s
Result: 070605c322893853bd0825ca8cf387d79665f9885dabbae5553f35659763f3f6
```