### PR TITLE
chore: always target the GitHub tags API when retrieving the latest tags

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -50,7 +50,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
 export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/git/git/git/matching-refs/
+    let version = http get https://api.github.com/repos/git/git/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -63,7 +63,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
 export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/golang/go/git/matching-refs/
+    let version = http get https://api.github.com/repos/golang/go/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref


### PR DESCRIPTION
Follow up of https://github.com/brioche-dev/brioche-packages/pull/334, but at the time of this PR, the packages [`git`](https://github.com/jaudiger/brioche-packages/blob/9afeba281e554ee1eefef388f1ed35d457617466/packages/git/project.bri) and [`go`](https://github.com/jaudiger/brioche-packages/blob/9afeba281e554ee1eefef388f1ed35d457617466/packages/go/project.bri) didn't have any live update methods. They were added later. All of that will be reworked soon with new std helpers for live updates. I began to work on it locally.

```bash
> brioche run -e liveUpdate -p packages/git
Build finished, completed 1 job in 10.22s
Running brioche-run
{
  "name": "git",
  "version": "2.50.0"
}
> brioche run -e liveUpdate -p packages/go
Build finished, completed (no new jobs) in 9.74s
Running brioche-run
{
  "name": "go",
  "version": "1.24.4"
}
```