### PR TITLE
feat(nlohmannJson): add package

### DIFF
--- a/packages/nlohmann_json/brioche.lock
+++ b/packages/nlohmann_json/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nlohmann/json.git": {
+      "v3.12.0": "55f93686c01528224f448c19128836e7df245f72"
+    }
+  }
+}

--- a/packages/nlohmann_json/project.bri
+++ b/packages/nlohmann_json/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "nlohmann_json",
+  version: "3.12.0",
+  repository: "https://github.com/nlohmann/json.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function nlohmannJson(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // By default, the data directory will be set to "share", but we want it to be "lib"
+      CMAKE_INSTALL_DATADIR: "lib",
+      JSON_BuildTests: "OFF",
+      JSON_MultipleHeaders: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "lib/cmake" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion nlohmann_json | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, nlohmannJson)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new recipe [`nlohmann_json`](https://github.com/nlohmann/json): JSON for Modern C++

```bash
[container@f36faaa936d4 workspace]$ bt packages/nlohmann_json/
Build finished, completed (no new jobs) in 2.00s
Result: 19936c49a3847e8d2a9c102358ec89cb1abf772ed96baee657a24a7d6c7283e0
[container@f36faaa936d4 workspace]$ blu packages/nlohmann_json/
Build finished, completed (no new jobs) in 4.26s
Running brioche-run
{
  "name": "nlohmann_json",
  "version": "3.12.0",
  "repository": "https://github.com/nlohmann/json.git"
}
```