### PR TITLE
feat(asdf): add package

### DIFF
--- a/packages/asdf/brioche.lock
+++ b/packages/asdf/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/asdf-vm/asdf": {
+      "v0.18.0": "80fffd86853fbfcc31e6a52aee99f8ab3d5fae9f"
+    }
+  }
+}

--- a/packages/asdf/project.bri
+++ b/packages/asdf/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "asdf",
+  version: "0.18.0",
+  repository: "https://github.com/asdf-vm/asdf",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function asdf(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      generate: true,
+      ldflags: ["-s", "-w"],
+    },
+    path: "./cmd/asdf",
+    runnable: "bin/asdf",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    asdf version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(asdf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate() {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`asdf`](https://github.com/asdf-vm/asdf): an extendable version manager with support for Ruby, Node.js, Elixir, Erlang & more

```bash
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche run -e liveUpdate -p packages/asdf/
Build finished, completed (no new jobs) in 9.81s
Running brioche-run
{
  "name": "asdf",
  "version": "0.18.0",
  "repository": "https://github.com/asdf-vm/asdf"
}
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ brioche build -e test -p packages/asdf/
Build finished, completed (no new jobs) in 1.98s
Result: 7facc46b0b89ffc294c8970c5e57524d291e51d1991376336d628c600e6b42f3
```