### PR TITLE
Fix live update errors

### DIFF
--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -62,10 +62,11 @@ jobs:
               git fetch --depth=1 origin "$branch_name" || echo "No existing branch for package $package"
               git checkout "origin/${branch_name}" || git checkout "${git_head}"
               git clean -ffdx
+              git restore .
               if ! brioche live-update -p "$package" --locked; then
                 echo "🔴 Failed to update $package"
                 echo "::error file=$package/project.bri::Failed to update $package"
-                failed_packages+=( "$package" )
+                failed_packages+=("$package")
                 continue
               fi
 

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -129,7 +129,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -42,7 +42,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -54,7 +54,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -67,7 +67,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/go(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/go(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -45,7 +45,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -51,7 +51,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/nasm-(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/nasm-(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -50,7 +50,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -132,7 +132,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -77,7 +77,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)(\\.(?P<patch>[\\d]+))?)'
+        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)(\\.(?P<patch>[\\d]+))?)$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -68,7 +68,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -78,7 +78,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/zziplib/project.bri
+++ b/packages/zziplib/project.bri
@@ -58,7 +58,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
         | get -i 0
       }
       | sort-by -n major minor patch


### PR DESCRIPTION
This PR fixes 2 issues with live updates:

1. Fix "Live Update" GitHub Actions workflow not cleaning up properly between packages. This caused failures e.g. in [Live Updates#27](https://github.com/brioche-dev/brioche-packages/actions/runs/15347290763), due to `git` leaving a dirty lockfile around, causing subsequent packages to fail. This PR uses `git restore .` to clean up any modified files
2. Fix regex matching across several packages. This was causing issues with git, which recently had a `v2.50.0-rc0` release. The regex for matching tags matched this release but not the `-rc0` part, which tried to live-update to `2.50.0`. The fix was to just update the regex to exclude tags with anything following the patch number in the version (a.k.a prerelease versions, which we shouldn't try to live-update to anyway)