### PR TITLE
refactor(curl): remove unnecessary CMAKE_PREFIX_PATH

### DIFF
--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -16,6 +16,11 @@ const source = Brioche.download(
   .unarchive("tar", "gzip")
   .peel();
 
+/**
+ * Options for the curl package.
+ *
+ * @property minimal - If set to true, will build curl with only the minimum required dependencies.
+ */
 interface CurlOptions {
   minimal?: boolean;
 }
@@ -24,9 +29,7 @@ interface CurlOptions {
  * Builds the curl package. By default, this will build with all the optional
  * dependencies enabled.
  *
- * ## Options
- *
- * - `minimal`: If set, will only build with the minimum required dependencies.
+ * @param options - Options to configure the build.
  */
 export default function curl(
   options: CurlOptions = {},

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -65,7 +65,6 @@ export default function curl(
           CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
-          CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
           CURL_ROOT: { fallback: { path: "." } },
         }),
       (recipe) => std.withRunnableLink(recipe, "bin/curl"),


### PR DESCRIPTION
As shown below, there is no need to expose `CMAKE_PREFIX_PATH` in the `curl` recipe, since there is no CMake files present.

```bash
[container@fd7763c91f9e workspace]$ bb packages/curl
Build finished, completed (no new jobs) in 1.84s
Result: 3ef6623484d67f7cdca559b6261400a85564f8390fa034bc39ebdf56a11db755
Writing output
Wrote output to /tmp/output
[container@fd7763c91f9e workspace]$ find /tmp/output -name "*.cmake"
```