### PR TITLE
chore(libcap): remove unnecessary parenthesis for dependencies

### DIFF
--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -34,7 +34,7 @@ export default function libcap(): std.Recipe<std.Directory> {
       DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
-    .dependencies(std.toolchain(), std.runtimeUtils(), briocheObjcopy())
+    .dependencies(std.toolchain, std.runtimeUtils, briocheObjcopy)
     .toDirectory()
     .pipe(
       std.pkgConfigMakePathsRelative,


### PR DESCRIPTION
Nothing else.