### PR TITLE
feat(sqlx_cli): add package

### DIFF
--- a/packages/sqlx_cli/brioche.lock
+++ b/packages/sqlx_cli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/launchbadge/sqlx": {
+      "v0.8.6": "bab1b022bd56a64f9a08b46b36b97c5cff19d77e"
+    }
+  }
+}

--- a/packages/sqlx_cli/project.bri
+++ b/packages/sqlx_cli/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import nushell from "nushell";
+import openssl from "openssl";
+
+export const project = {
+  name: "sqlx_cli",
+  version: "0.8.6",
+  repository: "https://github.com/launchbadge/sqlx",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function sqlxCli(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [openssl],
+    path: "sqlx-cli",
+    runnable: "bin/sqlx",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    sqlx --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(sqlxCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sqlx-cli ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/launchbadge/sqlx/git/matching-refs/tags
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/(?P<tag>v(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+)(?P<label>-.+)?)'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`sqlx_cli`](https://github.com/launchbadge/sqlx/tree/main): a Rust SQL Toolkit.

Tested in a native aarch64 VM 🚀

```bash
{
  "name": "sqlx_cli",
  "version": "v0.8.6",
  "repository": "https://github.com/launchbadge/sqlx"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.87s
Result: 263e22d099a7cdf9c5f36d01df1a9b2de83bf767675daa9c5609fd6e8509a560

⏵ Task `Run package test` finished successfully
```