### PR TITLE
feat(gperf): add package

### DIFF
--- a/packages/gperf/brioche.lock
+++ b/packages/gperf/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/gperf/gperf-3.3.tar.gz": {
+      "type": "sha256",
+      "value": "fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8"
+    }
+  }
+}

--- a/packages/gperf/project.bri
+++ b/packages/gperf/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "gperf",
+  version: "3.3",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/gperf/gperf-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function gperf(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/gperf"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gperf --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gperf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `GNU gperf ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/gperf
+      | lines
+      | where {|it| ($it | str contains "gperf-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="gperf-(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `gperf` that is already part of the `std.toolchain` but this one is more recent.

```bash
> brioche build -e test -p packages/gperf
Build finished, completed (no new jobs) in 1.81s
Result: 6bf146e63d0dcf3294d11f48b2e06c036fe1a6e260501405b2305f21f12b04e4

> brioche run -e liveUpdate -p packages/gperf
Build finished, completed (no new jobs) in 9.59s
Running brioche-run
{
  "name": "gperf",
  "version": "3.3"
}
```