### PR TITLE
refactor: remove redundant parentheses in template literals

### DIFF
--- a/examples/nodejs_frontend/project.bri
+++ b/examples/nodejs_frontend/project.bri
@@ -28,7 +28,7 @@ export function staticSite(): std.Recipe<std.Directory> {
     .env({
       // NOTE: Rollup needs a dynamic library provided by the toolchain.
       // Setting `$LD_LIBRARY_PATH` allows Node.js to find this library.
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain()}/lib`,
+      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
     })
     .toDirectory();
 }

--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -78,7 +78,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   `
     .dependencies(std.toolchain)
     .env({
-      I18NPATH: std.tpl`${std.toolchain()}/share/i18n`,
+      I18NPATH: std.tpl`${std.toolchain}/share/i18n`,
     })
     .toDirectory();
 

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -81,7 +81,7 @@ export default function awsCli(): std.Recipe<std.Directory> {
       PATH: std.tpl`${std.outputPath}/bin`,
       PIP_NO_INDEX: "1",
       PIP_FIND_LINKS: dependencies,
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain()}/lib`,
+      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
     })
     .outputScaffold(venv)
     .toDirectory();

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -113,12 +113,12 @@ export default function linux(
 
       // Needed since we're using `ld.bfd`, which tries to resolve transitive
       // dependencies for libraries, so it needs to know where to look
-      HOSTLDFLAGS: std.tpl`-Wl,-rpath-link,${std.toolchain()}/lib`,
+      HOSTLDFLAGS: std.tpl`-Wl,-rpath-link,${std.toolchain}/lib`,
 
       // Needed because tools from the kernel build use `pthread_exit`, which
       // dynamically opens `libgcc_s.so.1`, which is not directly a dependency
       // of glibc
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain()}/lib`,
+      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
 
       ...env,
     })
