### PR TITLE
feat(markdownlintcli2): add package

### DIFF
--- a/packages/markdownlint_cli2/brioche.lock
+++ b/packages/markdownlint_cli2/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/markdownlint_cli2/project.bri
+++ b/packages/markdownlint_cli2/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "markdownlint_cli2",
+  version: "0.18.1",
+  packageName: "markdownlint-cli2",
+};
+
+export default function markdownlintCli2(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/markdownlint-cli2"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    markdownlint-cli2 --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(markdownlintCli2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `markdownlint-cli2 v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected ${expected}, got ${result}`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `[markdownlint_cli2](https://github.com/DavidAnson/markdownlint-cli2)`: a  fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library

```bash
[container@6f9294b2850f workspace]$ bt packages/markdownlint_cli2
Build finished, completed (no new jobs) in 4.55s
Result: 16bc51ec665fe3f4566a7c506975053f5159e6f7554cf64d4495d23394bd53a6
[container@3db101c74769 workspace]$ blu packages/markdownlint_cli2
Build finished, completed (no new jobs) in 4.22s
Running brioche-run
{
  "name": "markdownlint_cli2",
  "version": "0.18.1",
  "packageName": "markdownlint-cli2"
}
``