### PR TITLE
Live update refactoring

### DIFF
--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -36,5 +36,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGithubReleases({ project });
+  return std.liveUpdate({
+    strategy: std.LiveUpdateStrategy.GithubRelease,
+    project,
+  });
 }

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -6,6 +6,7 @@ export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
+export * from "./live_update.bri";
 export * from "./live_update_from_github_releases.bri";
 
 import "./extra_global.bri";

--- a/packages/std/extra/live_update.bri
+++ b/packages/std/extra/live_update.bri
@@ -1,0 +1,49 @@
+import * as std from "/core";
+import {
+  liveUpdateFromGithubReleases,
+  LiveUpdateFromGithubReleasesOptions,
+} from "./live_update_from_github_releases.bri";
+
+// The default regex used for matching tags. Strips an optional "v" prefix,
+// then matches the rest if it looks like a version number (either semver or
+// a semver-like version)
+export const DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH_TAG =
+  /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
+
+export enum LiveUpdateStrategy {
+  GithubRelease,
+}
+
+/**
+ * This interface represents the base strategy for live-updating a project.
+ * It has to be extended to support different live-update strategies.
+ *
+ * @param strategy - A enum that identifies the strategy of live-update.
+ */
+export interface LiveUpdateBaseOptions {
+  readonly strategy: LiveUpdateStrategy;
+}
+
+/**
+ * This type represents a strategy for live-updating a project.
+ * It can be extended to support different live-update strategies.
+ */
+export type LiveUpdateOptions = LiveUpdateFromGithubReleasesOptions;
+
+/**
+ * Return a runnable recipe to live-update a project.
+ *
+ * @param options - The live update strategy to use.
+ * @returns A recipe that updates the project based on the specified strategy.
+ */
+export function liveUpdate(
+  options: LiveUpdateOptions,
+): std.Recipe<std.Directory> {
+  switch (options.strategy) {
+    case LiveUpdateStrategy.GithubRelease:
+      return liveUpdateFromGithubReleases(options);
+
+    case undefined:
+      throw new Error(`Unknown live update strategy`);
+  }
+}

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -1,17 +1,30 @@
 import * as std from "/core";
 import { withRunnable } from "./runnable.bri";
+import {
+  DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH_TAG,
+  type LiveUpdateStrategy,
+  type LiveUpdateBaseOptions,
+} from "./live_update.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
 // https://github.com/brioche-dev/brioche/issues/242
 
-// The default regex used for matching tags. Strips an optional "v" prefix,
-// then matches the rest if it looks like a version number (either semver or
-// a semver-like version)
-const DEFAULT_REGEX_MATCH_TAG =
-  /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
+/**
+ * Live update strategy for updating a project based on the latest release
+ * tag from a GitHub repository.
+ *
+ * @param strategy - The strategy of live update, which is
+ * `LiveUpdateStrategy.GithubRelease`.
+ * @param project - The project export that should be updated, which must
+ * include a `repository` property containing a GitHub repository URL.
+ * @param matchTag - An optional regex value to extract the version number
+ * from a tag name.
+ */
+export interface LiveUpdateFromGithubReleasesOptions
+  extends LiveUpdateBaseOptions {
+  readonly strategy: LiveUpdateStrategy.GithubRelease;
 
-interface LiveUpdateFromGithubReleasesOptions {
   project: { version: string; repository: string };
   matchTag?: RegExp;
 }
@@ -52,7 +65,8 @@ export function liveUpdateFromGithubReleases(
   options: LiveUpdateFromGithubReleasesOptions,
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
-  const matchTag = options.matchTag ?? DEFAULT_REGEX_MATCH_TAG;
+  const matchTag =
+    options.matchTag ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH_TAG;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");


### PR DESCRIPTION
This PR introduces a new `liveUpdate` abstraction to unify and extend live-update strategies for projects. The changes include the creation of a new module and refactor existing code to use the new abstraction (only for the package `amber`).