### PR TITLE
feat(libevent): add package

### DIFF
--- a/packages/libevent/brioche.lock
+++ b/packages/libevent/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libevent/libevent": {
+      "release-2.1.12-stable": "5df3037d10556bfcb675bc73e516978b75fc7bc7"
+    }
+  }
+}

--- a/packages/libevent/project.bri
+++ b/packages/libevent/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import openssl from "openssl";
+
+export const project = {
+  name: "libevent",
+  version: "2.1.12",
+  repository: "https://github.com/libevent/libevent",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `release-${project.version}-stable`,
+});
+
+export default function libevent(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./autogen.sh
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, openssl)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libevent | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libevent)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version}-stable`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>.*)-stable$/,
+  });
+}


### PR DESCRIPTION
Add a new package [`libevent`](https://github.com/libevent/libevent): an event notification library

```bash
[container@2e2630b7574b workspace]$ bt packages/libevent/
Build finished, completed (no new jobs) in 2.85s
Result: 7b980d211b166405910f42b328e3fa9801ccde0d8beb322ee9136e590abb8c0b
[container@2e2630b7574b workspace]$ blu packages/libevent/
Build finished, completed (no new jobs) in 4.23s
Running brioche-run
{
  "name": "libevent",
  "version": "2.1.12",
  "repository": "https://github.com/libevent/libevent"
}
```