### PR TITLE
Update "check" GH Actions job to check all packages together

### DIFF
--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -20,14 +20,4 @@ jobs:
 
       - name: Check packages
         run: |
-          packages=(packages/*)
-
-          n=1
-          for package in "${packages[@]}"; do
-            label="$package ($n / ${#packages[@]})"
-            ((n++))
-            echo "::group::$label"
-            brioche check -p "$package" --locked
-            brioche fmt -p "$package" --check
-            echo "::endgroup::"
-          done
+          echo ./packages/* | xargs printf -- '-p %s\n' | xargs brioche check


### PR DESCRIPTION
This PR takes advantage of https://github.com/brioche-dev/brioche/pull/255 to check all packages at once. Instead of checking each package individually, we use a single `brioche check` invocation (with `xargs`), which should be much faster