### PR TITLE
chore: add explicit type signatures to examples' export

### DIFF
--- a/examples/c_hello/project.bri
+++ b/examples/c_hello/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 
-export default () => {
+export default function (): std.Recipe<std.Directory> {
   // Compile main.c to bin/hello:
   // - gcc comes from `std.toolchain`
   // - `workDir` is used to bring in the `src` directory
@@ -11,5 +11,6 @@ export default () => {
     ln -s "bin/hello" "$BRIOCHE_OUTPUT/brioche-run"
   `
     .dependencies(std.toolchain)
-    .workDir(Brioche.glob("src"));
+    .workDir(Brioche.glob("src"))
+    .toDirectory();
 };

--- a/examples/go_cli/project.bri
+++ b/examples/go_cli/project.bri
@@ -1,6 +1,7 @@
+import * as std from "std";
 import { goBuild } from "go";
 
-export default function () {
+export default function (): std.Recipe<std.Directory> {
   return goBuild({
     source: Brioche.glob("**/*.go", "go.mod", "go.sum"),
     runnable: "bin/go_cli",

--- a/examples/nodejs_frontend/project.bri
+++ b/examples/nodejs_frontend/project.bri
@@ -34,7 +34,7 @@ export function staticSite(): std.Recipe<std.Directory> {
 }
 
 // Build the static site and serve it
-export default () => {
+export default function (): std.BashRunnable {
   // This script gets called when using `brioche run`. This will serve
   // the static site locally using miniserve
   return std.bashRunnable`

--- a/examples/rust_backend/project.bri
+++ b/examples/rust_backend/project.bri
@@ -1,14 +1,14 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
 
-export default function server() {
+export default function server(): std.Recipe<std.Directory> {
   return cargoBuild({
     source: Brioche.glob("src", "Cargo.*"),
     runnable: "bin/rust_backend",
   });
 }
 
-export function container() {
+export function container(): std.Recipe<std.File> {
   return std.ociContainerImage({
     recipe: server(),
   });

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -42,7 +42,7 @@ export interface BashRunnableUtils {
  * import * as std from "std";
  *
  * // Running `brioche run` will print "Hello, world!"
- * export default function () {
+ * export default function (): std.BashRunnable {
  *   return std.bashRunnable`
  *     echo "Hello, world!"
  *   `;


### PR DESCRIPTION
Just to enforce the signatures of functions found in the examples. It'll help `brioche check` for better checking possible unwanted mismatches