### PR TITLE
feat(cargo_chef): add package

### DIFF
--- a/packages/cargo_chef/brioche.lock
+++ b/packages/cargo_chef/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/LukeMathWalker/cargo-chef.git": {
+      "v0.1.71": "f3b371eb2bafbe7fe47e678f9ea26b8c08b53bbe"
+    }
+  }
+}

--- a/packages/cargo_chef/project.bri
+++ b/packages/cargo_chef/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_chef",
+  version: "0.1.71",
+  repository: "https://github.com/LukeMathWalker/cargo-chef.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoChef(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    // Disable using cargo-chef while building cargo-chef to avoid
+    // infinite recursion
+    cargoChefPrepare: false,
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo chef --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoChef)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `cargo-chef-chef ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,10 +1,6 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz": {
-      "type": "sha256",
-      "value": "bc601a12f1e086a995690e9eed86353b23d9e0429509bfaae1db2e39b41cde52"
-    },
     "https://static.rust-lang.org/dist/channel-rust-1.87.0.toml": {
       "type": "sha256",
       "value": "2949b5ea91e3f9c45e75ff2fc6cfc7776616c693ab599ed43abc2120b7522415"

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -1,4 +1,5 @@
 import * as std from "std";
+import cargoChef from "cargo_chef";
 import * as TOML from "smol_toml";
 import * as t from "typer";
 import nushell from "nushell";
@@ -435,14 +436,4 @@ export function vendorCrate(
   crate = crate.remove(".cargo/config");
 
   return crate;
-}
-
-function cargoChef(): std.Recipe<std.Directory> {
-  const pkg = Brioche.download(
-    "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
-  );
-
-  return std.directory({
-    bin: pkg.unarchive("tar", "gzip"),
-  });
 }


### PR DESCRIPTION
Add a new package [`cargo_chef`](https://github.com/LukeMathWalker/cargo-chef): a cargo-subcommand to speed up Rust Docker builds using Docker layer caching.

This one is yours @kylewlacy, I just cherry picked your changes to upstream from https://github.com/brioche-dev/brioche-packages/tree/build/wip-aarch64-linux.