### PR TITLE
Fix a possible bad symlink of lib64 folder with cmakeBuild()

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -183,13 +183,11 @@ export function cmakeBuild(
     cmake --install . --prefix="$BRIOCHE_OUTPUT"
 
     if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
-      if [ ! -d "$BRIOCHE_OUTPUT/lib" ]; then
-        ln -s lib64 "$BRIOCHE_OUTPUT/lib"
-      else
-        # If lib directory already exists, we symlink the contents
-        # of lib64 into it.
-        cp -as "$BRIOCHE_OUTPUT/lib64/." "$BRIOCHE_OUTPUT/lib/"
-      fi
+      # Ensure the lib folder exists
+      mkdir -p "$BRIOCHE_OUTPUT/lib"
+
+      # Create relative symlinks for lib64 contents to lib folder
+      ln --symbolic --relative "$BRIOCHE_OUTPUT"/lib64/* "$BRIOCHE_OUTPUT/lib/"
     fi
   `
     .dependencies(...dependencies, cmake)

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -183,7 +183,13 @@ export function cmakeBuild(
     cmake --install . --prefix="$BRIOCHE_OUTPUT"
 
     if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
-      ln -s lib64 "$BRIOCHE_OUTPUT/lib"
+      if [ ! -d "$BRIOCHE_OUTPUT/lib" ]; then
+        ln -s lib64 "$BRIOCHE_OUTPUT/lib"
+      else
+        # If lib directory already exists, we symlink the contents
+        # of lib64 into it.
+        cp -as "$BRIOCHE_OUTPUT/lib64/." "$BRIOCHE_OUTPUT/lib/"
+      fi
     fi
   `
     .dependencies(...dependencies, cmake)

--- a/packages/libgit2/project.bri
+++ b/packages/libgit2/project.bri
@@ -27,8 +27,8 @@ export default function libgit2(): std.Recipe<std.Directory> {
   }).pipe((recipe) =>
     std.setEnv(recipe, {
       CPATH: { append: [{ path: "include" }] },
-      LIBRARY_PATH: { append: [{ path: "lib64" }] },
-      PKG_CONFIG_PATH: { append: [{ path: "lib64/pkgconfig" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
     }),
   );
 }


### PR DESCRIPTION
Resolve an issue when using `cmakeBuild` when `lib`already exists and we want to symlink `lib64` folder.

Before (when building `libgit2` package):

```bash
[container@0f0fc8649678 workspace]$ ls /tmp/output/lib/
cmake/ lib64
[container@0f0fc8649678 workspace]$ ls /tmp/output/lib64
libgit2.so  libgit2.so.1.9  libgit2.so.1.9.0  pkgconfig

[container@0f0fc8649678 workspace]$ ls -al /tmp/output/lib/lib64
lrwxrwxrwx 1 container container 5 Jun  1 19:33 /tmp/output/lib/lib64 -> lib64
```


After (when building `libgit2` package):

```bash
[container@0f0fc8649678 workspace]$ ls /tmp/output/lib
cmake  libgit2.so  libgit2.so.1.9  libgit2.so.1.9.0  pkgconfig
[container@0f0fc8649678 workspace]$ ls /tmp/output/lib64
libgit2.so  libgit2.so.1.9  libgit2.so.1.9.0  pkgconfig

[container@0f0fc8649678 workspace]$ ls -al /tmp/output/lib
total 28
drwxr-xr-x 4 container container 4096 Jun  1 19:57 .
drwxr-xr-x 8 container container 4096 Jun  1 19:57 ..
drwxr-xr-x 3 container container 4096 Jun  1 19:57 cmake
lrwxrwxrwx 1 container container  205 Jun  1 19:57 libgit2.so -> /home/brioche-runner-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/.local/share/brioche/outputs/output-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/lib64/./libgit2.so
lrwxrwxrwx 1 container container  209 Jun  1 19:57 libgit2.so.1.9 -> /home/brioche-runner-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/.local/share/brioche/outputs/output-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/lib64/./libgit2.so.1.9
lrwxrwxrwx 1 container container  211 Jun  1 19:57 libgit2.so.1.9.0 -> /home/brioche-runner-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/.local/share/brioche/outputs/output-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/lib64/./libgit2.so.1.9.0
drwxr-xr-x 2 container container 4096 Jun  1 19:57 pkgconfig

[container@0f0fc8649678 workspace]$ ls -al /tmp/output/lib/pkgconfig/
total 12
drwxr-xr-x 2 container container 4096 Jun  1 19:57 .
drwxr-xr-x 4 container container 4096 Jun  1 19:57 ..
lrwxrwxrwx 1 container container  215 Jun  1 19:57 libgit2.pc -> /home/brioche-runner-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/.local/share/brioche/outputs/output-304fde3b5ae78859c0211792db1fa6b111c832db8d0c417ec6137360daefb0a8/lib64/./pkgconfig/libgit2.pc
```