### PR TITLE
feat(markdownlint): add package

### DIFF
--- a/packages/markdownlint_cli/brioche.lock
+++ b/packages/markdownlint_cli/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/markdownlint_cli/project.bri
+++ b/packages/markdownlint_cli/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "markdownlint_cli",
+  version: "0.45.0",
+  packageName: "markdownlint-cli",
+};
+
+export default function markdownlintCli(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/markdownlint"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    markdownlint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(markdownlintCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected ${expected}, got ${result}`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `[markdownlint_cli](https://github.com/igorshubovych/markdownlint-cli)`: a MarkdownLint Command Line Interface

```bash
[container@b83650471a4e workspace]$ blu packages/markdownlint_cli
 0.08s ✓ Process 78
Build finished, completed 1 job in 6.17s
Running brioche-run
{
  "name": "markdownlint_cli",
  "version": "0.45.0",
  "packageName": "markdownlint-cli"
}
[container@b83650471a4e workspace]$ bt packages/markdownlint_cli
Build finished, completed (no new jobs) in 4.55s
Result: de1b5c0f9318732fab79781ad1c4f09676d171ddc38ecd8e569ff6d1b5e01596
```