### PR TITLE
Update pkgconfig relative paths

### DIFF
--- a/packages/nlohmann_json/project.bri
+++ b/packages/nlohmann_json/project.bri
@@ -17,8 +17,6 @@ export default function nlohmannJson(): std.Recipe<std.Directory> {
     source,
     dependencies: [std.toolchain],
     set: {
-      // By default, the data directory will be set to "share", but we want it to be "lib"
-      CMAKE_INSTALL_DATADIR: "lib",
       JSON_BuildTests: "OFF",
       JSON_MultipleHeaders: "ON",
     },
@@ -26,7 +24,7 @@ export default function nlohmannJson(): std.Recipe<std.Directory> {
     std.setEnv(recipe, {
       CPATH: { append: [{ path: "include" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
-      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
       CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
     }),
   );

--- a/packages/nlohmann_json/project.bri
+++ b/packages/nlohmann_json/project.bri
@@ -23,7 +23,6 @@ export default function nlohmannJson(): std.Recipe<std.Directory> {
   }).pipe((recipe) =>
     std.setEnv(recipe, {
       CPATH: { append: [{ path: "include" }] },
-      LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
       CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
     }),

--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -9,18 +9,35 @@ import { runBash } from "./run_bash.bri";
  * environments without needing to modify them manually.
  *
  * @param recipe - The recipe to apply the transformation to.
+ *
  * @returns A new recipe with the transformed pkg-config files.
+ *
+ * @remark This function looks for pkg-config files in the standard locations
+ *   `lib/pkgconfig` and `share/pkgconfig` relative to the `$BRIOCHE_OUTPUT`
+ *   output directory.
  */
 export function pkgConfigMakePathsRelative(
   recipe: std.RecipeLike<std.Directory>,
 ): std.Recipe<std.Directory> {
   return runBash`
-    if [ ! -e "$BRIOCHE_OUTPUT"/lib/pkgconfig ]; then
-      # pkg-config dir does not exist
+    # Candidate pkg-config directories relative to $BRIOCHE_OUTPUT
+    pkg_dirs=(lib/pkgconfig share/pkgconfig)
+
+    # Collect only those that are present
+    find_roots=()
+    for rel in "\${pkg_dirs[@]}"; do
+      dir="$BRIOCHE_OUTPUT/$rel"
+      if [[ -d "$dir" ]]; then
+        find_roots+=("$dir")
+      fi
+    done
+
+    # No pkg-config dir found, exit
+    if [[ \${#find_roots[@]} -eq 0 ]]; then
       exit 0
     fi
 
-    find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
+    find "\${find_roots[@]}" -name '*.pc' -type f -print0 \
       | while IFS= read -r -d $'\\0' file; do
         sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
       done


### PR DESCRIPTION
This PR includes changes to improve the handling of pkg-config directories to better handle search path outside of the usual `lib` folder. Some packages put their pkg-config files inside the `share` folder. And we were having a workaround for that in the `nlohmann_json` recipe.

I'm also working on another [recipe](https://www.linuxfromscratch.org/blfs/view/svn/x/util-macros.html) (I'll upstream soon) that also exposes their pkg-config files in the same `share` folder. So, I thought it was worth the modification here. Since it could reduce the burden when packaging new libraries by abstracting the usual locations for the pkg-config files.

```bash
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ rm -rf /tmp/output; brioche build -o /tmp/output -p packages/nlohmann_json/
Build finished, completed (no new jobs) in 1.99s
Result: 5dcbfac91365fcab5619233f8cd2a88423c226dbaaf22a32695d16a66c1761ff
Writing output
Wrote output to /tmp/output

jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ ls /tmp/output/
brioche-env.d/ include/       share/

jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ ls /tmp/output/share/
cmake  pkgconfig