### PR TITLE
feat(krb5): add package

### DIFF
--- a/packages/krb5/brioche.lock
+++ b/packages/krb5/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz": {
+      "type": "sha256",
+      "value": "b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
+    }
+  }
+}

--- a/packages/krb5/project.bri
+++ b/packages/krb5/project.bri
@@ -1,0 +1,91 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "krb5",
+  version: "1.21.3",
+  extra: {
+    majorVersion: "1",
+    minorVersion: "21",
+  },
+};
+
+// Ensure the major version number matches the version
+std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+// Ensure the minor version number matches the version
+std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+
+const source = Brioche.download(
+  `https://kerberos.org/dist/krb5/${project.extra.majorVersion}.${project.extra.minorVersion}/krb5-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function krb5(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./src/configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/krb5-config"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion krb5 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, krb5)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://web.mit.edu/Kerberos/
+      | lines
+      | where {|it| $it | str contains 'Current release: <A HREF="krb5-' }
+      | parse --regex '<A HREF="krb5-.+/">krb5-(?<version>.+)</A>'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+      let majorVersion = $version
+        | split words
+        | get 0
+      let minorVersion = $version
+        | split words
+        | get 1
+
+      $env.project
+        | from json
+        | update version $version
+        | update extra.majorVersion $majorVersion
+        | update extra.minorVersion $minorVersion
+        | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`krb5`](https://web.mit.edu/Kerberos/): kerberos is a network authentication protocol.

```bash
[container@b2ec1fbd59c7 workspace]$ blu packages/krb5/
Build finished, completed (no new jobs) in 4.55s
Running brioche-run
{
  "name": "krb5",
  "version": "1.21.3",
  "extra": {
    "majorVersion": "1",
    "minorVersion": "21"
  }
}
[container@b2ec1fbd59c7 workspace]$ bt packages/krb5/
60993  │ 1.21.3
 0.11s ✓ Process 60993
Build finished, completed 1 job in 24.13s
Result: 35ffee22e65e83967d8b3521cd10f87060079206a858020f0ffade5a68da05a0
```