### PR TITLE
chore: update function comments to use TSDoc style

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -110,28 +110,28 @@ export type CMakeVariableType =
 /**
  * Generate and build a CMake project.
  *
- * A project buildsystem will be generated out-of-tree from the source project,
+ * @description A project buildsystem will be generated out-of-tree from the source project,
  * and will be built and installed automatically with the chosen build
  * generator.
  *
  * If the result includes a `lib64/`, the symlink `lib/` will be added
  * automatically to follow the standard Brioche conventions.
  *
- * ## Options
- *
- * - `source`: The CMake project to build.
- * - `path`: Optional subpath containing the root CMake project to build,
+ * @param source - The CMake project to build.
+ * @param path - Optional subpath containing the root CMake project to build,
  *   relative to `source`. This can be useful for monorepos with multiple
  *   CMake projects that reference each other.
- * - `dependencies`: Optionally add dependencies to the build. Most projects
+ * @param dependencies - Optionally add dependencies to the build. Most projects
  *   will want to include `std.toolchain()` or a similar toolchain.
- * - `env`: Optionally set environment variables for the build.
- * - `set`: Optionally set CMake cache variables during the build, as if
+ * @param env - Optionally set environment variables for the build.
+ * @param set - Optionally set CMake cache variables during the build, as if
  *   by passing `-D...`.
- * - `disablePostBuildSteps`: If set, the post build steps will not run. By
+ * @param disablePostBuildSteps - If set, the post build steps will not run. By
  *   default, only `std.pkgConfigMakePathsRelative` will be executed.
- * - `runnable`: Optionally set a path to the binary to run by default
+ * @param runnable - Optionally set a path to the binary to run by default
  *   (e.g. `bin/foo`).
+ *
+ * @returns The built CMake project artifact
  */
 export function cmakeBuild(
   options: CMakeBuildInstallOptions,

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -82,6 +82,23 @@ export default function cmake(): std.Recipe<std.Directory> {
     );
 }
 
