### PR TITLE
fix(libtirpc): remove a duplicate call to `std.pkgConfigMakePathsRelative`

### DIFF
--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -24,15 +24,12 @@ export default function libtirpc(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe(
-      std.pkgConfigMakePathsRelative,
-      (recipe) =>
-        std.setEnv(recipe, {
-          CPATH: { append: [{ path: "include" }] },
-          LIBRARY_PATH: { append: [{ path: "lib" }] },
-          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
-        }),
-      std.pkgConfigMakePathsRelative,
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
     );
 }
 


### PR DESCRIPTION
I saw it by inadvertence, but then after that, I did a complete check for all the other recipes, and it was the only one to have this duplicate call.