### PR TITLE
feat(gtest): add package

### DIFF
--- a/packages/gtest/brioche.lock
+++ b/packages/gtest/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/googletest.git": {
+      "v1.17.0": "52eb8108c5bdec04579160ae17225d66034bd723"
+    }
+  }
+}

--- a/packages/gtest/project.bri
+++ b/packages/gtest/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "gtest",
+  version: "1.17.0",
+  repository: "https://github.com/google/googletest.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function gtest(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion gtest | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gtest)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package `[gtest](https://github.com/google/googletest)`: GoogleTest - Google Testing and Mocking Framework

```bash
[container@229b00addb2f workspace]$ blu packages/gtest/
Build finished, completed (no new jobs) in 3.93s
Running brioche-run
{
  "name": "gtest",
  "version": "1.17.0",
  "repository": "https://github.com/google/googletest.git"
}
[container@229b00addb2f workspace]$ bt packages/gtest
Build finished, completed (no new jobs) in 1.68s
Result: a447d14fdcea861408dd77dc055814db266543d3e45fb6ecb9590fe66b98c26a
```