+/**
+ * Options for building and installing a CMake project.
+ *
+ * @param source - The CMake project to build.
+ * @param path - Optional subpath containing the root CMake project to build,
+ *   relative to `source`. This can be useful for monorepos with multiple
+ *   CMake projects that reference each other.
+ * @param dependencies - Optionally add dependencies to the build. Most projects
+ *   will want to include `std.toolchain()` or a similar toolchain.
+ * @param env - Optionally set environment variables for the build.
+ * @param set - Optionally set CMake cache variables during the build, as if
+ *   by passing `-D...`.
+ * @param disablePostBuildSteps - If set, the post build steps will not run. By
+ *   default, only `std.pkgConfigMakePathsRelative` will be executed.
+ * @param runnable - Optionally set a path to the binary to run by default
+ *   (e.g. `bin/foo`).
+ */
 export interface CMakeBuildInstallOptions {
   source: std.RecipeLike<std.Directory>;
   path?: string;
@@ -117,19 +134,7 @@ export type CMakeVariableType =
  * If the result includes a `lib64/`, the symlink `lib/` will be added
  * automatically to follow the standard Brioche conventions.
  *
- * @param source - The CMake project to build.
- * @param path - Optional subpath containing the root CMake project to build,
- *   relative to `source`. This can be useful for monorepos with multiple
- *   CMake projects that reference each other.
- * @param dependencies - Optionally add dependencies to the build. Most projects
- *   will want to include `std.toolchain()` or a similar toolchain.
- * @param env - Optionally set environment variables for the build.
- * @param set - Optionally set CMake cache variables during the build, as if
- *   by passing `-D...`.
- * @param disablePostBuildSteps - If set, the post build steps will not run. By
- *   default, only `std.pkgConfigMakePathsRelative` will be executed.
- * @param runnable - Optionally set a path to the binary to run by default
- *   (e.g. `bin/foo`).
+ * @param options - The options for building the CMake project.
  *
  * @returns The built CMake project artifact
  */

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -19,7 +19,7 @@ const source = Brioche.download(
 /**
  * Options for the curl package.
  *
- * @property minimal - If set to true, will build curl with only the minimum required dependencies.
+ * @param minimal - If set to true, will build curl with only the minimum required dependencies.
  */
 interface CurlOptions {
   minimal?: boolean;

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -75,12 +75,24 @@ export function liveUpdate(): std.WithRunnable {
   });
 }
 
+/**
+ * Options for checking out a git repository.
+ *
+ * @param repository - The URL of the git repository to checkout.
+ * @param commit - The full commit hash to checkout.
+ * @param options - Extra options for the checkout.
+ */
 interface GitCheckoutInit {
   repository: string;
   commit: string;
   options?: GitCheckoutOptions;
 }
 
+/**
+ * Specific git checkout options.
+ *
+ * @param submodules - Set to true to recursively checkout git submodules too.
+ */
 export interface GitCheckoutOptions {
   submodules?: boolean;
 }
@@ -93,10 +105,8 @@ export interface GitCheckoutOptions {
  * to get a commit hash from a git ref (such as a branch or tag name), and
  * then record the commit hash in the lockfile.
  *
- * @param repository - The URL of the git repository to checkout.
- * @param commit - The full commit hash to checkout.
- * @param options - Extra options for the checkout.
- * @param options.submodules - Set to true to recursively checkout git submodules too.
+ * @param init - An object containing the repository URL and commit hash to checkout.
+ * @param options - Options for the checkout, such as whether to include submodules.
  *
  * @returns The checked out repository as an artifact
  *

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -89,19 +89,18 @@ export interface GitCheckoutOptions {
  * Checkout a git repository at a specific commit. The specified commit will
  * be cloned without any history.
  *
- * See also the `Brioche.gitRef` function, which can be used with `gitCheckout`
+ * @description See also the `Brioche.gitRef` function, which can be used with `gitCheckout`
  * to get a commit hash from a git ref (such as a branch or tag name), and
  * then record the commit hash in the lockfile.
  *
- * ## Options
+ * @param repository - The URL of the git repository to checkout.
+ * @param commit - The full commit hash to checkout.
+ * @param options - Extra options for the checkout.
+ * @param options.submodules - Set to true to recursively checkout git submodules too.
  *
- * - `repository`: The URL of the git repository to checkout.
- * - `commit`: The full commit hash to checkout.
- * - `options`: Extra options for the checkout.
- *   - `submodules`: Set to true to recursively checkout git submodules too.
+ * @returns The checked out repository as an artifact
  *
- * ## Example
- *
+ * @example
  * ```typescript
  * import { gitCheckout } from "git";
  *

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -90,6 +90,14 @@ export function liveUpdate(): std.WithRunnable {
 
 type ModOptions = "readonly" | "vendor" | "mod";
 
+/**
+ * Build options when building and installing a Go module.
+ *
+ * @param generate - Run `go generate` before building.
+ * @param ldflags - An array of ldflags to pass to the `go install` command.
+ * @param trimpath - Set the `-trimpath` flag.
+ * @param mod - Set the `-mod` flag to one of `"readonly"`, `"vendor"`, or `"mod"`.
+ */
 interface GoBuildParameters {
   generate?: boolean;
   ldflags?: string[];
@@ -97,6 +105,18 @@ interface GoBuildParameters {
   mod?: ModOptions;
 }
 
+/**
+ * Options for building and installing a Go module.
+ *
+ * @param source - The Go module to build. Should include `go.mod`, as well as
+ *   `go.sum` if external dependencies are needed.
+ * @param dependencies - Optionally add additional dependencies to the build.
+ * @param env - Optionally set environment variables for the build.
+ * @param buildParams - Optional build parameters.
+ * @param path - Optionally set the package path to build (e.g. `./cmd/foo`).
+ * @param runnable - Optionally set a path to the binary to run
+ *   by default (e.g. `bin/foo`).
+ */
 interface GoBuildOptions {
   source: std.RecipeLike<std.Directory>;
   dependencies?: std.RecipeLike<std.Directory>[];
@@ -110,18 +130,7 @@ interface GoBuildOptions {
  * Build a Go module. Calls `go install` in the module directory, and
  * returns a recipe with the results stored in the `bin/` directory.
  *
- * @param source - The Go module to build. Should include `go.mod`, as well as
- *   `go.sum` if external dependencies are needed.
- * @param buildParams - Optional build parameters:
- * @param buildParams.generate - Run `go generate` before building.
- * @param buildParams.ldflags - An array of ldflags to pass to the `go install` command.
- * @param buildParams.trimpath - Set the `-trimpath` flag.
- * @param buildParams.mod - Set the `-mod` flag to one of `"readonly"`, `"vendor"`, or `"mod"`.
- * @param dependencies - Optionally add additional dependencies to the build.
- * @param env - Optionally set environment variables for the build.
- * @param path - Optionally set the package path to build (e.g. `./cmd/foo`).
- * @param runnable - Optionally set a path to the binary to run
- *   by default (e.g. `bin/foo`).
+ * @param options - Options for building the Go module.
  *
  * @returns A recipe with the built Go binaries stored in the `bin/` directory
  *

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -110,23 +110,22 @@ interface GoBuildOptions {
  * Build a Go module. Calls `go install` in the module directory, and
  * returns a recipe with the results stored in the `bin/` directory.
  *
- * ## Options
- *
- * - `source`: The Go module to build. Should include `go.mod`, as well as
+ * @param source - The Go module to build. Should include `go.mod`, as well as
  *   `go.sum` if external dependencies are needed.
- * - `buildParams`: Optional build parameters:
- *   - `generate`: Run `go generate` before building.
- *   - `ldflags`: An array of ldflags to pass to the `go install` command.
- *   - `trimpath`: Set the `-trimpath` flag.
- *   - `mod`: Set the `-mod` flag to one of `"readonly"`, `"vendor"`, or `"mod"`.
- * - `dependencies`: Optionally add additional dependencies to the build.
- * - `env`: Optionally set environment variables for the build.
- * - `path`: Optionally set the package path to build (e.g. `./cmd/foo`).
- * - `runnable`: Optionally set a path to the binary to run
+ * @param buildParams - Optional build parameters:
+ * @param buildParams.generate - Run `go generate` before building.
+ * @param buildParams.ldflags - An array of ldflags to pass to the `go install` command.
+ * @param buildParams.trimpath - Set the `-trimpath` flag.
+ * @param buildParams.mod - Set the `-mod` flag to one of `"readonly"`, `"vendor"`, or `"mod"`.
+ * @param dependencies - Optionally add additional dependencies to the build.
+ * @param env - Optionally set environment variables for the build.
+ * @param path - Optionally set the package path to build (e.g. `./cmd/foo`).
+ * @param runnable - Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
  *
- * ## Example
+ * @returns A recipe with the built Go binaries stored in the `bin/` directory
  *
+ * @example
  * ```typescript
  * import { goBuild } from "go";
  * import openssl from "openssl";

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -54,6 +54,14 @@ export function linuxDefconfig(
     .toFile();
 }
 
+/**
+ * Options for the Linux kernel build.
+ *
+ * @param config - The kernel `.config` file to use for the build. Defaults
+ *   to the default configuration produced by `make defconfig`.
+ * @param dependencies - Additional build dependencies.
+ * @param env - Additional environment variables to set during the build.
+ */
 interface LinuxOptions {
   config?: std.RecipeLike<std.File>;
   dependencies?: std.RecipeLike<std.Directory>[];
@@ -69,10 +77,7 @@ interface LinuxOptions {
  * - `boot/System.map`: The kernel's system map.
  * - `lib/modules/${version}`: Built kernel modules.
  *
- * @param config - The kernel `.config` file to use for the build. Defaults
- *   to the default configuration produced by `make defconfig`.
- * @param dependencies - Additional build dependencies.
- * @param env - Additional environment variables to set during the build.
+ * @param options - Options for the Linux kernel build.
  *
  * @returns A recipe containing the built Linux kernel with boot files and modules
  */

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -64,18 +64,17 @@ interface LinuxOptions {
  * A recipe that builds the Linux kernel. Defaults to using a default
  * configuration using `make defconfig`.
  *
- * The output will contain the following paths:
- *
+ * @description The output will contain the following paths:
  * - `boot/linux`: A symlink to the kernel image within `boot/`.
  * - `boot/System.map`: The kernel's system map.
  * - `lib/modules/${version}`: Built kernel modules.
  *
- * ## Options
- *
- * - `config`: The kernel `.config` file to use for the build. Defaults
+ * @param config - The kernel `.config` file to use for the build. Defaults
  *   to the default configuration produced by `make defconfig`.
- * - `dependencies`: Additional build dependencies.
- * - `env`: Additional environment variables to set during the build.
+ * @param dependencies - Additional build dependencies.
+ * @param env - Additional environment variables to set during the build.
+ *
+ * @returns A recipe containing the built Linux kernel with boot files and modules
  */
 export default function linux(
   options: LinuxOptions = {},
@@ -169,10 +168,8 @@ type LinuxUpdateConfigValue =
  * Update a Linux kernel configuration file by setting (or un-setting)
  * various configuration values.
  *
- * ## Arguments
- *
- * - `config`: The base kernel configuration file to start with.
- * - `values`: An object mapping configuration options to their values. Each
+ * @param config - The base kernel configuration file to start with.
+ * @param values - An object mapping configuration options to their values. Each
  *   value can be one of the following:
  *   - `true`: Enable the option
  *   - `false`: Disable the option
@@ -186,8 +183,9 @@ type LinuxUpdateConfigValue =
  *   - `{ moduleAfter: string }`: Enable the option as a module after
  *      another option is enabled
  *
- * ## Example
+ * @returns An updated Linux kernel configuration file
  *
+ * @example
  * ```typescript
  * const config = linuxUpdateConfig(linuxDefconfig(), {
  *   VIRTIO: true, // enable CONFIG_VIRTIO
@@ -196,7 +194,6 @@ type LinuxUpdateConfigValue =
  *   DEFAULT_INIT: { value: "/example" }, // override the default init path
  * });
  * ```
- *
  */
 export function linuxUpdateConfig(
   config: std.RecipeLike<std.File>,

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -79,12 +79,11 @@ interface NpmInstallOptions {
  * Install the dependencies from an NPM package. Returns a recipe containing
  * everything from the package, plus a `node_modules` directory.
  *
- * ## Options
+ * @param source - The NPM package dependencies to install.
  *
- * - `source`: The NPM package dependencies to install.
+ * @returns A recipe containing everything from the package, plus a `node_modules` directory
  *
- * ## Example
- *
+ * @example
  * ```typescript
  * import * as std from "std";
  * import nodejs, { npmInstall } from "nodejs";
@@ -135,13 +134,12 @@ const BinList = typer.array(
 /**
  * Installs a global NPM package. Returns a recipe containing the package
  *
- * ## Options
+ * @param packageName - The NPM package dependencies to install.
+ * @param version - The version of the package to install.
  *
- * - `packageName`: The NPM package dependencies to install.
- * - `version`: The version of the package to install.
+ * @returns A recipe containing the package
  *
- * ## Example
- *
+ * @example
  * ```typescript
  * import * as std from "std";
  * import { npmInstallGlobal } from "nodejs";

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -71,6 +71,11 @@ export function liveUpdate(): std.WithRunnable {
   });
 }
 
+/**
+ * Options for building and installing a NPM package.
+ * 
+ * @param source - The NPM package dependencies to install.
+ */
 interface NpmInstallOptions {
   source: std.RecipeLike<std.Directory>;
 }
@@ -79,7 +84,7 @@ interface NpmInstallOptions {
  * Install the dependencies from an NPM package. Returns a recipe containing
  * everything from the package, plus a `node_modules` directory.
  *
- * @param source - The NPM package dependencies to install.
+ * @param options - The options for installing the NPM package.
  *
  * @returns A recipe containing everything from the package, plus a `node_modules` directory
  *
@@ -118,6 +123,13 @@ export function npmInstall(
     .toDirectory();
 }
 
+/**
+ * Options for installing a global NPM package.
+ *
+ * @param packageName - The name of the NPM package to install.
+ * @param version - The version of the package to install.
+ * @param wrapBins - Whether to wrap the installed binaries.
+ */
 interface NpmInstallGlobalOptions {
   packageName: string;
   version: string;
@@ -134,8 +146,7 @@ const BinList = typer.array(
 /**
  * Installs a global NPM package. Returns a recipe containing the package
  *
- * @param packageName - The NPM package dependencies to install.
- * @param version - The version of the package to install.
+ * @param options - The options for installing the global NPM package.
  *
  * @returns A recipe containing the package
  *

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -16,10 +16,10 @@ const source = Brioche.gitCheckout({
 /**
  * Represents a Nushell plugin.
  *
- * ## Options
+ * @param name - The name of the plugin.
+ * @param dependencies - The dependencies of the plugin.
  *
- * `name`: The name of the plugin.
- * `dependencies`: The dependencies of the plugin.
+ * @returns A Nushell plugin representation
  */
 interface NushellPlugin {
   name: string;

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -153,6 +153,19 @@ export function liveUpdate(): std.WithRunnable {
   });
 }
 
+/**
+ * Parameters for building a Rust crate.
+ *
+ * @param features - An array of features to enable.
+ * @param defaultFeatures - Set to `false` to opt out of the crate's
+ *   default features.
+ * @param allFeatures - Set to `true` to enable all of the crate's features.
+ * @param bins - Set to `true` to build all bin targets in the crate, or set
+ *   to an array of bin targets to build. Defaults to `true` if no other
+ *   targets are specified.
+ * @param examples - Set to `true` to build all example targets in the crate,
+ *   or set to an array of example targets to build.
+ */
 interface CargoBuildParameters {
   features?: string[];
   defaultFeatures?: boolean;
@@ -161,20 +174,8 @@ interface CargoBuildParameters {
   examples?: boolean | string[];
 }
 
-export interface CargoBuildOptions {
-  source: std.RecipeLike<std.Directory>;
-  path?: string;
-  runnable?: string;
-  dependencies?: std.RecipeLike<std.Directory>[];
-  env?: Record<string, std.ProcessTemplateLike>;
-  unsafe?: std.ProcessUnsafeOptions;
-  cargoChefPrepare?: boolean;
-  buildParams?: CargoBuildParameters;
-}
-
 /**
- * Build a Cargo crate. Defaults to the release profile. Calls
- * `cargo install` internally, and returns the contents of `$CARGO_INSTALL_ROOT`
+ * Options for building and installing a Rust crate.
  *
  * @param source - The crate to build.
  * @param path - Optionally set a subpath to the crate to build. This is useful
@@ -192,16 +193,24 @@ export interface CargoBuildOptions {
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
- * @param buildParams - Optional build parameters:
- * @param buildParams.features - An array of features to enable.
- * @param buildParams.defaultFeatures - Set to `false` to opt out of the crate's
- *   default features.
- * @param buildParams.allFeatures - Set to `true` to enable all of the crate's features.
- * @param buildParams.bins - Set to `true` to build all bin targets in the crate, or set
- *   to an array of bin targets to build. Defaults to `true` if no other
- *   targets are specified.
- * @param buildParams.examples - Set to `true` to build all example targets in the crate,
- *   or set to an array of example targets to build.
+ * @param buildParams - Optional build parameters.
+ */
+export interface CargoBuildOptions {
+  source: std.RecipeLike<std.Directory>;
+  path?: string;
+  runnable?: string;
+  dependencies?: std.RecipeLike<std.Directory>[];
+  env?: Record<string, std.ProcessTemplateLike>;
+  unsafe?: std.ProcessUnsafeOptions;
+  cargoChefPrepare?: boolean;
+  buildParams?: CargoBuildParameters;
+}
+
+/**
+ * Build a Cargo crate. Defaults to the release profile. Calls
+ * `cargo install` internally, and returns the contents of `$CARGO_INSTALL_ROOT`
+ *
+ * @param options - Options for building the crate.
  *
  * @returns The contents of `$CARGO_INSTALL_ROOT` containing the built crate
  *
@@ -363,6 +372,16 @@ export function createSkeletonCrate(
     .toDirectory();
 }
 
+/**
+ * Options for vendoring a Rust crate's dependencies.
+ *
+ * @param source - The crate to build.
+ * @param cargoChefPrepare - Controls if the crate from `source` should get
+ *   pre-processed by `cargo chef prepare` before being built, which avoids
+ *   unnecessarily re-downloading dependencies when the source changes.
+ *   Defaults to `true` (should only be disabled when there's an upstream
+ *   issue with `cargo chef`).
+ */
 interface VendorCrateOptions {
   source: std.RecipeLike<std.Directory>;
   cargoChefPrepare?: boolean;
@@ -373,12 +392,7 @@ interface VendorCrateOptions {
  * dependencies vendored using `cargo vendor`. `.cargo/config.toml` will
  * also be updated to use the vendored dependencies.
  *
- * @param source - The crate to build.
- * @param cargoChefPrepare - Controls if the crate from `source` should get
- *   pre-processed by `cargo chef prepare` before being built, which avoids
- *   unnecessarily re-downloading dependencies when the source changes.
- *   Defaults to `true` (should only be disabled when there's an upstream
- *   issue with `cargo chef`).
+ * @param options - Options for vendoring the crate's dependencies.
  *
  * @returns The same crate with dependencies vendored and `.cargo/config.toml` updated
  */

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -176,37 +176,36 @@ export interface CargoBuildOptions {
  * Build a Cargo crate. Defaults to the release profile. Calls
  * `cargo install` internally, and returns the contents of `$CARGO_INSTALL_ROOT`
  *
- * ## Options
- *
- * - `source`: The crate to build.
- * - `path`: Optionally set a subpath to the crate to build. This is useful
+ * @param source - The crate to build.
+ * @param path - Optionally set a subpath to the crate to build. This is useful
  *   when building a crate within a workspace.
- * - `runnable`: Optionally set a path to the binary to run
+ * @param runnable - Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
- * - `dependencies`: Optionally add additional dependencies to the build.
- * - `env`: Optionally set environment variables for the build.
- * - `unsafe`: Optional unsafe options to enable when building. For example,
+ * @param dependencies - Optionally add additional dependencies to the build.
+ * @param env - Optionally set environment variables for the build.
+ * @param unsafe - Optional unsafe options to enable when building. For example,
  *   passing `{ networking: true }` will allow a `build.rs` script to
  *   download files during the build. You must take extra care to ensure
  *   the build is hermetic when setting these options!
- * - `cargoChefPrepare`: Controls if the crate from `source` should get
+ * @param cargoChefPrepare - Controls if the crate from `source` should get
  *   pre-processed by `cargo chef prepare` before being built, which avoids
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
- * - `buildParams`: Optional build parameters:
- *   - `features`: An array of features to enable.
- *   - `defaultFeatures`: Set to `false` to opt out of the crate's
- *     default features.
- *   - `allFeatures`: Set to `true` to enable all of the crate's features.
- *   - `bins`: Set to `true` to build all bin targets in the crate, or set
- *     to an array of bin targets to build. Defaults to `true` if no other
- *     targets are specified.
- *   - `examples`: Set to `true` to build all example targets in the crate,
- *     or set to an array of example targets to build.
+ * @param buildParams - Optional build parameters:
+ * @param buildParams.features - An array of features to enable.
+ * @param buildParams.defaultFeatures - Set to `false` to opt out of the crate's
+ *   default features.
+ * @param buildParams.allFeatures - Set to `true` to enable all of the crate's features.
+ * @param buildParams.bins - Set to `true` to build all bin targets in the crate, or set
+ *   to an array of bin targets to build. Defaults to `true` if no other
+ *   targets are specified.
+ * @param buildParams.examples - Set to `true` to build all example targets in the crate,
+ *   or set to an array of example targets to build.
  *
- * ## Example
+ * @returns The contents of `$CARGO_INSTALL_ROOT` containing the built crate
  *
+ * @example
  * ```typescript
  * import openssl from "openssl";
  * import { cargoBuild } from "rust";
@@ -374,14 +373,14 @@ interface VendorCrateOptions {
  * dependencies vendored using `cargo vendor`. `.cargo/config.toml` will
  * also be updated to use the vendored dependencies.
  *
- * ## Options
- *
- * - `source`: The crate to build.
- * - `cargoChefPrepare`: Controls if the crate from `source` should get
+ * @param source - The crate to build.
+ * @param cargoChefPrepare - Controls if the crate from `source` should get
  *   pre-processed by `cargo chef prepare` before being built, which avoids
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
+ *
+ * @returns The same crate with dependencies vendored and `.cargo/config.toml` updated
  */
 export function vendorCrate(
   options: VendorCrateOptions,

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -26,8 +26,11 @@ declare global {
      * Include a file from the filesystem. The path is relative to the
      * current Brioche module, and cannot go outside the project root.
      *
-     * ## Example
+     * @param path - The relative path to the file to include
      *
+     * @returns A file recipe with the contents of the specified file
+     *
+     * @example
      * ```
      * project/
      * ├── project.bri
@@ -47,8 +50,11 @@ declare global {
      * Include a directory from the filesystem. The path is relative to the
      * current Brioche module, and cannot go outside the project root.
      *
-     * ## Example
+     * @param path - The relative path to the directory to include
      *
+     * @returns A directory recipe containing all files in the specified directory
+     *
+     * @example
      * ```
      * project/
      * ├── project.bri
@@ -72,8 +78,11 @@ declare global {
      * relative to the current Brioche module. The glob pattern will not
      * match any paths if it tries going outside the current module directory.
      *
-     * ## Example
+     * @param patterns - One or more glob patterns to match files
      *
+     * @returns A directory recipe containing all files matching the glob patterns
+     *
+     * @example
      * ```
      * project/
      * ├── project.bri
@@ -101,10 +110,13 @@ declare global {
      * not take a hash, and it **must** be called with a constant string URL.
      * The hash of the downloaded file will be saved in the lockfile.
      *
-     * See also `std.download`, which can be used even if URL is not constant.
+     * @description See also `std.download`, which can be used even if URL is not constant.
      *
-     * ## Example
+     * @param url - The URL to download (must be a constant string)
      *
+     * @returns A file recipe containing the downloaded content
+     *
+     * @example
      * ```typescript
      * const file = Brioche.download("http://example.com/");
      * ```
@@ -117,16 +129,15 @@ declare global {
      * commit hash will be saved in the lockfile, so the same commit hash
      * will be used until the lockfile is updated.
      *
-     * See also the `gitCheckout` function from the `git` package, which can
+     * @description See also the `gitCheckout` function from the `git` package, which can
      * checkout a git repo from a commit hash returned from `Brioche.gitRef`.
      *
-     * ## Options
+     * @param repository - A git repository URL.
+     * @param ref - A git ref, such as a branch or tag name. Example: `main`
      *
-     * - `repository`: A git repository URL.
-     * - `ref`: A git ref, such as a branch or tag name. Example: `main`
+     * @returns The commit hash for the specified git ref
      *
-     * ## Example
-     *
+     * @example
      * ```typescript
      * import { gitCheckout } from "git";
      *

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -9,6 +9,12 @@ import { BRIOCHE_VERSION } from "./runtime.bri";
 import { semverMatches } from "./semver.bri";
 import { assert } from "./utils.bri";
 
+/**
+ * Options for retrieving a git ref commit hash.
+ *
+ * @param repository - A git repository URL.
+ * @param ref - A git ref, such as a branch or tag name. Example: `main`
+ */
 export interface GitRefOptions {
   repository: string;
   ref: string;
@@ -132,10 +138,9 @@ declare global {
      * @description See also the `gitCheckout` function from the `git` package, which can
      * checkout a git repo from a commit hash returned from `Brioche.gitRef`.
      *
-     * @param repository - A git repository URL.
-     * @param ref - A git ref, such as a branch or tag name. Example: `main`
+     * @param options - Options for the git ref.
      *
-     * @returns The commit hash for the specified git ref
+     * @returns The commit hash for the specified git ref.
      *
      * @example
      * ```typescript

--- a/packages/std/core/recipes/directory.bri
+++ b/packages/std/core/recipes/directory.bri
@@ -12,8 +12,11 @@ import {
  * Constructs a new directory. Takes an object argument, where each key
  * is a filename and each value is a recipe
  *
- * ## Example
+ * @param entries - An object mapping filenames to recipes
  *
+ * @returns A directory recipe containing the specified entries
+ *
+ * @example
  * ```typescript
  * std.directory({
  *   "hello": std.directory({

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -2,6 +2,12 @@ import { File } from "./file.bri";
 import { Hash } from "./hash.bri";
 import { type Recipe, createRecipe } from "./recipe.bri";
 
+/**
+ * Options required to download a file from a URL.
+ * 
+ * @param url - The URL to download
+ * @param hash - The hash to verify the downloaded content
+ */
 export interface DownloadOptions {
   url: string;
   hash: Hash;
@@ -16,8 +22,6 @@ export interface DownloadOptions {
  * a hash, but only works with a constant URL.
  *
  * @param opts - Download options including URL and hash
- * @param opts.url - The URL to download
- * @param opts.hash - The hash to verify the downloaded content
  *
  * @returns A file recipe containing the downloaded content
  *

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -12,17 +12,24 @@ export interface DownloadOptions {
  * a file of its results. A hash must be provided, and will
  * be used to verify the downloaded contents.
  *
- * See also `Brioche.download`, which does not require specifying
+ * @description See also `Brioche.download`, which does not require specifying
  * a hash, but only works with a constant URL.
  *
- * ## Example
+ * @param opts - Download options including URL and hash
+ * @param opts.url - The URL to download
+ * @param opts.hash - The hash to verify the downloaded content
  *
+ * @returns A file recipe containing the downloaded content
+ *
+ * @example
+ * ```typescript
  * std.download({
  *   url: "https://gist.githubusercontent.com/kylewlacy/c0f1a43e2641686f377178880fcce6ae/raw/f48155695445aa218e558fba824b61cf718d5e55/lorem-ipsum.txt",
  *   hash: std.sha256Hash(
  *     "642e3f58cc2bcc0d12d2e1e21dd9ea131f058a98e23e9beac79881bb0a324d06"
  *   ),
  * });
+ * ```
  */
 export function download(opts: DownloadOptions): Recipe<File> {
   return createRecipe(["file"], {

--- a/packages/std/core/recipes/file.bri
+++ b/packages/std/core/recipes/file.bri
@@ -5,8 +5,11 @@ import { type Recipe, createRecipe, fileRecipeUtils } from "./recipe.bri";
 /**
  * Create a new file, which contains the provided content.
  *
- * ## Example
+ * @param content - The content for the file (string or Uint8Array)
  *
+ * @returns A file recipe containing the specified content
+ *
+ * @example
  * ```typescript
  * std.file("Hello, world!");
  * ```

--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -8,8 +8,12 @@ import type { Directory } from "./directory.bri";
  * Returns a directory recipe containing only files that match one of the
  * specified glob patterns.
  *
- * ## Example
+ * @param recipe - The directory recipe to filter
+ * @param patterns - An array of glob patterns to match files against
  *
+ * @returns A directory recipe containing only files matching the glob patterns
+ *
+ * @example
  * ```typescript
  * import * as std from "std";
  *

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -82,33 +82,32 @@ export interface ProcessUtils {
  * the process writes to the path `$BRIOCHE_OUTPUT`. The process can
  * write a file, directory, or symlink to this path.
  *
- * Most options can be passed as a string literal, or as a template using
+ * @description Most options can be passed as a string literal, or as a template using
  * the template function `std.tpl`. Recipes in the template will be
  * expanded to an absolute path when the process runs.
- *
- * ## Options
  *
  * These options can be passed when calling `std.process()`, or can be
  * set by calling methods on another process recipe (these methods are
  * **immutable**, so make sure to assign the result to a variable!)
  *
- * - `command`: The command to run. Should either be a template, or a
+ * @param command - The command to run. Should either be a template, or a
  *   string referencing a command from `dependencies`.
- * - `args`: An array of arguments to pass to the command.
- * - `env`: An object containing environment variables to set for the process.
- * - `dependencies`: An array of dependencies to call the process with.
+ * @param args - An array of arguments to pass to the command.
+ * @param env - An object containing environment variables to set for the process.
+ * @param dependencies - An array of dependencies to call the process with.
  *   Dependencies will be merged into the process's environment.
- * - `workDir`: Set to a directory recipe that will be copied into the
+ * @param workDir - Set to a directory recipe that will be copied into the
  *   process's starting working directory.
- * - `outputScaffold`: Set to a recipe that will be be used to initialize
+ * @param outputScaffold - Set to a recipe that will be be used to initialize
  *   `$BRIOCHE_OUTPUT`, which the process can then manipulate.
- * - `unsafe`: A nested object with extra unsafe options that can be enabled.
+ * @param unsafe - A nested object with extra unsafe options that can be enabled.
  *   You must take extra care to ensure that running the process is hermetic
  *   when using these options! The following options are available:
- *   - `networking`: Set to `true` to allow the process to access the network.
+ * @param unsafe.networking - Set to `true` to allow the process to access the network.
  *
- * ## Example
+ * @returns The contents that the process writes to `$BRIOCHE_OUTPUT`
  *
+ * @example
  * ```typescript
  * // Call Bash and write "Hello world!" to the output path
  * std.process({

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -11,6 +11,22 @@ import {
 } from "./recipe.bri";
 import { castToFile, castToDirectory, castToSymlink } from "./cast.bri";
 
+/**
+ * Process options.
+ * 
+ * @param command - The command to run. Should either be a template, or a
+ *   string referencing a command from `dependencies`.
+ * @param args - An array of arguments to pass to the command.
+ * @param env - An object containing environment variables to set for the process.
+ * @param currentDir - Set the process's current working directory.
+ * @param dependencies - An array of dependencies to call the process with.
+ *   Dependencies will be merged into the process's environment.
+ * @param workDir - Set to a directory recipe that will be copied into the
+ *   process's starting working directory.
+ * @param outputScaffold - Set to a recipe that will be be used to initialize
+ *   `$BRIOCHE_OUTPUT`, which the process can then manipulate.
+ * @param unsafe - A nested object with extra unsafe options that can be enabled.
+ */
 export type ProcessOptions = {
   command: ProcessTemplateLike;
   args?: ProcessTemplateLike[];
@@ -22,6 +38,14 @@ export type ProcessOptions = {
   unsafe?: ProcessUnsafeOptions;
 };
 
+/**
+ * Unsafe options for a process.
+ * 
+ * @remark You must take extra care to ensure that running the process is hermetic
+ *   when using these options!
+ * 
+ * @param networking - Set to `true` to allow the process to access the network.
+ */
 export interface ProcessUnsafeOptions {
   networking?: boolean;
 }
@@ -90,20 +114,7 @@ export interface ProcessUtils {
  * set by calling methods on another process recipe (these methods are
  * **immutable**, so make sure to assign the result to a variable!)
  *
- * @param command - The command to run. Should either be a template, or a
- *   string referencing a command from `dependencies`.
- * @param args - An array of arguments to pass to the command.
- * @param env - An object containing environment variables to set for the process.
- * @param dependencies - An array of dependencies to call the process with.
- *   Dependencies will be merged into the process's environment.
- * @param workDir - Set to a directory recipe that will be copied into the
- *   process's starting working directory.
- * @param outputScaffold - Set to a recipe that will be be used to initialize
- *   `$BRIOCHE_OUTPUT`, which the process can then manipulate.
- * @param unsafe - A nested object with extra unsafe options that can be enabled.
- *   You must take extra care to ensure that running the process is hermetic
- *   when using these options! The following options are available:
- * @param unsafe.networking - Set to `true` to allow the process to access the network.
+ * @param options - The options for the process.
  *
  * @returns The contents that the process writes to `$BRIOCHE_OUTPUT`
  *

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -156,8 +156,11 @@ interface RecipeUtils {
    * value as the input to the next function. This is a convenience method
    * around the `std.pipe()` utility function.
    *
-   * ## Example
+   * @param functions - Functions to pipe the recipe through
    *
+   * @returns The result of piping the recipe through all the functions
+   *
+   * @example
    * ```typescript
    * const result = recipe.pipe(
    *   function1,
@@ -176,8 +179,11 @@ interface FileRecipeUtils extends RecipeUtils {
   /**
    * Returns a new file with the given permissions set.
    *
-   * ## Example
+   * @param permissions - The permissions to set on the file
    *
+   * @returns A new file recipe with the specified permissions
+   *
+   * @example
    * ```typescript
    * // Create a shell script and mark it as executable
    * std.file(std.indoc`
@@ -191,8 +197,12 @@ interface FileRecipeUtils extends RecipeUtils {
   /**
    * Unarchive a (possibly compressed) archive file, returning a directory.
    *
-   * ## Example
+   * @param archiveFormat - The archive format (e.g., "tar", "zip")
+   * @param compressionFormat - Optional compression format (e.g., "gzip", "bzip2")
    *
+   * @returns A directory recipe containing the unarchived contents
+   *
+   * @example
    * ```typescript
    * Brioche.includeFile("archive.tar.gz").unarchive("tar", "gzip");
    * ```

--- a/packages/std/core/recipes/symlink.bri
+++ b/packages/std/core/recipes/symlink.bri
@@ -10,9 +10,9 @@ export interface SymlinkOptions {
 /**
  * Create a new symlink pointing at a provided path.
  *
- * ## Options
+ * @param target - The target path of the symlink.
  *
- * - `target`: The target path of the symlink.
+ * @returns A new symlink pointing to the target path
  */
 export function symlink(opts: SymlinkOptions): Symlink {
   return new Symlink({

--- a/packages/std/core/recipes/symlink.bri
+++ b/packages/std/core/recipes/symlink.bri
@@ -3,6 +3,11 @@ import { source as briocheSource } from "../source.bri";
 import { assert } from "../utils.bri";
 import { type Recipe, symlinkRecipeUtils } from "./recipe.bri";
 
+/**
+ * Options for creating a symlink.
+ *
+ * @param target - The target path of the symlink
+ */
 export interface SymlinkOptions {
   target: string;
 }
@@ -10,7 +15,7 @@ export interface SymlinkOptions {
 /**
  * Create a new symlink pointing at a provided path.
  *
- * @param target - The target path of the symlink.
+ * @param opts - Options for the symlink target.
  *
  * @returns A new symlink pointing to the target path
  */

--- a/packages/std/core/semver.bri
+++ b/packages/std/core/semver.bri
@@ -237,8 +237,12 @@ function semverCompareConstraint(
  * Returns true if the given semantic version is compatible with the
  * given constraints. Multiple constraints can be separated with a comma.
  *
- * ## Example
+ * @param version - The semantic version to check
+ * @param constraints - The version constraints to match against
  *
+ * @returns True if the version matches the constraints, false otherwise
+ *
+ * @example
  * ```typescript
  * import * as std from "std";
  *

--- a/packages/std/core/utils.bri
+++ b/packages/std/core/utils.bri
@@ -14,8 +14,11 @@ export function assert(
  * Used as a type-checked assertion that a codepath is unreachable, such
  * as for pattern matching. Throws an error if called.
  *
- * ## Example
+ * @param never - The value that should never be reached
  *
+ * @returns Never returns - always throws an error
+ *
+ * @example
  * ```ts
  * type Fizzbuzz = "fizz" | "buzz";
  *
@@ -29,6 +32,7 @@ export function assert(
  *       // This branch can never be reached
  *       // (if a new variant is added, this will become a type error)
  *       return unreachable(value);
+ *   }
  * }
  * ```
  */
@@ -173,11 +177,15 @@ export function jsonSerialize(value: Equatable): string {
  * A template function that strips extra indentation from a string, useful
  * for including multiline strings, such as shell scripts or patch files.
  *
- * The first and last lines are removed if they are empty, and the level
+ * @description The first and last lines are removed if they are empty, and the level
  * of indentation is determined by the line with the smallest indentation.
  *
- * ## Example
+ * @param strings - Template string parts
+ * @param values - Template string values
  *
+ * @returns The dedented string with extra indentation removed
+ *
+ * @example
  * ```
  * const script = std.indoc`
  *   #!/bin/bash
@@ -250,10 +258,14 @@ export function mixin<T extends object, U extends object>(
  * Pipe a value through a list of functions, feeding the previous value as
  * the input to the next function.
  *
- * For recipes, see also the equivalent `.pipe()` method.
+ * @description For recipes, see also the equivalent `.pipe()` method.
  *
- * ## Example
+ * @param value - The initial value to pipe through the functions
+ * @param functions - The functions to pipe the value through
  *
+ * @returns The result of piping the value through all the functions
+ *
+ * @example
  * ```typescript
  * const result = std.pipe(
  *   value,

--- a/packages/std/extra/apply_patch.bri
+++ b/packages/std/extra/apply_patch.bri
@@ -1,6 +1,15 @@
 import * as std from "/core";
 import { tools } from "/toolchain";
 
+/**
+ * Options for applying a patch to a directory.
+ *
+ * @param source - The input directory recipe to patch.
+ * @param patch - The patch file to apply.
+ * @param strip - The number of components to strip from the patch's path.
+ *   Corresponds to the `-p` (`--strip`) flag of the `patch` command. Using
+ *   `null` corresponds to leaving the `-p` flag off.
+ */
 interface ApplyPatchOptions {
   source: std.RecipeLike<std.Directory>;
   patch: std.RecipeLike<std.File>;
@@ -10,11 +19,7 @@ interface ApplyPatchOptions {
 /**
  * Create a recipe that applies a patch to the provided directory.
  *
- * @param source - The input directory recipe to patch
- * @param patch - The patch file to apply
- * @param strip - The number of components to strip from the patch's path.
- * Corresponds to the `-p` (`--strip`) flag of the `patch` command. Using
- * `null` corresponds to leaving the `-p` flag off.
+ * @param opts - Options for applying the patch.
  *
  * @returns A recipe with the patch applied to the source directory
  *

--- a/packages/std/extra/apply_patch.bri
+++ b/packages/std/extra/apply_patch.bri
@@ -10,16 +10,15 @@ interface ApplyPatchOptions {
 /**
  * Create a recipe that applies a patch to the provided directory.
  *
- * ## Options
- *
- * - `source`: The input directory recipe to patch
- * - `patch`: The patch file to apply
- * - `strip`: The number of components to strip from the patch's path.
+ * @param source - The input directory recipe to patch
+ * @param patch - The patch file to apply
+ * @param strip - The number of components to strip from the patch's path.
  * Corresponds to the `-p` (`--strip`) flag of the `patch` command. Using
  * `null` corresponds to leaving the `-p` flag off.
  *
- * ## Example
+ * @returns A recipe with the patch applied to the source directory
  *
+ * @example
  * ```typescript
  * const source = Brioche.gitCheckout({
  *   repository: "https://github.com/kamiyaa/joshuto.git",

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -30,13 +30,18 @@ export interface BashRunnableUtils {
  * run the Bash script, but allows it to be run outside of Brioche, such
  * as by calling `brioche run` or by putting it into an OCI container image.
  *
- * The Bash script will be called with the `-e`, `-u`, and `-o pipefail`
+ * @description The Bash script will be called with the `-e`, `-u`, and `-o pipefail`
  * settings. Extra arguments are accessible through `$@`, just like a normal
  * Bash script.
  *
  * See also `std.runBash` to run a Bash script while baking!
  *
- * ## Example
+ * @param strings - The template string parts for the Bash script
+ * @param values - The template string values
+ *
+ * @returns A self-contained runnable recipe containing the Bash script
+ *
+ * @example
  *
  * ```typescript
  * import * as std from "std";

--- a/packages/std/extra/extra_global.bri
+++ b/packages/std/extra/extra_global.bri
@@ -17,18 +17,17 @@ declare global {
      * will be saved in the lockfile, so the same commit hash will be used
      * until the lockfile is updated.
      *
-     * See also the function `Brioche.gitRef`, which directly returns the
+     * @description See also the function `Brioche.gitRef`, which directly returns the
      * resolved commit hash instead.
      *
-     * ## Options
-     *
-     * - `repository`: A git repository URL.
-     * - `ref`: A git ref, such as a branch or tag name. Example: `main`
-     * - `options`: Extra options for the checkout. See the `gitCheckout`
+     * @param repository - A git repository URL.
+     * @param ref - A git ref, such as a branch or tag name. Example: `main`
+     * @param options - Extra options for the checkout. See the `gitCheckout`
      *   function from the `git` package for all available extra options.
      *
-     * ## Example
+     * @returns The checked out repository without history
      *
+     * @example
      * ```typescript
      * import * as std from "std";
      *

--- a/packages/std/extra/extra_global.bri
+++ b/packages/std/extra/extra_global.bri
@@ -3,6 +3,11 @@ import { source } from "/core/source.bri";
 import type { GitRefOptions } from "/core/global.bri";
 import type { GitCheckoutOptions } from "git";
 
+/**
+ * Options for checking out a git repository.
+ *
+ * @param options - Extra options for the checkout. See the `GitCheckoutOptions` interface.
+ */
 interface GitCheckoutInit extends GitRefOptions {
   options?: GitCheckoutOptions;
 }
@@ -20,10 +25,7 @@ declare global {
      * @description See also the function `Brioche.gitRef`, which directly returns the
      * resolved commit hash instead.
      *
-     * @param repository - A git repository URL.
-     * @param ref - A git ref, such as a branch or tag name. Example: `main`
-     * @param options - Extra options for the checkout. See the `gitCheckout`
-     *   function from the `git` package for all available extra options.
+     * @param options - Options for the git checkout.
      *
      * @returns The checked out repository without history
      *

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -11,6 +11,16 @@ import type {} from "nushell";
 const DEFAULT_REGEX_MATCH_TAG =
   /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
 
+/**
+ * Options for the live update from GitHub releases.
+ *
+ * @param project - The project export that should be updated. Must include a
+ *   `repository` property containing a GitHub repository URL.
+ * @param matchTag - A regex value (`/.../`) to extract the version number from
+ *   a tag name. The regex must include a group named "version". If not
+ *   provided, an optional "v" prefix will be stripped and the rest of the
+ *   tag will be checked if it's a semver or semver-like version number.
+ */
 interface LiveUpdateFromGithubReleasesOptions {
   project: { version: string; repository: string };
   matchTag?: RegExp;
@@ -22,12 +32,7 @@ interface LiveUpdateFromGithubReleasesOptions {
  * regex match against the latest tag name. The repository is inferrred from the
  * `repository` field of the project.
  *
- * @param project - The project export that should be updated. Must include a
- *   `repository` property containing a GitHub repository URL.
- * @param matchTag - A regex value (`/.../`) to extract the version number from
- *   a tag name. The regex must include a group named "version". If not
- *   provided, an optional "v" prefix will be stripped and the rest of the
- *   tag will be checked if it's a semver or semver-like version number.
+ * @param options - Options for the live update from GitHub releases.
  *
  * @returns A runnable recipe to live-update the project
  *

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -22,17 +22,16 @@ interface LiveUpdateFromGithubReleasesOptions {
  * regex match against the latest tag name. The repository is inferrred from the
  * `repository` field of the project.
  *
- * ## Options
- *
- * - `project`: The project export that should be updated. Must include a
+ * @param project - The project export that should be updated. Must include a
  *   `repository` property containing a GitHub repository URL.
- * - `matchTag`: A regex value (`/.../`) to extract the version number from
+ * @param matchTag - A regex value (`/.../`) to extract the version number from
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
  *   tag will be checked if it's a semver or semver-like version number.
  *
- * ## Example
+ * @returns A runnable recipe to live-update the project
  *
+ * @example
  * ```typescript
  * export const project = {
  *   name: "brioche",

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -1,6 +1,13 @@
 import * as std from "/core";
 import { runBash } from "./run_bash.bri";
 
+/**
+ * Options for creating an OCI container image.
+ *
+ * @param recipe - The recipe to use as the image layer.
+ * @param entrypoint - The entrypoint to use for the image.
+ *   Defaults to `["/brioche-run"]`.
+ */
 interface OciContainerImageOptions {
   recipe: std.RecipeLike<std.Directory>;
   entrypoint?: string[];
@@ -10,9 +17,7 @@ interface OciContainerImageOptions {
  * Create an OCI container image from a recipe. The recipe
  * will be included as a layer in the image.
  *
- * @param recipe - The recipe to use as the image layer.
- * @param entrypoint - The entrypoint to use for the image.
- *   Defaults to `["/brioche-run"]`.
+ * @param options - Options for the OCI container image.
  *
  * @returns An OCI container image with the recipe as a layer
  *

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -10,15 +10,13 @@ interface OciContainerImageOptions {
  * Create an OCI container image from a recipe. The recipe
  * will be included as a layer in the image.
  *
- * ## Options
- *
- * - `recipe`: The recipe to use as the image layer.
- * - `entrypoint`: The entrypoint to use for the image.
+ * @param recipe - The recipe to use as the image layer.
+ * @param entrypoint - The entrypoint to use for the image.
  *   Defaults to `["/brioche-run"]`.
  *
- * ## Notes
+ * @returns An OCI container image with the recipe as a layer
  *
- * The returned image matches the [OCI Image Layout Specification][oci-spec],
+ * @remarks The returned image matches the [OCI Image Layout Specification][oci-spec],
  * and additionally has a manifest file following the [Docker Image Specification][docker-spec].
  *
  * [oci-spec]: https://github.com/opencontainers/image-spec/blob/dd33f727e2faea07432ef6f06d6f9afe73f3f519/image-layout.md

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -10,12 +10,16 @@ import { tools } from "/toolchain";
  * extra dependencies or environment variables using `.dependencies()`
  * or `.env()`, respectively, along with other process options.
  *
- * See also `std.bashRunnable,` which will return a recipe that packages
+ * @description See also `std.bashRunnable,` which will return a recipe that packages
  * up a Bash script that can be run outside of Brioche.
  *
- * ## Example
+ * @param strings - The template string parts for the Bash script
+ * @param values - The template string values
  *
- * ``` typescript
+ * @returns A process recipe that runs the Bash script
+ *
+ * @example
+ * ```typescript
  * import * as std from "std";
  *
  * // Running `brioche build -o output` will create a directory `output`

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -32,11 +32,19 @@ export interface RunnableOptions {
  * Brioche, such as by calling `brioche run` or by putting it into an OCI
  * container image.
  *
- * See also `std.bashRunnable`, which allows running a full Bash script instead
+ * @description See also `std.bashRunnable`, which allows running a full Bash script instead
  * of a single command.
  *
- * ## Example
+ * @param recipe - The base recipe to add the runnable to
+ * @param options - Configuration for the runnable command
+ * @param options.command - The command to run
+ * @param options.args - Arguments to pass to the command
+ * @param options.env - Environment variables to set
+ * @param options.dependencies - Additional dependencies
  *
+ * @returns A runnable recipe with `brioche-run` executable
+ *
+ * @example
  * ```typescript
  * import * as std from "std";
  *
@@ -79,8 +87,17 @@ export function withRunnable(
  * Return a new recipe with an executable at `path` that runs the specified
  * command. This wraps the command so it can be run outside Brioche.
  *
- * ## Example
+ * @param recipe - The base recipe to add the executable to
+ * @param path - The path where the executable should be placed
+ * @param options - Configuration for the runnable command
+ * @param options.command - The command to run
+ * @param options.args - Arguments to pass to the command
+ * @param options.env - Environment variables to set
+ * @param options.dependencies - Additional dependencies
  *
+ * @returns A new recipe with an executable at the specified path
+ *
+ * @example
  * ```typescript
  * import * as std from "std";
  *

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -19,6 +19,14 @@ export interface WithRunnableUtils {
   dependencies(...dependencies: std.RecipeLike<std.Directory>[]): WithRunnable;
 }
 
+/**
+ * Options for configuring a runnable command.
+ *
+ * @param command - The command to run
+ * @param args - Arguments to pass to the command
+ * @param env - Environment variables to set when running the command
+ * @param dependencies - Additional dependencies to include in the `$PATH`
+ */
 export interface RunnableOptions {
   command: RunnableTemplateValue;
   args?: RunnableTemplateValue[];
@@ -35,12 +43,8 @@ export interface RunnableOptions {
  * @description See also `std.bashRunnable`, which allows running a full Bash script instead
  * of a single command.
  *
- * @param recipe - The base recipe to add the runnable to
- * @param options - Configuration for the runnable command
- * @param options.command - The command to run
- * @param options.args - Arguments to pass to the command
- * @param options.env - Environment variables to set
- * @param options.dependencies - Additional dependencies
+ * @param recipe - The base recipe to add the runnable to.
+ * @param options - Options for the runnable command.
  *
  * @returns A runnable recipe with `brioche-run` executable
  *
@@ -87,13 +91,9 @@ export function withRunnable(
  * Return a new recipe with an executable at `path` that runs the specified
  * command. This wraps the command so it can be run outside Brioche.
  *
- * @param recipe - The base recipe to add the executable to
- * @param path - The path where the executable should be placed
- * @param options - Configuration for the runnable command
- * @param options.command - The command to run
- * @param options.args - Arguments to pass to the command
- * @param options.env - Environment variables to set
- * @param options.dependencies - Additional dependencies
+ * @param recipe - The base recipe to add the executable to.
+ * @param path - The path where the executable should be placed.
+ * @param options - Options for the runnable command.
  *
  * @returns A new recipe with an executable at the specified path
  *

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -12,12 +12,20 @@ export type EnvValue =
  * variables will be set when the recipe is included as a dependency for a
  * process recipe.
  *
- * Each environment variable can be set to either append one or more paths
+ * @description Each environment variable can be set to either append one or more paths
  * (relative to the root of the recipe), or set a fallback path / value
  * if the environment variable is empty.
  *
- * ## Example
+ * @param recipe - The recipe to add environment variables to
+ * @param env - An object mapping environment variable names to their configuration.
+ *   Each value can be:
+ *   - `{ append: [{ path: string }] }`: Append paths to the environment variable
+ *   - `{ fallback: { path: string } }`: Set a fallback path if the variable is empty
+ *   - `{ fallback: { value: string } }`: Set a fallback value if the variable is empty
  *
+ * @returns A new recipe with the specified environment variables configured
+ *
+ * @example
  * ```typescript
  * let myLibrary = std.runBash`
  *   mkdir -p "$BRIOCHE_OUTPUT/lib"

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -5,11 +5,15 @@ import * as std from "/core";
  * run with `brioche run` or when the recipe is put into an OCI container
  * image.
  *
- * This will add a symlink from `brioche-run` to the specified path, which
+ * @description This will add a symlink from `brioche-run` to the specified path, which
  * is used by `brioche run` to determine the executable to run.
  *
- * ## Example
+ * @param recipe - The recipe to add the runnable link to
+ * @param path - The path to the executable within the recipe
  *
+ * @returns A new recipe with a `brioche-run` symlink pointing to the specified path
+ *
+ * @example
  * ```typescript
  * import * as std from "std";
  *

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -9,7 +9,7 @@ import * as std from "/core";
  * is used by `brioche run` to determine the executable to run.
  *
  * @param recipe - The recipe to add the runnable link to
- * @param path - The path to the executable within the recipe
+ * @param runPath - The path to the executable within the recipe
  *
  * @returns A new recipe with a `brioche-run` symlink pointing to the specified path
  *


### PR DESCRIPTION
This PR standardizes the documentation style by replacing informal option lists with TSDoc-style `@param`, `@returns`, and `@example` annotations. This improves code readability and consistency, plus it helps for better IDE integration when `bri` files are configured to be recognized as TypeScript files.