### PR TITLE
feat(yamlLanguageServer): add package

### DIFF
--- a/packages/yaml_language_server/brioche.lock
+++ b/packages/yaml_language_server/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/yaml_language_server/project.bri
+++ b/packages/yaml_language_server/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "yaml_language_server",
+  version: "1.18.0",
+  packageName: "yaml-language-server",
+};
+
+export default function yamlLanguageServer(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/yaml-language-server"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // The package does not provide any version no help commands,
+  // so we will run the server and check that it starts with error output.
+  const script = std.runBash`
+    (yaml-language-server 2>&1 || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(yamlLanguageServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "Error: Connection input stream is not set.";
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.packageName}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`yaml_language_server`](https://github.com/redhat-developer/yaml-language-server): a Language Server for YAML Files

```bash
[container@a46679c949d8 workspace]$ blu packages/yaml_language_server/
Build finished, completed (no new jobs) in 4.42s
Running brioche-run
{
  "name": "yaml_language_server",
  "version": "1.18.0",
  "packageName": "yaml-language-server"
}
[container@a46679c949d8 workspace]$ bt packages/yaml_language_server/
Build finished, completed (no new jobs) in 4.01s
Result: 11c4385a9ae296aad626e1c69239d0e2b98ca544cf0c29fbad3730ba13c19f6b
```