@@ -232,7 +232,7 @@ export function linuxUpdateConfig(
 
   return std
     .process({
-      command: std.tpl`${linuxSource()}/scripts/config`,
+      command: std.tpl`${linuxSource}/scripts/config`,
       args: ["--file", std.outputPath, ...args],
       dependencies: [std.tools],
       outputScaffold: config,

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -193,7 +193,7 @@ export function npmInstallGlobal(
       // Use a Nushell script to get a list of installed bin symlinks to wrap
       const binsJson = await std
         .process({
-          command: std.tpl`${nushell()}/bin/nu`,
+          command: std.tpl`${nushell}/bin/nu`,
           args: [Brioche.includeFile("find-nodejs-bins.nu")],
           env: {
             recipe,

--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -20,7 +20,7 @@ export default function perl(): std.Recipe<std.Directory> {
   `
     .dependencies(std.toolchain)
     .env({
-      I18NPATH: std.tpl`${std.toolchain()}/share/i18n`,
+      I18NPATH: std.tpl`${std.toolchain}/share/i18n`,
     })
     .toDirectory();
 

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -306,7 +306,7 @@ export function cargoBuild(options: CargoBuildOptions) {
   // Use `cargo install` to build and install the project to `$BRIOCHE_OUTPUT`
   let buildResult = std
     .process({
-      command: std.tpl`${rust()}/bin/cargo`,
+      command: std.tpl`${rust}/bin/cargo`,
       args: [
         "install",
 

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -4,7 +4,7 @@ import { type Recipe, createRecipe } from "./recipe.bri";
 
 /**
  * Options required to download a file from a URL.
- * 
+ *
  * @param url - The URL to download
  * @param hash - The hash to verify the downloaded content
  */

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -13,7 +13,7 @@ import { castToFile, castToDirectory, castToSymlink } from "./cast.bri";
 
 /**
  * Process options.
- * 
+ *
  * @param command - The command to run. Should either be a template, or a
  *   string referencing a command from `dependencies`.
  * @param args - An array of arguments to pass to the command.
@@ -40,10 +40,10 @@ export type ProcessOptions = {
 
 /**
  * Unsafe options for a process.
- * 
+ *
  * @remark You must take extra care to ensure that running the process is hermetic
  *   when using these options!
- * 
+ *
  * @param networking - Set to `true` to allow the process to access the network.
  */
 export interface ProcessUnsafeOptions {
@@ -122,7 +122,7 @@ export interface ProcessUtils {
  * ```typescript
  * // Call Bash and write "Hello world!" to the output path
  * std.process({
- *   command: std.tpl`${std.tools()}/bin/bash`,
+ *   command: std.tpl`${std.tools}/bin/bash`,
  *   args: ["-c", 'echo "Hello world!" > "$BRIOCHE_OUTPUT"'],
  * });
  * ```

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -34,7 +34,7 @@ export function autopack(
 
   return std
     .process({
-      command: std.tpl`${runtimeUtils()}/bin/brioche-packer`,
+      command: std.tpl`${runtimeUtils}/bin/brioche-packer`,
       args: [
         "autopack",
         std.outputPath,

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -44,7 +44,7 @@ export function runBash(
 ): std.Process {
   const script = std.indoc(strings, ...values);
   return std.process({
-    command: std.tpl`${tools()}/bin/bash`,
+    command: std.tpl`${tools}/bin/bash`,
     args: ["-e", "-u", "-o", "pipefail", "-c", script],
     dependencies: [tools],
   });

--- a/packages/std/toolchain/native/acl.bri
+++ b/packages/std/toolchain/native/acl.bri
@@ -11,7 +11,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let acl = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -25,9 +25,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
-        CPPFLAGS: std.tpl`-I${attr()}/include`,
-        LDFLAGS: std.tpl`-L${attr()}/lib`,
+        PATH: std.tpl`${stage2}/bin`,
+        CPPFLAGS: std.tpl`-I${attr}/include`,
+        LDFLAGS: std.tpl`-L${attr}/lib`,
       },
       workDir: source,
     })
@@ -35,7 +35,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   acl = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -46,7 +46,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: acl,
     })

--- a/packages/std/toolchain/native/attr.bri
+++ b/packages/std/toolchain/native/attr.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/autoconf.bri
+++ b/packages/std/toolchain/native/autoconf.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
     .peel();
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -23,7 +23,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -31,7 +31,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let autoconf = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -51,7 +51,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/automake.bri
+++ b/packages/std/toolchain/native/automake.bri
@@ -12,7 +12,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -27,13 +27,13 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${autoconf()}/bin:${stage2()}/bin`,
-        M4: std.tpl`${m4()}/bin/m4`,
-        AUTOM4TE: std.tpl`${autoconf()}/bin/autom4te`,
-        trailer_m4: std.tpl`${autoconf()}/share/autoconf/autoconf/trailer.m4`,
-        PERL5LIB: std.tpl`${autoconf()}/share/autoconf`,
-        autom4te_perllibdir: std.tpl`${autoconf()}/share/autoconf`,
-        AC_MACRODIR: std.tpl`${autoconf()}/share/autoconf`,
+        PATH: std.tpl`${autoconf}/bin:${stage2}/bin`,
+        M4: std.tpl`${m4}/bin/m4`,
+        AUTOM4TE: std.tpl`${autoconf}/bin/autom4te`,
+        trailer_m4: std.tpl`${autoconf}/share/autoconf/autoconf/trailer.m4`,
+        PERL5LIB: std.tpl`${autoconf}/share/autoconf`,
+        autom4te_perllibdir: std.tpl`${autoconf}/share/autoconf`,
+        AC_MACRODIR: std.tpl`${autoconf}/share/autoconf`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/bash.bri
+++ b/packages/std/toolchain/native/bash.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let bash = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,7 +26,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       ],
       env: {
         source: source,
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/bc.bri
+++ b/packages/std/toolchain/native/bc.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -27,7 +27,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/binutils.bri
+++ b/packages/std/toolchain/native/binutils.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let binutils = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -37,9 +37,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin:${flex()}/bin`,
-        CPPFLAGS: std.tpl`-I${zlib()}/include`,
-        LDFLAGS: std.tpl`-L${zlib()}/lib`,
+        PATH: std.tpl`${stage2}/bin:${flex}/bin`,
+        CPPFLAGS: std.tpl`-I${zlib}/include`,
+        LDFLAGS: std.tpl`-L${zlib}/lib`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/bison.bri
+++ b/packages/std/toolchain/native/bison.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/bzip2.bri
+++ b/packages/std/toolchain/native/bzip2.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -27,7 +27,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       ],
       env: {
         sourcePatch,
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -35,7 +35,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -54,7 +54,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       ],
       env: {
         sourcePatch,
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/coreutils.bri
+++ b/packages/std/toolchain/native/coreutils.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/diffutils.bri
+++ b/packages/std/toolchain/native/diffutils.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/expat.bri
+++ b/packages/std/toolchain/native/expat.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/file.bri
+++ b/packages/std/toolchain/native/file.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/findutils.bri
+++ b/packages/std/toolchain/native/findutils.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/flex.bri
+++ b/packages/std/toolchain/native/flex.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let flex = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/gawk.bri
+++ b/packages/std/toolchain/native/gawk.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -21,7 +21,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -29,7 +29,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -41,7 +41,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/gcc.bri
+++ b/packages/std/toolchain/native/gcc.bri
@@ -19,7 +19,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -32,7 +32,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -55,7 +55,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
   // TODO: Enable NLS
   let gcc = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -91,9 +91,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${buildSysroot}/bin:${stage2()}/bin`,
-        CPPFLAGS: std.tpl`-I${zlib()}/include -I${gmp()}/include -I${mpfr()}/include -I${mpc()}/include -isystem ${stage2()}/usr/lib/gcc/x86_64-lfs-linux-gnu/13.2.0/include -isystem ${buildSysroot}/include -isystem ${buildSysroot}/usr/include`,
-        LDFLAGS: std.tpl`-L${zlib()}/lib -L${gmp()}/lib -L${mpfr()}/lib -L${mpc()}/lib -L${buildSysroot}/lib -L${buildSysroot}/lib64 -lm --sysroot=${buildSysroot}`,
+        PATH: std.tpl`${buildSysroot}/bin:${stage2}/bin`,
+        CPPFLAGS: std.tpl`-I${zlib}/include -I${gmp}/include -I${mpfr}/include -I${mpc}/include -isystem ${stage2}/usr/lib/gcc/x86_64-lfs-linux-gnu/13.2.0/include -isystem ${buildSysroot}/include -isystem ${buildSysroot}/usr/include`,
+        LDFLAGS: std.tpl`-L${zlib}/lib -L${gmp}/lib -L${mpfr}/lib -L${mpc}/lib -L${buildSysroot}/lib -L${buildSysroot}/lib64 -lm --sysroot=${buildSysroot}`,
         buildSysroot,
         gmp: gmp(),
         mpfr: mpfr(),

--- a/packages/std/toolchain/native/gdbm.bri
+++ b/packages/std/toolchain/native/gdbm.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -25,7 +25,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/gettext.bri
+++ b/packages/std/toolchain/native/gettext.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,7 +26,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       ],
       env: {
         source,
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/glibc.bri
+++ b/packages/std/toolchain/native/glibc.bri
@@ -16,7 +16,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -28,7 +28,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         sourcePatchFhs,
         sourcePatchMemalign,
       },
@@ -38,7 +38,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let glibc = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -67,7 +67,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         stage2: stage2(),
       },
       workDir: source,

--- a/packages/std/toolchain/native/gmp.bri
+++ b/packages/std/toolchain/native/gmp.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,7 +26,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/gperf.bri
+++ b/packages/std/toolchain/native/gperf.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/grep.bri
+++ b/packages/std/toolchain/native/grep.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -21,7 +21,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -29,7 +29,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -41,7 +41,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/groff.bri
+++ b/packages/std/toolchain/native/groff.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/gzip.bri
+++ b/packages/std/toolchain/native/gzip.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -336,7 +336,7 @@ function autopack(
 
   return std
     .process({
-      command: std.tpl`${runtimeUtils()}/bin/brioche-packer`,
+      command: std.tpl`${runtimeUtils}/bin/brioche-packer`,
       args: [
         "autopack",
         std.outputPath,
@@ -356,7 +356,7 @@ function fixShebangs(
   // `/usr/bin/env`. This currently duplicates the fix from stage 2
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -392,7 +392,7 @@ function fixShebangs(
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: recipe,
     })
@@ -406,7 +406,7 @@ function pkgConfigMakePathsRelative(
   // relative paths (using the `${pcfiledir}` variable)
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -419,7 +419,7 @@ function pkgConfigMakePathsRelative(
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: recipe,
     })

--- a/packages/std/toolchain/native/inetutils.bri
+++ b/packages/std/toolchain/native/inetutils.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -35,7 +35,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/intltool.bri
+++ b/packages/std/toolchain/native/intltool.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -34,7 +34,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -46,10 +46,10 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${perlDep}/bin:${stage2()}/bin`,
+        PATH: std.tpl`${perlDep}/bin:${stage2}/bin`,
 
         // expat is dynamically loaded by the Perl XML::Parser module
-        LD_LIBRARY_PATH: std.tpl`${expat()}/lib`,
+        LD_LIBRARY_PATH: std.tpl`${expat}/lib`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/less.bri
+++ b/packages/std/toolchain/native/less.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -24,7 +24,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/libelf.bri
+++ b/packages/std/toolchain/native/libelf.bri
@@ -18,7 +18,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -37,9 +37,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain}/bin:${bzip2()}/bin:${stage2()}/bin`,
-        LDFLAGS: std.tpl`-L${zlib()}/lib`,
-        CPPFLAGS: std.tpl`-I${zlib()}/include`,
+        PATH: std.tpl`${toolchain}/bin:${bzip2}/bin:${stage2}/bin`,
+        LDFLAGS: std.tpl`-L${zlib}/lib`,
+        CPPFLAGS: std.tpl`-I${zlib}/include`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/libpipeline.bri
+++ b/packages/std/toolchain/native/libpipeline.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/libtool.bri
+++ b/packages/std/toolchain/native/libtool.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -23,7 +23,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/libxcrypt.bri
+++ b/packages/std/toolchain/native/libxcrypt.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -27,7 +27,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/linux_headers.bri
+++ b/packages/std/toolchain/native/linux_headers.bri
@@ -10,7 +10,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,7 +26,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/m4.bri
+++ b/packages/std/toolchain/native/m4.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/make.bri
+++ b/packages/std/toolchain/native/make.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/man_db.bri
+++ b/packages/std/toolchain/native/man_db.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -30,14 +30,14 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin:${groff()}/bin`,
-        MAGIC: std.tpl`${stage2()}/usr/share/misc/magic`,
-        libpipeline_CFLAGS: std.tpl`-I${libpipeline()}/include`,
-        libpipeline_LIBS: std.tpl`-L${libpipeline()}/lib -lpipeline`,
-        CFLAGS: std.tpl`-I${gdbm()}/include`,
-        LDFLAGS: std.tpl`-L${gdbm()}/lib -lgdbm`,
-        GROFF_FONT_PATH: std.tpl`${groff()}/share/groff/current/font`,
-        GROFF_TMAC_PATH: std.tpl`${groff()}/share/groff/current/tmac`,
+        PATH: std.tpl`${stage2}/bin:${groff}/bin`,
+        MAGIC: std.tpl`${stage2}/usr/share/misc/magic`,
+        libpipeline_CFLAGS: std.tpl`-I${libpipeline}/include`,
+        libpipeline_LIBS: std.tpl`-L${libpipeline}/lib -lpipeline`,
+        CFLAGS: std.tpl`-I${gdbm}/include`,
+        LDFLAGS: std.tpl`-L${gdbm}/lib -lgdbm`,
+        GROFF_FONT_PATH: std.tpl`${groff}/share/groff/current/font`,
+        GROFF_TMAC_PATH: std.tpl`${groff}/share/groff/current/tmac`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/mpc.bri
+++ b/packages/std/toolchain/native/mpc.bri
@@ -12,7 +12,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,9 +26,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
-        CPPFLAGS: std.tpl`-I${gmp()}/include -I${mpfr()}/include`,
-        LDFLAGS: std.tpl`-L${gmp()}/lib -L${mpfr()}/lib`,
+        PATH: std.tpl`${stage2}/bin`,
+        CPPFLAGS: std.tpl`-I${gmp}/include -I${mpfr}/include`,
+        LDFLAGS: std.tpl`-L${gmp}/lib -L${mpfr}/lib`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/mpfr.bri
+++ b/packages/std/toolchain/native/mpfr.bri
@@ -11,7 +11,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -25,7 +25,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       outputScaffold: source,
     })
@@ -33,7 +33,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let mpfr = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -48,9 +48,9 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
-        CPPFLAGS: std.tpl`-I${gmp()}/include`,
-        LDFLAGS: std.tpl`-L${gmp()}/lib`,
+        PATH: std.tpl`${stage2}/bin`,
+        CPPFLAGS: std.tpl`-I${gmp}/include`,
+        LDFLAGS: std.tpl`-L${gmp}/lib`,
       },
       workDir: source,
     })
@@ -59,7 +59,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
   let libtoolArchive = mpfr.get("lib/libmpfr.la");
   libtoolArchive = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -69,7 +69,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         libtoolArchive,
       },
     })

--- a/packages/std/toolchain/native/ncurses.bri
+++ b/packages/std/toolchain/native/ncurses.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let ncurses = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -30,7 +30,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/patch.bri
+++ b/packages/std/toolchain/native/patch.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/patchelf.bri
+++ b/packages/std/toolchain/native/patchelf.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,18 +26,18 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${autoconf()}/bin:${automake()}/bin:${stage2()}/bin`,
+        PATH: std.tpl`${autoconf}/bin:${automake}/bin:${stage2}/bin`,
         // TODO: Move these variables into `autoconf()` / `automake()`
-        M4: std.tpl`${m4()}/bin/m4`,
-        AUTOM4TE: std.tpl`${autoconf()}/bin/autom4te`,
-        trailer_m4: std.tpl`${autoconf()}/share/autoconf/autoconf/trailer.m4`,
-        PERL5LIB: std.tpl`${autoconf()}/share/autoconf:${automake()}/share/automake-1.16`,
-        autom4te_perllibdir: std.tpl`${autoconf()}/share/autoconf`,
-        AC_MACRODIR: std.tpl`${autoconf()}/share/autoconf`,
-        ACLOCAL_AUTOMAKE_DIR: std.tpl`${automake()}/share/aclocal-1.16`,
+        M4: std.tpl`${m4}/bin/m4`,
+        AUTOM4TE: std.tpl`${autoconf}/bin/autom4te`,
+        trailer_m4: std.tpl`${autoconf}/share/autoconf/autoconf/trailer.m4`,
+        PERL5LIB: std.tpl`${autoconf}/share/autoconf:${automake}/share/automake-1.16`,
+        autom4te_perllibdir: std.tpl`${autoconf}/share/autoconf`,
+        AC_MACRODIR: std.tpl`${autoconf}/share/autoconf`,
+        ACLOCAL_AUTOMAKE_DIR: std.tpl`${automake}/share/aclocal-1.16`,
         AUTOMAKE_UNINSTALLED: "1",
-        AUTOCONF: std.tpl`${autoconf()}/bin/autoconf`,
-        AUTOMAKE_LIBDIR: std.tpl`${automake()}/share/automake-1.16`,
+        AUTOCONF: std.tpl`${autoconf}/bin/autoconf`,
+        AUTOMAKE_LIBDIR: std.tpl`${automake}/share/automake-1.16`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/perl.bri
+++ b/packages/std/toolchain/native/perl.bri
@@ -12,7 +12,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -30,7 +30,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         zlib: zlib(),
         bzip2: bzip2(),
         BUILD_ZLIB: "FALSE",

--- a/packages/std/toolchain/native/perl_xml_parser.bri
+++ b/packages/std/toolchain/native/perl_xml_parser.bri
@@ -12,7 +12,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -28,7 +28,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${perl()}/bin:${stage2()}/bin`,
+        PATH: std.tpl`${perl}/bin:${stage2}/bin`,
         expat: expat(),
       },
       workDir: source,

--- a/packages/std/toolchain/native/pkgconf.bri
+++ b/packages/std/toolchain/native/pkgconf.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   let pkgconf = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -26,7 +26,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/procps_ng.bri
+++ b/packages/std/toolchain/native/procps_ng.bri
@@ -12,7 +12,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -27,13 +27,13 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin:${pkgconf()}/bin`,
-        MAGIC: std.tpl`${stage2()}/usr/share/misc/magic`,
-        CFLAGS: std.tpl`-I${ncurses()}/include`,
-        LDFLAGS: std.tpl`-L${ncurses()}/lib`,
-        NCURSES_CFLAGS: std.tpl`-I${ncurses()}/include`,
-        NCURSES_LIBS: std.tpl`-L${ncurses()}/lib -lncursesw`,
-        PKG_CONFIG_PATH: std.tpl`${ncurses()}/lib/pkgconfig`,
+        PATH: std.tpl`${stage2}/bin:${pkgconf}/bin`,
+        MAGIC: std.tpl`${stage2}/usr/share/misc/magic`,
+        CFLAGS: std.tpl`-I${ncurses}/include`,
+        LDFLAGS: std.tpl`-L${ncurses}/lib`,
+        NCURSES_CFLAGS: std.tpl`-I${ncurses}/include`,
+        NCURSES_LIBS: std.tpl`-L${ncurses}/lib -lncursesw`,
+        PKG_CONFIG_PATH: std.tpl`${ncurses}/lib/pkgconfig`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/psmisc.bri
+++ b/packages/std/toolchain/native/psmisc.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/readline.bri
+++ b/packages/std/toolchain/native/readline.bri
@@ -13,7 +13,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   source = std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -28,7 +28,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         sourcePatch,
       },
       outputScaffold: source,
@@ -37,7 +37,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -51,7 +51,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
         sourcePatch,
       },
       workDir: source,

--- a/packages/std/toolchain/native/sed.bri
+++ b/packages/std/toolchain/native/sed.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/tar.bri
+++ b/packages/std/toolchain/native/tar.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/texinfo.bri
+++ b/packages/std/toolchain/native/texinfo.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/util_linux.bri
+++ b/packages/std/toolchain/native/util_linux.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -41,7 +41,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/which.bri
+++ b/packages/std/toolchain/native/which.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/xz.bri
+++ b/packages/std/toolchain/native/xz.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/zlib.bri
+++ b/packages/std/toolchain/native/zlib.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-c",
         "-euo",
@@ -22,7 +22,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/zstd.bri
+++ b/packages/std/toolchain/native/zstd.bri
@@ -10,7 +10,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${stage2()}/bin/bash`,
+      command: std.tpl`${stage2}/bin/bash`,
       args: [
         "-euo",
         "pipefail",
@@ -21,7 +21,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${stage2()}/bin`,
+        PATH: std.tpl`${stage2}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_19_gettext.bri
+++ b/packages/std/toolchain/stage2/2_19_gettext.bri
@@ -24,8 +24,8 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin`,
-        GCONV_PATH: std.tpl`${toolchain()}/usr/lib/gconv`,
+        PATH: std.tpl`${toolchain}/bin`,
+        GCONV_PATH: std.tpl`${toolchain}/usr/lib/gconv`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_20_bison.bri
+++ b/packages/std/toolchain/stage2/2_20_bison.bri
@@ -26,7 +26,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin`,
+        PATH: std.tpl`${toolchain}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_21_perl.bri
+++ b/packages/std/toolchain/stage2/2_21_perl.bri
@@ -26,7 +26,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin`,
+        PATH: std.tpl`${toolchain}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_22_python.bri
+++ b/packages/std/toolchain/stage2/2_22_python.bri
@@ -24,7 +24,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin`,
+        PATH: std.tpl`${toolchain}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_23_texinfo.bri
+++ b/packages/std/toolchain/stage2/2_23_texinfo.bri
@@ -24,7 +24,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin:${perl()}/usr/bin`,
+        PATH: std.tpl`${toolchain}/bin:${perl}/usr/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/2_24_util_linux.bri
+++ b/packages/std/toolchain/stage2/2_24_util_linux.bri
@@ -39,7 +39,7 @@ export default std.memo(async (): Promise<std.Recipe<std.Directory>> => {
         `,
       ],
       env: {
-        PATH: std.tpl`${toolchain()}/bin`,
+        PATH: std.tpl`${toolchain}/bin`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/stage2/index.bri
+++ b/packages/std/toolchain/stage2/index.bri
@@ -23,7 +23,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
 
   return std
     .process({
-      command: std.tpl`${toolchain()}/bin/bash`,
+      command: std.tpl`${toolchain}/bin/bash`,
       args: [
         "-euo",
         "pipefail",


### PR DESCRIPTION
This PR standardizes the usage of `std.tpl` by removing now unnecessary parenthesis.