### PR TITLE
perf(git): use newer git clone argument to clone a single revision

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -140,13 +140,9 @@ export function gitCheckout(
     );
 
     // Clone and fetch only the specified commit. See this article:
-    // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
+    // https://about.gitlab.com/blog/whats-new-in-git-2-49-0/#thin-clone-using---revision
     let repo = std.runBash`
-      cd "$BRIOCHE_OUTPUT"
-      git -c init.defaultBranch=main init
-      git remote add origin "$repository"
-      git fetch --depth 1 origin "$commit"
-      git -c advice.detachedHead=false checkout FETCH_HEAD
+      git -c advice.detachedHead=false clone --depth 1 --revision "$commit" "$repository" "$BRIOCHE_OUTPUT"
     `
       .dependencies(git)
       .env({


### PR DESCRIPTION
With the release of Git 2.49, we can rewrite our bash script to clone a repository at a specific revision without the history. See https://about.gitlab.com/blog/whats-new-in-git-2-49-0/#thin-clone-using---revision.

I benchmarked the new approach with `hyperfine`, and it's at least 1.1 times faster:

```bash
➜ export REPOSITORY="https://github.com/brioche-dev/brioche.git"
➜ export COMMIT="a4c817f0acc16536e4e528170bec0ee9782c4528"
➜ hyperfine \
  --prepare 'TMP=$(mktemp -d -p ./temp) && echo $TMP > .tmpdir' \
  --conclude 'rm -rf "$(cat .tmpdir)" && rm .tmpdir' \
  'git -c advice.detachedHead=false clone --depth 1 --revision=$COMMIT $REPOSITORY "$(cat .tmpdir)"' \
  'cd "$(cat .tmpdir)" && \
       git -c init.defaultBranch=main init && \
       git remote add origin $REPOSITORY && \
       git fetch --depth 1 origin $COMMIT && \
       git -c advice.detachedHead=false checkout FETCH_HEAD'
Benchmark 1: git -c advice.detachedHead=false clone --depth 1 --revision=$COMMIT $REPOSITORY "$(cat .tmpdir)"
  Time (mean ± σ):      1.236 s ±  0.085 s    [User: 0.106 s, System: 0.071 s]
  Range (min … max):    1.051 s …  1.346 s    10 runs

Benchmark 2: cd "$(cat .tmpdir)" && \
       git -c init.defaultBranch=main init && \
       git remote add origin $REPOSITORY && \
       git fetch --depth 1 origin $COMMIT && \
       git -c advice.detachedHead=false checkout FETCH_HEAD
  Time (mean ± σ):      1.391 s ±  0.093 s    [User: 0.025 s, System: 0.039 s]
  Range (min … max):    1.229 s …  1.536 s    10 runs

Summary
  git -c advice.detachedHead=false clone --depth 1 --revision=$COMMIT $REPOSITORY "$(cat .tmpdir)" ran
    1.13 ± 0.11 times faster than cd "$(cat .tmpdir)" && \
       git -c init.defaultBranch=main init && \
       git remote add origin $REPOSITORY && \
       git fetch --depth 1 origin $COMMIT && \
       git -c advice.detachedHead=false checkout FETCH_HEAD
```