### PR TITLE
Fix `std.pkgConfigMakePathsRelative` when `lib/pkgconfig` doesn't exist

### DIFF
--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -15,6 +15,11 @@ export function pkgConfigMakePathsRelative(
   recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   return runBash`
+    if [ ! -e "$BRIOCHE_OUTPUT"/lib/pkgconfig ]; then
+      # pkg-config dir does not exist
+      exit 0
+    fi
+
     find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
       | while IFS= read -r -d $'\\0' file; do
         sed -i 's|=/|=\${pcfiledir}/../../|' "$file"


### PR DESCRIPTION
This PR builds on #587 to fix the case where `lib/pkgconfig` doesn't exist. When it doesn't exist, the script just exits early. This should resolve the build error seen in [Build#221](https://github.com/brioche-dev/brioche-packages/actions/runs/15372048869/job/43252539211), where `cmake` failed to build, since it doesn't have a pkg-config dir