### PR TITLE
chore(iamlive): add at least one assertion in the test

### DIFF
--- a/packages/iamlive/project.bri
+++ b/packages/iamlive/project.bri
@@ -25,10 +25,15 @@ export default function iamlive(): std.Recipe<std.Directory> {
 export async function test(): Promise<std.Recipe<std.File>> {
   // iamlive does not provide any version command, so the help command is used to verify the installation.
   const script = std.runBash`
-    iamlive -help | tee "$BRIOCHE_OUTPUT"
+    iamlive -help 2>&1 | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(iamlive)
     .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
 
   return script;
 }


### PR DESCRIPTION
Add at least one assertion in the test method of `iamlive`. Even if the package doesn't output any version, at least we should assert that it outputs something. Not ideal, but better than nothing I guess.