### PR TITLE
Better handle pkg config paths

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -20,7 +20,7 @@ export default function alsaLib(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -71,6 +71,7 @@ export default function cmake(): std.Recipe<std.Directory> {
           "libexec/cmake/brioche-packer",
           std.symlink({ target: "runtime-utils/bin/brioche-packer" }),
         ),
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -89,6 +89,7 @@ export interface CMakeBuildInstallOptions {
   config?: string;
   env?: Record<string, std.ProcessTemplateLike>;
   set?: Record<string, CMakeVariable>;
+  disablePostBuildSteps?: boolean;
   runnable?: string;
 }
 
@@ -127,6 +128,8 @@ export type CMakeVariableType =
  * - `env`: Optionally set environment variables for the build.
  * - `set`: Optionally set CMake cache variables during the build, as if
  *   by passing `-D...`.
+ * - `disablePostBuildSteps`: If set, the post build steps will not run. By
+ *   default, only `std.pkgConfigMakePathsRelative` will be executed.
  * - `runnable`: Optionally set a path to the binary to run by default
  *   (e.g. `bin/foo`).
  */
@@ -193,6 +196,10 @@ export function cmakeBuild(
       ...env,
     })
     .toDirectory();
+
+  if (options.disablePostBuildSteps == null || !options.disablePostBuildSteps) {
+    result = std.pkgConfigMakePathsRelative(result);
+  }
 
   if (options.runnable != null) {
     result = std.withRunnableLink(result, options.runnable);

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -59,6 +59,7 @@ export default function curl(
     })
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -30,7 +30,7 @@ export default function expat(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -22,7 +22,6 @@ const source = Brioche.download(
 
 export default function expat(): std.Recipe<std.Directory> {
   return std.runBash`
-    ls
     ./configure --prefix=/
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -35,6 +35,7 @@ export default function icu(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain)
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -21,7 +21,7 @@ export default function libarchive(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -43,7 +43,7 @@ export default function libcap(): std.Recipe<std.Directory> {
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
         }),
-      makePkgConfigPathsRelative,
+      std.pkgConfigMakePathsRelative,
       fixSharedObjects,
     );
 }
@@ -155,22 +155,6 @@ function fixSharedObjects(
       done
   `
     .dependencies(jq, std.runtimeUtils)
-    .outputScaffold(recipe)
-    .toDirectory();
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
     .outputScaffold(recipe)
     .toDirectory();
 }

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -37,13 +37,13 @@ export default function libcap(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain(), std.runtimeUtils(), briocheObjcopy())
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
         }),
-      std.pkgConfigMakePathsRelative,
       fixSharedObjects,
     );
 }

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -21,7 +21,7 @@ export default function libffi(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -22,7 +22,7 @@ export default function libjpeg(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -20,7 +20,7 @@ export default function libpcap(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -21,7 +21,7 @@ export default function libpng(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -21,7 +21,7 @@ export default function libPsl(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, python)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -20,7 +20,7 @@ export default function libsodium(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -31,7 +31,7 @@ export default function libtirpc(): std.Recipe<std.Directory> {
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
         }),
-      makePkgConfigPathsRelative,
+      std.pkgConfigMakePathsRelative,
     );
 }
 
@@ -79,20 +79,4 @@ export function liveUpdate(): std.WithRunnable {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell],
   });
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -25,6 +25,7 @@ export default function libtirpc(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain)
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -21,7 +21,7 @@ export default function libunwind(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -31,7 +31,7 @@ export default function libxml2(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, python)
     .toDirectory()
-    .pipe(makePkgConfigPathsRelative, (recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },
@@ -93,20 +93,4 @@ export function liveUpdate(): std.WithRunnable {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell],
   });
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -32,7 +32,7 @@ export default function libxslt(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, python, libxml2)
     .toDirectory()
