### PR TITLE
feat(dependabot): add package

### DIFF
--- a/packages/dependabot/brioche.lock
+++ b/packages/dependabot/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/dependabot/cli": {
+      "v1.66.0": "1c003ea48f759f688e44303fd3873b5910aa5816"
+    }
+  }
+}

--- a/packages/dependabot/project.bri
+++ b/packages/dependabot/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "dependabot",
+  version: "1.66.0",
+  repository: "https://github.com/dependabot/cli",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function dependabot(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      generate: true,
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/dependabot/cli/cmd/dependabot/internal/cmd.version=${project.version}`,
+      ],
+    },
+    path: "./cmd/dependabot",
+    runnable: "bin/dependabot",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dependabot --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dependabot)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `dependabot version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`dependabot`](https://github.com/dependabot/cli): A tool for testing and debugging Dependabot update jobs.

```bash
[container@brioche-package-devenv workspace]$ bt packages/dependabot/
5301   │ dependabot version 1.66.0
 0.16s ✓ Process 5301
42.63s ✓ Process 2773
Build finished, completed 2 jobs in 46.62s
Result: ecb7f7fecaf48f035813dac71de4110c47a651518bbc307228257908b7a47960
[container@brioche-package-devenv workspace]$ blu packages/dependabot/
Build finished, completed (no new jobs) in 4.06s
Running brioche-run
{
  "name": "dependabot",
  "version": "1.66.0",
  "repository": "https://github.com/dependabot/cli"
}
```