### PR TITLE
fix(libssh2): add a missing `std.pkgConfigMakePathsRelative` when building the package

### DIFF
--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -23,7 +23,7 @@ export default function libssh2(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain, openssl)
     .toDirectory()
-    .pipe((recipe) =>
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         LIBRARY_PATH: { append: [{ path: "lib" }] },


### PR DESCRIPTION
I missed it in https://github.com/brioche-dev/brioche-packages/pull/587. Nothing more. I just saw it yesterday while looking at a completely different things ^^'