### PR TITLE
[jujutsu] Upgrade to v0.30.0

### DIFF
--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/jj-vcs/jj.git": {
-      "v0.29.0": "94269d2e7228ff502b2116258e5ae6b3b07ec434"
+      "v0.30.0": "34b0961c940e1ad3be5cd9c5f5e608b0aa0ba859"
     }
   }
 }

--- a/packages/jujutsu/brioche.lock
+++ b/packages/jujutsu/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/martinvonz/jj.git": {
+    "https://github.com/jj-vcs/jj.git": {
       "v0.29.0": "94269d2e7228ff502b2116258e5ae6b3b07ec434"
     }
   }

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -5,7 +5,7 @@ import { cargoBuild } from "rust";
 export const project = {
   name: "jujutsu",
   version: "0.29.0",
-  repository: "https://github.com/martinvonz/jj.git",
+  repository: "https://github.com/jj-vcs/jj.git",
 };
 
 const source = Brioche.gitCheckout({

--- a/packages/jujutsu/project.bri
+++ b/packages/jujutsu/project.bri
@@ -1,10 +1,9 @@
 import * as std from "std";
-import openssl from "openssl";
 import { cargoBuild } from "rust";
 
 export const project = {
   name: "jujutsu",
-  version: "0.29.0",
+  version: "0.30.0",
   repository: "https://github.com/jj-vcs/jj.git",
 };
 
@@ -18,7 +17,6 @@ export default function jujutsu(): std.Recipe<std.Directory> {
     source,
     runnable: "bin/jj",
     path: "cli",
-    dependencies: [openssl],
   });
 }
 


### PR DESCRIPTION
This PR upgrades the `jujutsu` package to [v0.30.0](https://github.com/jj-vcs/jj/releases/tag/v0.30.0)

From the release notes, jj no longer depends on `openssl`, so I manually removed it as a dependency. Also, I updated the repo URL (from https://github.com/martinvonz/jj.git, which now redirects to https://github.com/jj-vcs/jj.git)