### PR TITLE
feat(ncurses): add package

### DIFF
--- a/packages/ncurses/brioche.lock
+++ b/packages/ncurses/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz": {
+      "type": "sha256",
+      "value": "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
+    }
+  }
+}

--- a/packages/ncurses/project.bri
+++ b/packages/ncurses/project.bri
@@ -1,0 +1,82 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "ncurses",
+  version: "6.5",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/ncurses/ncurses-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function ncurses(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --without-debug \
+      --with-shared \
+      --with-cxx-shared \
+      --with-versioned-syms \
+      --enable-sigwinch \
+      --enable-symlinks \
+      --enable-pc-files \
+      --enable-widec \
+      --with-pkg-config-libdir=/lib/pkgconfig
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion ncursesw | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, ncurses)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version}.`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/ncurses
+      | lines
+      | where {|it| ($it | str contains "ncurses-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="ncurses-(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package (already part of the std.toolchain) [`ncurses`](https://invisible-island.net/ncurses/announce.html):  a free software emulation of curses in System V Release 4.0 (SVr4), and more

```bash
[container@85c0ffe2427d workspace]$ blu packages/ncurses/
Build finished, completed (no new jobs) in 4.04s
Running brioche-run
{
  "name": "ncurses",
  "version": "6.5"
}
[container@85c0ffe2427d workspace]$ bt packages/ncurses/
Build finished, completed (no new jobs) in 1.59s
Result: a0122cca7541a0218e61541121788cfdb22636f86b6c88522411bee0b9b5bcaf
```