### PR TITLE
feat(lzo): add package

### DIFF
--- a/packages/lzo/brioche.lock
+++ b/packages/lzo/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz": {
+      "type": "sha256",
+      "value": "c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"
+    }
+  }
+}

--- a/packages/lzo/project.bri
+++ b/packages/lzo/project.bri
@@ -1,0 +1,70 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "lzo",
+  version: "2.10",
+};
+
+const source = Brioche.download(
+  `https://www.oberhumer.com/opensource/lzo/download/lzo-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lzo(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lzo2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lzo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://www.oberhumer.com/opensource/lzo/download
+      | lines
+      | where {|it| ($it | str contains "lzo-") }
+      | parse --regex '<a href="lzo-(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`lzo`](https://www.oberhumer.com/opensource/lzo/): a portable lossless data compression library written in ANSI C

```bash
[jaudiger@lima-fedora-x86-64 brioche-packages]$ brioche run -e liveUpdate -p packages/lzo
 0.26s ✓ Process 19329
Build finished, completed 1 job in 49.55s
Running brioche-run
{
  "name": "lzo",
  "version": "2.10"
}
[jaudiger@lima-fedora-x86-64 brioche-packages]$ brioche build -e test -p packages/lzo
19379  │ 2.10
 0.22s ✓ Process 19379
Build finished, completed 1 job in 18.71s
Result: 18565e1d0ffbaff7b0dd12f6789e705c5b2c7b4395c17b623dd44dc5d9e6ec60
```