### PR TITLE
feat(boost): add package

### DIFF
--- a/packages/boost/brioche.lock
+++ b/packages/boost/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-b2-nodocs.tar.xz": {
+      "type": "sha256",
+      "value": "ad9ce2c91bc0977a7adc92d51558f3b9c53596bb88246a280175ebb475da1762"
+    }
+  }
+}

--- a/packages/boost/project.bri
+++ b/packages/boost/project.bri
@@ -1,0 +1,73 @@
+import * as std from "std";
+import cmake from "cmake";
+
+export const project = {
+  name: "boost",
+  version: "1.88.0",
+  repository: "https://github.com/boostorg/boost",
+};
+
+const source = Brioche.download(
+  `https://github.com/boostorg/boost/releases/download/boost-${project.version}/boost-${project.version}-b2-nodocs.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function boost(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./bootstrap.sh --prefix="$BRIOCHE_OUTPUT"
+    ./b2 \
+      --prefix="$BRIOCHE_OUTPUT" \
+      -j8 \
+      --layout=system \
+      install \
+      variant=release \
+      threading=multi
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.file(std.indoc`
+    cmake_minimum_required(VERSION 4.0)
+    project(QueryVersion)
+
+    find_package(Boost REQUIRED CONFIG)
+    message(STATUS "Boost version: \${Boost_VERSION}")
+  `);
+
+  const script = std.runBash`
+    cp "$src" CMakeLists.txt
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cmake, boost)
+    .env({ src: src })
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Boost version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^boost-(?<version>.*)$/,
+  });
+}


### PR DESCRIPTION
Add a new package [`boost`](https://github.com/boostorg/boost): provides free peer-reviewed portable C++ source libraries

```bash
[container@1ea5fc976642 workspace]$ bt packages/boost/
Build finished, completed (no new jobs) in 1.71s
Result: 5da2013f5155b281439281bfb89254ddd4e4226c9a2b3122a57aef2f4cd610dc
[container@1ea5fc976642 workspace]$ blu packages/boost/
Build finished, completed (no new jobs) in 4.43s
Running brioche-run
{
  "name": "boost",
  "version": "1.88.0",
  "repository": "https://github.com/boostorg/boost"
}
```