### PR TITLE
feat(toml11): add package

### DIFF
--- a/packages/toml11/brioche.lock
+++ b/packages/toml11/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/ToruNiina/toml11": {
+      "v4.4.0": "be08ba2be2a964edcdb3d3e3ea8d100abc26f286"
+    }
+  }
+}

--- a/packages/toml11/project.bri
+++ b/packages/toml11/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "toml11",
+  version: "4.4.0",
+  repository: "https://github.com/ToruNiina/toml11",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function toml11(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "lib/cmake" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.file(std.indoc`
+    cmake_minimum_required(VERSION 4.0)
+    project(QueryVersion)
+
+    find_package(toml11 REQUIRED CONFIG)
+    message(STATUS "toml11 version: \${toml11_VERSION}")
+  `);
+
+  const script = std.runBash`
+    cp "$src" CMakeLists.txt
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cmake, toml11)
+    .env({ src: src })
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `toml11 version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`toml11`](https://github.com/ToruNiina/toml11): TOML for Modern C++

```bash
[container@0f0fc8649678 workspace]$ blu packages/toml11/
Build finished, completed (no new jobs) in 4.12s
Running brioche-run
{
  "name": "toml11",
  "version": "4.4.0",
  "repository": "https://github.com/ToruNiina/toml11"
}
[container@0f0fc8649678 workspace]$ bt packages/toml11/
Build finished, completed (no new jobs) in 1.88s
Result: a685197f6323b6e527a5a997481dc0c1f5fbf98f057cdefc50836698a6a7a430
```