### PR TITLE
feat(iamlive): add package

### DIFF
--- a/packages/iamlive/brioche.lock
+++ b/packages/iamlive/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/iann0036/iamlive.git": {
+      "v1.1.24": "8c1356ea736c5b57cf8dbc98b64d76c1989ef5f2"
+    }
+  }
+}

--- a/packages/iamlive/project.bri
+++ b/packages/iamlive/project.bri
@@ -1,0 +1,38 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "iamlive",
+  version: "1.1.24",
+  repository: "https://github.com/iann0036/iamlive.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function iamlive(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/iamlive",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // iamlive does not provide any version command, so the help command is used to verify the installation.
+  const script = std.runBash`
+    iamlive -help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(iamlive)
+    .toFile();
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Adding [iamlive](https://github.com/iann0036/iamlive)
Note: the test command calls `-help` because of not having a version flag/command.
```bash
brioche build -e test
154995 │   -debug
       │     dumps associated HTTP requests when set in proxy mode
       │   -fails-only
       │     when set, only failed AWS calls will be added to the policy, csm mode only
       │   -force-wildcard-resource
       │     when set, the Resource will always be a wildcard
       │   -host string
       │     host to listen on for CSM (default "127.0.0.1")
       │   -mode string
       │     the listening mode (csm,proxy) (default "csm")
       │   -output-file string
       │     specify a file that will be written to on SIGHUP or exit
       │   -override-aws-map string
       │     overrides the embedded AWS mapping JSON file with the filepath provided
       │   -profile string
       │     use the specified profile when combined with --set-ini (default "default")
       │   -provider string
       │     the cloud service provider to intercept calls for (default "aws")
       │   -refresh-rate int
       │     instead of flushing to console every API call, do it this number of seconds
       │   -set-ini
       │     when set, the .aws/config file will be updated to use the CSM monitoring or CA bundle and removed when exiting
       │   -sort-alphabetical
       │     sort actions alphabetically
 0.03s ✓ Process 154995
Build finished, completed 1 job in 1.00s
Result: beffb02b8f56545d0f99e2906f92feccb668bc5a31e74d06f6f27c4965119153
```