### PR TITLE
feat(editline): add package

### DIFF
--- a/packages/editline/brioche.lock
+++ b/packages/editline/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/troglobit/editline": {
+      "1.17.1": "ecabef273ebf4193c5d6aff196de1c204169bc52"
+    }
+  }
+}

--- a/packages/editline/project.bri
+++ b/packages/editline/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+
+export const project = {
+  name: "editline",
+  version: "1.17.1",
+  repository: "https://github.com/troglobit/editline",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function editline(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./autogen.sh
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libeditline | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, editline)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`editline`](https://github.com/troglobit/editline): a small replacement for GNU readline() for UNIX

```bash
[container@0f0fc8649678 workspace]$ blu packages/editline/
Build finished, completed (no new jobs) in 4.05s
Running brioche-run
{
  "name": "editline",
  "version": "1.17.1",
  "repository": "https://github.com/troglobit/editline"
}
[container@0f0fc8649678 workspace]$ bt packages/editline/
Build finished, completed (no new jobs) in 1.70s
Result: f95a716ffcade281bfc188ada498d6a1f928912570c75e56cf8fad58fb3d638e
```