### PR TITLE
feat(gmp): add package

### DIFF
--- a/packages/gmp/brioche.lock
+++ b/packages/gmp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz": {
+      "type": "sha256",
+      "value": "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+    }
+  }
+}

--- a/packages/gmp/project.bri
+++ b/packages/gmp/project.bri
@@ -1,0 +1,73 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "gmp",
+  version: "6.3.0",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/gmp/gmp-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function gmp(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --with-pic \
+      --enable-cxx
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion gmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gmp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/gmp
+      | lines
+      | where {|it| ($it | str contains "gmp-") and ($it | str contains ".xz") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="gmp-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package (already part of the std.toolchain) [`gmp`](https://gmplib.org): a free library for arbitrary precision arithmetic

```bash
[container@85c0ffe2427d workspace]$ blu packages/gmp
Build finished, completed (no new jobs) in 4.30s
Running brioche-run
{
  "name": "gmp",
  "version": "6.3.0"
}
[container@85c0ffe2427d workspace]$ bt packages/gmp
Build finished, completed (no new jobs) in 1.57s
Result: 435b733966880a7fdd31e651904b154333692a331a028d5fd2698d39672204cc
```