### PR TITLE
fix(biome): resolve live update issue

### DIFF
--- a/packages/biome/brioche.lock
+++ b/packages/biome/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/biomejs/biome.git": {
-      "cli/v1.9.4": "fa93a147abe64e9c85908d317a8dd1de343ad132"
+      "@biomejs/biome@2.0.1": "6d2b50b7ec1a7664a90cc25c1d3eb5ba716924dd"
     }
   }
 }

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -3,13 +3,13 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "biome",
-  version: "1.9.4",
+  version: "2.0.1",
   repository: "https://github.com/biomejs/biome.git",
 };
 
 const source = Brioche.gitCheckout({
   repository: project.repository,
-  ref: `cli/v${project.version}`,
+  ref: `@biomejs/biome@${project.version}`,
 });
 
 export default function biome(): std.Recipe<std.Directory> {
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^cli\/v(?<version>.*)$/,
+    matchTag: /^@biomejs\/biome@(?<version>.*)$/,
   });
 }


### PR DESCRIPTION
Same as with https://github.com/brioche-dev/brioche-packages/pull/706, but for `biome` recipe. It fixes an issue detected during the last [live update run](https://github.com/brioche-dev/brioche-packages/actions/runs/15779487892).

```bash
> brioche build -e test -p packages/biome
158932 │ Version: 2.0.1
 0.17s ✓ Process 158932
Build finished, completed 1 job in 6.31s
Result: 000d513d952648874c489520e9db99494a6c91c074555e794cf19259b79b2415

> brioche run -e liveUpdate -p packages/biome
{
  "name": "biome",
  "version": "2.0.1",
  "repository": "https://github.com/biomejs/biome.git"
}
```