### PR TITLE
feat(libyaml): add package

### DIFF
--- a/packages/libyaml/brioche.lock
+++ b/packages/libyaml/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/yaml/libyaml": {
+      "0.2.5": "2c891fc7a770e8ba2fec34fc6b545c672beb37e6"
+    }
+  }
+}

--- a/packages/libyaml/project.bri
+++ b/packages/libyaml/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+
+export const project = {
+  name: "libyaml",
+  version: "0.2.5",
+  repository: "https://github.com/yaml/libyaml",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libyaml(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./bootstrap
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion yaml-0.1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libyaml)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libyaml`](https://github.com/yaml/libyaml): a C library for parsing and emitting YAML.

```bash
[container@b2ec1fbd59c7 workspace]$ blu packages/libyaml/
 INFO run_build: brioche::run: updated lockfiles num_lockfiles_updated=1
 0.09s ✓ Process 63962
Build finished, completed 1 job in 6.40s
Running brioche-run
{
  "name": "libyaml",
  "version": "0.2.5",
  "repository": "https://github.com/yaml/libyaml"
}
[container@b2ec1fbd59c7 workspace]$ bt packages/libyaml/
68219  │ 0.2.5
 0.11s ✓ Process 68219
Build finished, completed 1 job in 2.67s
Result: b2961ab520a27b9ec889c696e8ac1847c0d92148c24935a04385e1576ec01629
```