-    .pipe(makePkgConfigPathsRelative, (recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },
@@ -94,20 +94,4 @@ export function liveUpdate(): std.WithRunnable {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell],
   });
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -24,6 +24,7 @@ export default function oniguruma(): std.Recipe<std.Directory> {
     .workDir(source)
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -25,6 +25,7 @@ export default function openssl(): std.Recipe<std.Directory> {
     .workDir(source)
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -28,7 +28,7 @@ export default function pcre(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -29,7 +29,7 @@ export default function pcre2(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain)
     .workDir(source)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -33,7 +33,7 @@ export default function postgresql(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, icu, openssl, libxml, libxslt)
     .toDirectory()
-    .pipe(makePkgConfigPathsRelative, (recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         LIBRARY_PATH: { append: [{ path: "lib" }] },
         CPATH: { append: [{ path: "include" }] },
@@ -80,20 +80,4 @@ export function liveUpdate(): std.WithRunnable {
     env: { project: JSON.stringify(project) },
     dependencies: [nushell, curl],
   });
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -126,7 +126,7 @@ export default async function python(options: PythonOptions = {}) {
     // to avoid issues with absolute paths
     (recipe) => std.recipe(fixShebangs(recipe)),
     // Fix absolute paths in pkg-config files
-    (recipe) => makePkgConfigPathsRelative(recipe),
+    (recipe) => std.pkgConfigMakePathsRelative(recipe),
     (recipe) =>
       recipe
         .insert("bin/python", std.symlink({ target: "python3" }))
@@ -232,20 +232,4 @@ async function fixShebangs(
   });
 
   return std.merge(recipe, ...pythonWrappedShebangs, ...fixedShellShebangs);
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -125,13 +125,13 @@ export default async function python(options: PythonOptions = {}) {
     // Some binaries under `/bin` are shebang scripts. These need to be wrapped
     // to avoid issues with absolute paths
     (recipe) => std.recipe(fixShebangs(recipe)),
-    // Fix absolute paths in pkg-config files
-    (recipe) => std.pkgConfigMakePathsRelative(recipe),
     (recipe) =>
       recipe
         .insert("bin/python", std.symlink({ target: "python3" }))
         .insert("bin/python-config", std.symlink({ target: "python3-config" }))
         .insert("bin/pydoc", std.symlink({ target: "pydoc3" })),
+    // Fix absolute paths in pkg-config files
+    std.pkgConfigMakePathsRelative,
     (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -24,6 +24,7 @@ export default function re2c(): std.Recipe<std.Directory> {
     .workDir(source)
     .toDirectory()
     .pipe(
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -39,7 +39,7 @@ export default function sqlite(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain)
     .toDirectory()
     .pipe(
-      makePkgConfigPathsRelative,
+      std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
           CPATH: { append: [{ path: "include" }] },
@@ -99,20 +99,4 @@ function encodeVersionNumber(version: string): string {
   );
 
   return `${major}${xx}${yy}${zz}`;
-}
-
-// TODO: Figure out where to move this, this is copied from `std`
-function makePkgConfigPathsRelative(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  // Replaces things that look like absolute paths in pkg-config files with
-  // relative paths (using the `${pcfiledir}` variable)
-  return std.runBash`
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
-      | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
-      done
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -7,5 +7,6 @@ export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
 export * from "./live_update_from_github_releases.bri";
+export * from "./pkg_config_make_paths_relative.bri";
 
 import "./extra_global.bri";

--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -1,0 +1,25 @@
+import * as std from "/core";
+import { runBash } from "./run_bash.bri";
+
+/**
+ * Create a recipe that replaces absolute paths in pkg-config files with
+ * relative paths using the `${pcfiledir}` variable.
+ *
+ * This is useful for ensuring that pkg-config files can be used in different
+ * environments without needing to modify them manually.
+ *
+ * @param recipe - The recipe to apply the transformation to.
+ * @returns A new recipe with the transformed pkg-config files.
+ */
+export function pkgConfigMakePathsRelative(
+  recipe: std.RecipeLike<std.Directory>,
+): std.Recipe<std.Directory> {
+  return runBash`
+    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+      | while IFS= read -r -d $'\\0' file; do
+        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+      done
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
+}

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -309,7 +309,7 @@ export const toolchain = std.memo(
     });
 
     toolchain = fixShebangs(toolchain);
-    toolchain = makePkgConfigPathsRelative(toolchain);
+    toolchain = pkgConfigMakePathsRelative(toolchain);
 
     return toolchain;
   },
@@ -399,7 +399,7 @@ function fixShebangs(
     .toDirectory();
 }
 
-function makePkgConfigPathsRelative(
+function pkgConfigMakePathsRelative(
   recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   // Replaces things that look like absolute paths in pkg-config files with

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -22,7 +22,7 @@ export default function talloc(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, python)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -21,7 +21,7 @@ export default function xz(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -21,7 +21,7 @@ export default function zlib(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -20,7 +20,7 @@ export default function zlibNg(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },


### PR DESCRIPTION
This PR introduces several changes to streamline the handling of `pkg-config` files across multiple packages and adds a new configuration option for CMake builds. The most significant updates include replacing custom implementations of `makePkgConfigPathsRelative` with the standardized `std.pkgConfigMakePathsRelative` utility, removing redundant code, and enhancing CMake build options to allow disabling post-build steps.

This is part of https://github.com/brioche-dev/brioche-packages/issues/136. I decided by default to run these post build steps in the `cmakeBuild` helper function. At the end, we should probably do it in an upcoming `makeBuild` helper function which will streamline the creation of packages using `make` command.

This PR follows [a discussion](https://discord.com/channels/1246413282894413844/1246522443972083832/1378212360572899439) started on Discord.