### PR TITLE
feat(patch): add package

### DIFF
--- a/packages/patch/brioche.lock
+++ b/packages/patch/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/patch/patch-2.8.tar.xz": {
+      "type": "sha256",
+      "value": "f87cee69eec2b4fcbf60a396b030ad6aa3415f192aa5f7ee84cad5e11f7f5ae3"
+    }
+  }
+}

--- a/packages/patch/project.bri
+++ b/packages/patch/project.bri
@@ -1,0 +1,66 @@
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "patch",
+  version: "2.8",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/patch/patch-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function patch(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/patch"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    patch --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(patch)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `GNU patch ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/patch
+      | lines
+      | where {|it| ($it | str contains "patch-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="patch-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`patch`](https://savannah.gnu.org/projects/patch) (that is already part of the std.toolchain(), though): it takes a patch file containing a difference listing produced by the diff program and applies those differences to one or more original files, producing patched versions

```bash
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche build -e test -p packages/patch/
Build finished, completed (no new jobs) in 1.67s
Result: 154c23d4eae298ea97d4b74d58bce9205e4f8213fc8a397af2c311bc6657dd39
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche run -e liveUpdate -p packages/patch/
Build finished, completed (no new jobs) in 4.30s
Running brioche-run
{
  "name": "patch",
  "version": "2.8"
}
```