### PR TITLE
fix(pv): resolve issue with live update

### DIFF
--- a/packages/pv/brioche.lock
+++ b/packages/pv/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://www.ivarch.com/programs/sources/pv-1.9.31.tar.gz": {
+    "https://www.ivarch.com/s/pv-1.9.31.tar.gz": {
       "type": "sha256",
       "value": "a35e92ec4ac0e8f380e8e840088167ae01014bfa008a3a9d6506b848079daedf"
     }

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -7,7 +7,7 @@ export const project = {
 };
 
 const source = Brioche.download(
-  `https://www.ivarch.com/programs/sources/pv-${project.version}.tar.gz`,
+  `https://www.ivarch.com/s/pv-${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();
@@ -47,8 +47,8 @@ export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
     let version = http get https://ivarch.com/programs/pv.shtml
       | lines
-      | where {|it| ($it | str contains "sources/pv") and (not ($it | str contains "sig")) }
-      | parse --regex '<a href="sources/pv-(?<version>.+)\.tar\.[^"]+">'
+      | where {|it| ($it | str contains "/s/pv") and (not ($it | str contains "sig")) }
+      | parse --regex '<a href="/s/pv-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version
 


### PR DESCRIPTION
Resolve the issue with `pv` recipe detected during the last [live update run](https://github.com/brioche-dev/brioche-packages/actions/runs/15779487892). The URL used has been changed. This PR reflects it.

```bash
> brioche run -e liveUpdate -p packages/pv
Build finished, completed (no new jobs) in 14.32s
Running brioche-run
{
  "name": "pv",
  "version": "1.9.31"
}
```