### PR TITLE
feat(renovate): add package

### DIFF
--- a/packages/renovate/brioche.lock
+++ b/packages/renovate/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/renovate/project.bri
+++ b/packages/renovate/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+import nushell from "nushell";
+
+export const project = {
+  name: "renovate",
+  version: "40.48.5",
+};
+
+export default function renovate(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.name,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/renovate"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    renovate --version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(renovate)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let releaseData = http get https://registry.npmjs.org/${project.name}/latest
+
+    let version = $releaseData
+      | get version
+      | str replace --regex '^v' ''
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`renovate`](https://github.com/renovatebot/renovate): a cross-platform Dependency Automation by Mend.io

```bash
[jaudiger@lima-fedora-x86-64 brioche-packages]$ brioche build -e test -p packages/renovate/
19948  │ 40.48.5
35.25s ✓ Process 19948
Build finished, completed 1 job in 3m32s
Result: 9ad7136cb3abd52e0a3c44ac20e0888d88080da1f8fd36b4873589fb0a0b376d
[jaudiger@lima-fedora-x86-64 brioche-packages]$ brioche run -e liveUpdate -p packages/renovate/
Build finished, completed (no new jobs) in 49.31s
Running brioche-run
{
  "name": "renovate",
  "version": "40.54.1"
}
```