### PR TITLE
feat(blake3): add package

### DIFF
--- a/packages/blake3/brioche.lock
+++ b/packages/blake3/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/BLAKE3-team/BLAKE3.git": {
+      "1.8.2": "df610ddc3b93841ffc59a87e3da659a15910eb46"
+    }
+  }
+}

--- a/packages/blake3/project.bri
+++ b/packages/blake3/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "blake3",
+  version: "1.8.2",
+  repository: "https://github.com/BLAKE3-team/BLAKE3.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function blake3(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    path: "c",
+    dependencies: [std.toolchain],
+    set: {
+      BLAKE3_USE_TBB: "ON",
+      BLAKE3_EXAMPLES: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libblake3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, blake3)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`blake3`](https://github.com/BLAKE3-team/BLAKE3): the official Rust and C implementations of the BLAKE3 cryptographic hash function

```bash
[container@1ea5fc976642 workspace]$ blu packages/blake3/
Build finished, completed (no new jobs) in 4.85s
Running brioche-run
{
  "name": "blake3",
  "version": "1.8.2",
  "repository": "https://github.com/BLAKE3-team/BLAKE3.git"
}
[container@1ea5fc976642 workspace]$ bt packages/blake3/
2544   │ 1.8.2
 0.11s ✓ Process 2544
Build finished, completed 1 job in 2.86s
Result: 3f122b72902789273f2439b9928bad9992270e91ebeb790ad04788af9258807a
```