### PR TITLE
feat(cyrus_sasl): add package

### DIFF
--- a/packages/cyrus_sasl/brioche.lock
+++ b/packages/cyrus_sasl/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.28/cyrus-sasl-2.1.28.tar.gz": {
+      "type": "sha256",
+      "value": "7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c"
+    }
+  }
+}

--- a/packages/cyrus_sasl/project.bri
+++ b/packages/cyrus_sasl/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import krb5 from "krb5";
+import openssl from "openssl";
+
+export const project = {
+  name: "cyrus_sasl",
+  version: "2.1.28",
+  repository: "https://github.com/cyrusimap/cyrus-sasl",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/cyrus-sasl-${project.version}/cyrus-sasl-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cyrusSasl(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, krb5, openssl)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libsasl2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cyrusSasl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^cyrus-sasl-(?<version>.*)$/,
+  });
+}


### PR DESCRIPTION
Add a new package [`cyrus_sasl`](https://github.com/cyrusimap/cyrus-sasl): the Cyrus SASL API implementation. It can be used on the client or server side to provide authentication and authorization services.

```bash
[container@16d1c691fbce workspace]$ blu packages/cyrus_sasl/
Build finished, completed (no new jobs) in 4.56s
Running brioche-run
{
  "name": "cyrus_sasl",
  "version": "2.1.28",
  "repository": "https://github.com/cyrusimap/cyrus-sasl"
}
[container@16d1c691fbce workspace]$ bt packages/cyrus_sasl/
Build finished, completed (no new jobs) in 1.54s
Result: b0e1cc6862a85954a16c14aa412f45a78dcf53a458eb8d46c36ebbfc3b86f16e
```