### PR TITLE
Fix impurity in `mitmproxy` package

### DIFF
--- a/packages/mitmproxy/project.bri
+++ b/packages/mitmproxy/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.gitCheckout({
 
 export default function mitmproxy(): std.Recipe<std.Directory> {
   return std.runBash`
-    uv tool install mitmproxy
+    uv tool install .
   `
     .workDir(source)
     .dependencies(python, uv)


### PR DESCRIPTION
This PR updates the `mitmproxy` package

I didn't realize when you do `uv tool install $name`, it treats `$name` as a normal PyPI package name. In other words, it's basically equivalent to doing `pip install $name`!

Instead, it looks like `uv tool install .` will install a package from the current directory, which (I think) is what we want. It doesn't seem like there's a way to enforce the lockfile from this command, so I'm still not 100% sure this is fully pure yet? At a minimum, it seems like this change resolves some of the live-update issues we've seen around mitmproxy (#563, #569, #573)