### PR TITLE
feat(libfaketime): add package

### DIFF
--- a/packages/libfaketime/brioche.lock
+++ b/packages/libfaketime/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/wolfcw/libfaketime": {
+      "v0.9.11": "6714b98794a9e8a413bf90d2927abf5d888ada99"
+    }
+  }
+}

--- a/packages/libfaketime/project.bri
+++ b/packages/libfaketime/project.bri
@@ -9,7 +9,14 @@ export const project = {
 const source = Brioche.gitCheckout({
   repository: project.repository,
   ref: `v${project.version}`,
-});
+}).pipe((source) =>
+  // Patch the source to fix the finding of the library path
+  std.applyPatch({
+    source,
+    patch: Brioche.includeFile("resolve-library-path.patch"),
+    strip: 1,
+  }),
+);
 
 export default function libfaketime(): std.Recipe<std.Directory> {
   return std.runBash`

--- a/packages/libfaketime/project.bri
+++ b/packages/libfaketime/project.bri
@@ -23,7 +23,6 @@ export default function libfaketime(): std.Recipe<std.Directory> {
     .pipe(
       (recipe) =>
         std.setEnv(recipe, {
-          CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
         }),
       (recipe) => std.withRunnableLink(recipe, "bin/faketime"),

--- a/packages/libfaketime/project.bri
+++ b/packages/libfaketime/project.bri
@@ -36,23 +36,72 @@ export default function libfaketime(): std.Recipe<std.Directory> {
     );
 }
 
-export async function test(): Promise<std.Recipe<std.File>> {
-  const script = std.runBash`
+export function test(): std.Recipe<std.Directory> {
+  const tests: (() => Promise<std.Recipe<std.Directory>>)[] = [];
+
+  // 1. Validate the library version
+  tests.push(async () => {
+    const script = std.runBash`
     faketime --version | tee "$BRIOCHE_OUTPUT"
   `
-    .dependencies(libfaketime)
-    .toFile();
+      .dependencies(libfaketime)
+      .toFile();
 
-  const result = (await script.read()).trim();
+    const result = (await script.read()).trim();
 
-  // Check that the result contains the expected version
-  const expected = `Version ${project.version}`;
-  std.assert(
-    result.includes(expected),
-    `expected '${expected}', got '${result}'`,
-  );
+    // Check that the result contains the expected version
+    const expected = `Version ${project.version}`;
+    std.assert(
+      result.includes(expected),
+      `expected '${expected}', got '${result}'`,
+    );
 
-  return script;
+    return std.directory().insert("version-check", script);
+  });
+
+  // 2. Validate the binary functionality when used as standalone
+  tests.push(async () => {
+    const script = std.runBash`
+      faketime "2000-01-01 00:00:00" date | tee "$BRIOCHE_OUTPUT"
+  `
+      .dependencies(libfaketime)
+      .env({
+        // Needed because `date` dynamically opens `libm.so.6`,
+        // which is not directly a dependency
+        LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
+      })
+      .toFile();
+
+    const result = (await script.read()).trim();
+
+    // Check that the result contains the expected output
+    std.assert(result === "Sat Jan  1 00:00:00 UTC 2000");
+
+    return std.directory().insert("standalone-mode", script);
+  });
+
+  // 3. Validate the library functionality when used with LD_PRELOAD
+  tests.push(async () => {
+    const script = std.runBash`
+      FAKETIME="@2000-01-01 00:00:00" date | tee "$BRIOCHE_OUTPUT"
+    `
+      .env({
+        // Needed because `date` dynamically opens `libm.so.6`,
+        // which is not directly a dependency
+        LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
+        LD_PRELOAD: std.tpl`${libfaketime}/lib/faketime/libfaketime.so.1`,
+      })
+      .toFile();
+
+    const result = (await script.read()).trim();
+
+    // Check that the result contains the expected output
+    std.assert(result === "Sat Jan  1 00:00:00 UTC 2000");
+
+    return std.directory().insert("ld-preload-mode", script);
+  });
+
+  return std.merge(...tests);
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {

--- a/packages/libfaketime/project.bri
+++ b/packages/libfaketime/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+
+export const project = {
+  name: "libfaketime",
+  version: "0.9.11",
+  repository: "https://github.com/wolfcw/libfaketime",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libfaketime(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make install \
+      PREFIX=/ \
+      DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/faketime"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    faketime --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(libfaketime)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/libfaketime/resolve-library-path.patch
+++ b/packages/libfaketime/resolve-library-path.patch
@@ -1,0 +1,53 @@
+diff --git a/src/faketime.c b/src/faketime.c
+index ce7925b..d443950 100644
+--- a/src/faketime.c
++++ b/src/faketime.c
+@@ -40,6 +40,7 @@
+ #include <string.h>
+ #include <time.h>
+ #include <fcntl.h>
++#include <libgen.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+@@ -368,23 +369,33 @@ int main (int argc, char **argv)
+          * on MultiArch platforms, such as Debian, we put a literal $LIB into LD_PRELOAD.
+          */
+ #ifndef MULTI_ARCH
+-        ftpl_path = PREFIX LIBDIRNAME "/libfaketimeMT.so.1";
++        ftpl_path = "/.." LIBDIRNAME "/libfaketimeMT.so.1";
+ #else
+-        ftpl_path = PREFIX "/$LIB/faketime/libfaketimeMT.so.1";
++        ftpl_path = "/.." "/$LIB/faketime/libfaketimeMT.so.1";
+ #endif
+       }
+       else
+       {
+ #ifndef MULTI_ARCH
+-        ftpl_path = PREFIX LIBDIRNAME "/libfaketime.so.1";
++        ftpl_path = "/.." LIBDIRNAME "/libfaketime.so.1";
+ #else
+-        ftpl_path = PREFIX "/$LIB/faketime/libfaketime.so.1";
++        ftpl_path = "/.." "/$LIB/faketime/libfaketime.so.1";
+ #endif
+       }
+-      len = ((ld_preload)?strlen(ld_preload) + 1: 0) + 1 + strlen(ftpl_path);
++      char directory_path[PATH_BUFSIZE];
++      ssize_t directory_path_len = readlink("/proc/self/exe", directory_path, PATH_BUFSIZE - 1);
++      if (directory_path_len == -1 || directory_path_len >= (ssize_t)PATH_BUFSIZE)
++      {
++          perror("faketime: readlink");
++          exit(EXIT_FAILURE);
++      }
++      directory_path[directory_path_len] = '\0';
++      (void)dirname(directory_path);
++
++      len = ((ld_preload)?strlen(ld_preload) + 1: 0) + 1 + strlen(directory_path) + strlen(ftpl_path);
+       ld_preload_new = malloc(len);
+-      snprintf(ld_preload_new, len ,"%s%s%s", (ld_preload)?ld_preload:"",
+-              (ld_preload)?":":"", ftpl_path);
++      snprintf(ld_preload_new, len ,"%s%s%s%s", (ld_preload)?ld_preload:"",
++              (ld_preload)?":":"", directory_path, ftpl_path);
+       setenv("LD_PRELOAD", ld_preload_new, true);
+       free(ld_preload_new);
+     }


### PR DESCRIPTION
Add a new package [`libfaketime`](https://github.com/wolfcw/libfaketime): libfaketime modifies the system time for a single application

```bash
[container@bbf67fa58b38 workspace]$ bt packages/libfaketime/
880    │ faketime: Version 0.9.11
       │ For usage information please use 'faketime --help'.
 0.11s ✓ Process 880
Build finished, completed 1 job in 2.78s
Result: ac4a56db725ea7d23087d32a280bf45e79ec696b7d02fea0d67d0276b6c442d9
[container@bbf67fa58b38 workspace]$ blu packages/libfaketime/
 0.06s ✓ Process 946
Build finished, completed 1 job in 5.34s
Running brioche-run
{
  "name": "libfaketime",
  "version": "0.9.11",
  "repository": "https://github.com/wolfcw/libfaketime"
}
```