### PR TITLE
Uniformize TSDoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To contribute a new package, check out this repo, create a new project under `pa
 
 For example, if you were going to add a new package called "fizzbuzz", you would create the directory `packages/fizzbuzz/`, add the file `project.bri`, then write the build script. You could also test it locally by running `brioche build -p ./packages/fizzbuzz`.
 
-Every published package must include a `project` export setting it's name (and optionally a version number):
+Every published package must include a `project` export setting its name (and optionally a version number):
 
 ```ts
 export const project = {

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -127,7 +127,7 @@ export type CMakeVariableType =
 /**
  * Generate and build a CMake project.
  *
- * @description A project buildsystem will be generated out-of-tree from the source project,
+ * @description A project build system will be generated out-of-tree from the source project,
  * and will be built and installed automatically with the chosen build
  * generator.
  *

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -73,7 +73,7 @@ export function liveUpdate(): std.WithRunnable {
 
 /**
  * Options for building and installing a NPM package.
- * 
+ *
  * @param source - The NPM package dependencies to install.
  */
 interface NpmInstallOptions {

--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -32,7 +32,7 @@ declare global {
      * Include a file from the filesystem. The path is relative to the
      * current Brioche module, and cannot go outside the project root.
      *
-     * @param path - The relative path to the file to include
+     * @param path - The relative path to the file to include.
      *
      * @returns A file recipe with the contents of the specified file
      *
@@ -56,7 +56,7 @@ declare global {
      * Include a directory from the filesystem. The path is relative to the
      * current Brioche module, and cannot go outside the project root.
      *
-     * @param path - The relative path to the directory to include
+     * @param path - The relative path to the directory to include.
      *
      * @returns A directory recipe containing all files in the specified directory
      *
@@ -84,7 +84,7 @@ declare global {
      * relative to the current Brioche module. The glob pattern will not
      * match any paths if it tries going outside the current module directory.
      *
-     * @param patterns - One or more glob patterns to match files
+     * @param patterns - One or more glob patterns to match files.
      *
      * @returns A directory recipe containing all files matching the glob patterns
      *

--- a/packages/std/core/recipes/directory.bri
+++ b/packages/std/core/recipes/directory.bri
@@ -12,7 +12,7 @@ import {
  * Constructs a new directory. Takes an object argument, where each key
  * is a filename and each value is a recipe
  *
- * @param entries - An object mapping filenames to recipes
+ * @param entries - An object mapping filenames to recipes.
  *
  * @returns A directory recipe containing the specified entries
  *

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -5,8 +5,8 @@ import { type Recipe, createRecipe } from "./recipe.bri";
 /**
  * Options required to download a file from a URL.
  *
- * @param url - The URL to download
- * @param hash - The hash to verify the downloaded content
+ * @param url - The URL to download.
+ * @param hash - The hash to verify the downloaded content.
  */
 export interface DownloadOptions {
   url: string;
@@ -21,7 +21,7 @@ export interface DownloadOptions {
  * @description See also `Brioche.download`, which does not require specifying
  * a hash, but only works with a constant URL.
  *
- * @param opts - Download options including URL and hash
+ * @param opts - Download options including URL and hash.
  *
  * @returns A file recipe containing the downloaded content
  *

--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -8,8 +8,8 @@ import type { Directory } from "./directory.bri";
  * Returns a directory recipe containing only files that match one of the
  * specified glob patterns.
  *
- * @param recipe - The directory recipe to filter
- * @param patterns - An array of glob patterns to match files against
+ * @param recipe - The directory recipe to filter.
+ * @param patterns - An array of glob patterns to match files against.
  *
  * @returns A directory recipe containing only files matching the glob patterns
  *

--- a/packages/std/core/recipes/recipe.bri
+++ b/packages/std/core/recipes/recipe.bri
@@ -156,7 +156,7 @@ interface RecipeUtils {
    * value as the input to the next function. This is a convenience method
    * around the `std.pipe()` utility function.
    *
-   * @param functions - Functions to pipe the recipe through
+   * @param functions - Functions to pipe the recipe through.
    *
    * @returns The result of piping the recipe through all the functions
    *
@@ -179,7 +179,7 @@ interface FileRecipeUtils extends RecipeUtils {
   /**
    * Returns a new file with the given permissions set.
    *
-   * @param permissions - The permissions to set on the file
+   * @param permissions - The permissions to set on the file.
    *
    * @returns A new file recipe with the specified permissions
    *

--- a/packages/std/core/recipes/symlink.bri
+++ b/packages/std/core/recipes/symlink.bri
@@ -6,7 +6,7 @@ import { type Recipe, symlinkRecipeUtils } from "./recipe.bri";
 /**
  * Options for creating a symlink.
  *
- * @param target - The target path of the symlink
+ * @param target - The target path of the symlink.
  */
 export interface SymlinkOptions {
   target: string;

--- a/packages/std/core/semver.bri
+++ b/packages/std/core/semver.bri
@@ -237,8 +237,8 @@ function semverCompareConstraint(
  * Returns true if the given semantic version is compatible with the
  * given constraints. Multiple constraints can be separated with a comma.
  *
- * @param version - The semantic version to check
- * @param constraints - The version constraints to match against
+ * @param version - The semantic version to check.
+ * @param constraints - The version constraints to match against.
  *
  * @returns True if the version matches the constraints, false otherwise
  *

--- a/packages/std/core/utils.bri
+++ b/packages/std/core/utils.bri
@@ -14,7 +14,7 @@ export function assert(
  * Used as a type-checked assertion that a codepath is unreachable, such
  * as for pattern matching. Throws an error if called.
  *
- * @param never - The value that should never be reached
+ * @param never - The value that should never be reached.
  *
  * @returns Never returns - always throws an error
  *
@@ -180,8 +180,8 @@ export function jsonSerialize(value: Equatable): string {
  * @description The first and last lines are removed if they are empty, and the level
  * of indentation is determined by the line with the smallest indentation.
  *
- * @param strings - Template string parts
- * @param values - Template string values
+ * @param strings - Template string parts.
+ * @param values - Template string values.
  *
  * @returns The dedented string with extra indentation removed
  *
@@ -260,8 +260,8 @@ export function mixin<T extends object, U extends object>(
  *
  * @description For recipes, see also the equivalent `.pipe()` method.
  *
- * @param value - The initial value to pipe through the functions
- * @param functions - The functions to pipe the value through
+ * @param value - The initial value to pipe through the functions.
+ * @param functions - The functions to pipe the value through.
  *
  * @returns The result of piping the value through all the functions
  *

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -36,8 +36,8 @@ export interface BashRunnableUtils {
  *
  * See also `std.runBash` to run a Bash script while baking!
  *
- * @param strings - The template string parts for the Bash script
- * @param values - The template string values
+ * @param strings - The template string parts for the Bash script.
+ * @param values - The template string values.
  *
  * @returns A self-contained runnable recipe containing the Bash script
  *

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -13,8 +13,8 @@ import { tools } from "/toolchain";
  * @description See also `std.bashRunnable,` which will return a recipe that packages
  * up a Bash script that can be run outside of Brioche.
  *
- * @param strings - The template string parts for the Bash script
- * @param values - The template string values
+ * @param strings - The template string parts for the Bash script.
+ * @param values - The template string values.
  *
  * @returns A process recipe that runs the Bash script
  *

--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -22,10 +22,10 @@ export interface WithRunnableUtils {
 /**
  * Options for configuring a runnable command.
  *
- * @param command - The command to run
- * @param args - Arguments to pass to the command
- * @param env - Environment variables to set when running the command
- * @param dependencies - Additional dependencies to include in the `$PATH`
+ * @param command - The command to run.
+ * @param args - Arguments to pass to the command.
+ * @param env - Environment variables to set when running the command.
+ * @param dependencies - Additional dependencies to include in the `$PATH`.
  */
 export interface RunnableOptions {
   command: RunnableTemplateValue;

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -16,7 +16,7 @@ export type EnvValue =
  * (relative to the root of the recipe), or set a fallback path / value
  * if the environment variable is empty.
  *
- * @param recipe - The recipe to add environment variables to
+ * @param recipe - The recipe to add environment variables to.
  * @param env - An object mapping environment variable names to their configuration.
  *   Each value can be:
  *   - `{ append: [{ path: string }] }`: Append paths to the environment variable

--- a/packages/std/extra/with_runnable_link.bri
+++ b/packages/std/extra/with_runnable_link.bri
@@ -8,8 +8,8 @@ import * as std from "/core";
  * @description This will add a symlink from `brioche-run` to the specified path, which
  * is used by `brioche run` to determine the executable to run.
  *
- * @param recipe - The recipe to add the runnable link to
- * @param runPath - The path to the executable within the recipe
+ * @param recipe - The recipe to add the runnable link to.
+ * @param runPath - The path to the executable within the recipe.
  *
  * @returns A new recipe with a `brioche-run` symlink pointing to the specified path
  *


### PR DESCRIPTION
This PR just focuses on improving code documentation by standardizing punctuation in parameter descriptions across various files. All changes involve adding a period at the end of parameter descriptions in JSDoc comments to ensure consistency and clarity.