### PR TITLE
chore: add explicit type signatures to live update github methods

### DIFF
--- a/packages/asdf/project.bri
+++ b/packages/asdf/project.bri
@@ -43,6 +43,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/carapace/project.bri
+++ b/packages/carapace/project.bri
@@ -40,6 +40,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cargo_about/project.bri
+++ b/packages/cargo_about/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cargo_audit/project.bri
+++ b/packages/cargo_audit/project.bri
@@ -36,7 +36,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^cargo-audit\/v(?<version>.*)$/,

--- a/packages/cargo_chef/project.bri
+++ b/packages/cargo_chef/project.bri
@@ -39,6 +39,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cargo_msrv/project.bri
+++ b/packages/cargo_msrv/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cargo_mutants/project.bri
+++ b/packages/cargo_mutants/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cargo_nextest/project.bri
+++ b/packages/cargo_nextest/project.bri
@@ -41,7 +41,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^cargo-nextest-(?<version>.*)$/,

--- a/packages/cargo_udeps/project.bri
+++ b/packages/cargo_udeps/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cmctl/project.bri
+++ b/packages/cmctl/project.bri
@@ -52,6 +52,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/cosign/project.bri
+++ b/packages/cosign/project.bri
@@ -62,7 +62,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/sigstore/cosign/releases/latest
 

--- a/packages/delve/project.bri
+++ b/packages/delve/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/dependabot/project.bri
+++ b/packages/dependabot/project.bri
@@ -45,6 +45,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/difftastic/project.bri
+++ b/packages/difftastic/project.bri
@@ -37,7 +37,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
   });

--- a/packages/eza/project.bri
+++ b/packages/eza/project.bri
@@ -47,6 +47,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/fzf/project.bri
+++ b/packages/fzf/project.bri
@@ -49,6 +49,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/go_mockery/project.bri
+++ b/packages/go_mockery/project.bri
@@ -45,6 +45,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/gosec/project.bri
+++ b/packages/gosec/project.bri
@@ -51,6 +51,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/grcov/project.bri
+++ b/packages/grcov/project.bri
@@ -35,6 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/gron/project.bri
+++ b/packages/gron/project.bri
@@ -40,6 +40,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/htop/project.bri
+++ b/packages/htop/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/jjui/project.bri
+++ b/packages/jjui/project.bri
@@ -39,6 +39,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/k9s/project.bri
+++ b/packages/k9s/project.bri
@@ -48,6 +48,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/kor/project.bri
+++ b/packages/kor/project.bri
@@ -52,6 +52,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/mdbook/project.bri
+++ b/packages/mdbook/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -88,6 +88,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/mitmproxy/project.bri
+++ b/packages/mitmproxy/project.bri
@@ -72,6 +72,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ninja/project.bri
+++ b/packages/ninja/project.bri
@@ -39,6 +39,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/opentofu/project.bri
+++ b/packages/opentofu/project.bri
@@ -49,6 +49,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/rip2/project.bri
+++ b/packages/rip2/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/ripgrep/project.bri
+++ b/packages/ripgrep/project.bri
@@ -40,6 +40,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/sccache/project.bri
+++ b/packages/sccache/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -41,6 +41,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/steampipe/project.bri
+++ b/packages/steampipe/project.bri
@@ -38,6 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -53,6 +53,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/tflint/project.bri
+++ b/packages/tflint/project.bri
@@ -41,6 +41,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/trivy/project.bri
+++ b/packages/trivy/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/vegeta/project.bri
+++ b/packages/vegeta/project.bri
@@ -56,7 +56,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   const src = std.file(std.indoc`
     let releaseData = http get https://api.github.com/repos/tsenart/vegeta/releases/latest
 

--- a/packages/xh/project.bri
+++ b/packages/xh/project.bri
@@ -37,6 +37,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate() {
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({ project });
 }


### PR DESCRIPTION
I missed that in https://github.com/brioche-dev/brioche-packages/pull/612