### PR TITLE
feat(lzop): add package

### DIFF
--- a/packages/lzop/brioche.lock
+++ b/packages/lzop/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.lzop.org/download/lzop-1.04.tar.gz": {
+      "type": "sha256",
+      "value": "7e72b62a8a60aff5200a047eea0773a8fb205caf7acbe1774d95147f305a2f41"
+    }
+  }
+}

--- a/packages/lzop/project.bri
+++ b/packages/lzop/project.bri
@@ -1,0 +1,66 @@
+import lzo from "lzo";
+import nushell from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "lzop",
+  version: "1.04",
+};
+
+const source = Brioche.download(
+  `https://www.lzop.org/download/lzop-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lzop(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, lzo)
+    .toDirectory();
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    lzop --version| tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(lzop)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `lzop ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://www.lzop.org/download
+      | lines
+      | where {|it| ($it | str contains "lzop-") }
+      | parse --regex '<a href="lzop-(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`lzop`](https://www.lzop.org): a file compressor which is very similar to [gzip](http://www.gzip.org/). lzop uses the [LZO data compression library](http://www.oberhumer.com/opensource/lzo/) for compression services, and its main advantages over gzip are much higher compression and decompression speed (at the cost of some compression ratio).

```bash
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche build -e test -p packages/lzop
Build finished, completed (no new jobs) in 1.70s
Result: 750d87dce724f7566e3a1c68d30526198a2c0dd4b7c080db8e67087586132409
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche run -e liveUpdate -p packages/lzop
Build finished, completed (no new jobs) in 4.57s
Running brioche-run
{
  "name": "lzop",
  "version": "1.04"
}
```