### PR TITLE
feat(util_macros): add package

### DIFF
--- a/packages/util_macros/brioche.lock
+++ b/packages/util_macros/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/util/util-macros-1.20.2.tar.xz": {
+      "type": "sha256",
+      "value": "9ac269eba24f672d7d7b3574e4be5f333d13f04a7712303b1821b2a51ac82e8e"
+    }
+  }
+}

--- a/packages/util_macros/project.bri
+++ b/packages/util_macros/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "util_macros",
+  version: "1.20.2",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/util/util-macros-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function utilMacros(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xorg-macros | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, utilMacros)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://www.x.org/archive/individual/util
+      | lines
+      | where {|it| ($it | str contains "util-macros") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="util-macros-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`util_macros`](https://cgit.freedesktop.org/xorg/util/macros/): util-macros package contains the m4 macros used by all of the Xorg packages

```bash
> limactl shell ubuntu -- brioche build -e test -p packages/util_macros
Build finished, completed (no new jobs) in 1.63s
Result: 93def359accdbc05d51ff03b584c7eb326b40cc84adc42c5eab69fefa710f9ee

> limactl shell ubuntu -- brioche run -e liveUpdate -p packages/util_macros
0.07s ✓ Process 8592
Build finished, completed 1 job in 10.47s
Running brioche-run
{
  "name": "util_macros",
  "version": "1.20.2"
}

jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ rm -rf /tmp/output; brioche build -o /tmp/output -p packages/util_macros/
Build finished, completed (no new jobs) in 1.67s
Result: d0314fa9181635e887cd9f022afd35e735f142b27c6eacac43de03ea7ae69f24
Writing output
Wrote output to /tmp/output
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ ls /tmp/output
brioche-env.d  share
jaudiger@lima-ubuntu:/Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages$ ls /tmp/output/share/
aclocal  pkgconfig  util-macros
```