### PR TITLE
Update on live update

### DIFF
--- a/packages/sqlx_cli/project.bri
+++ b/packages/sqlx_cli/project.bri
@@ -45,7 +45,7 @@ export function liveUpdate(): std.WithRunnable {
       | get ref
       | each {|ref|
         $ref
-        | parse --regex '^refs/tags/(?P<tag>v(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+)(?P<label>-.+)?)'
+        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+)(?P<label>-.+)?)'
         | get -i 0
       }
       | sort-by -n major minor patch

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -41,7 +41,7 @@ export type ProcessOptions = {
 /**
  * Unsafe options for a process.
  *
- * @remark You must take extra care to ensure that running the process is hermetic
+ * @remarks You must take extra care to ensure that running the process is hermetic
  *   when using these options!
  *
  * @param networking - Set to `true` to allow the process to access the network.

--- a/packages/std/extra/live_update_from_github_releases.bri
+++ b/packages/std/extra/live_update_from_github_releases.bri
@@ -51,8 +51,7 @@ export function liveUpdateFromGithubReleases(
   options: LiveUpdateFromGithubReleasesOptions,
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
-  const matchTag =
-    options.matchTag ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH;
+  const matchTag = options.matchTag ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");

--- a/packages/std/extra/live_update_from_npm_packages.bri
+++ b/packages/std/extra/live_update_from_npm_packages.bri
@@ -111,7 +111,7 @@ interface NpmPackageInfo {
 function tryParseNpmPackage(
   extraOptions: LiveUpdateFromNpmPackagesExtraOptions,
 ): NpmPackageInfo | null {
-  const match = extraOptions.packageName.match(/^(?<packageName>[\w\.-]+)$/);
+  const match = extraOptions.packageName.match(/^(?<packageName>[\w\.@/-]+)$/);
 
   const { packageName } = match?.groups ?? {};
   if (packageName == null) {

--- a/packages/std/extra/live_update_from_npm_packages.bri
+++ b/packages/std/extra/live_update_from_npm_packages.bri
@@ -20,14 +20,9 @@ interface LiveUpdateFromNpmPackagesExtraOptions {
  *
  * @param project - The project export that should be updated. Must include a
  *   `extra.packageName` property containing the name of the NPM package.
- * @param matchVersion - A regex value (`/.../`) to extract the version number from
- *   a string. The regex must include a group named "version". If not
- *   provided, an optional "v" prefix will be stripped and the rest of the
- *   version will be checked if it's a semver or semver-like version number.
  */
 interface LiveUpdateFromNpmPackagesOptions {
   project: { version: string; extra: LiveUpdateFromNpmPackagesExtraOptions };
-  matchVersion?: RegExp;
 }
 
 /**
@@ -35,6 +30,9 @@ interface LiveUpdateFromNpmPackagesOptions {
  * version from the NPM registry. The project's version will be set based on a
  * regex match against the latest version. The package name is inferred from the
  * extra options of the project.
+ *
+ * @remarks The version schema of a NPM package should follow the SemVer
+ * specification.
  *
  * @param options - Options for the live update from NPM packages.
  *
@@ -51,10 +49,7 @@ interface LiveUpdateFromNpmPackagesOptions {
  * };
  *
  * export function liveUpdate(): std.Recipe<std.Directory> {
- *   return std.liveUpdateFromNpmPackages({
- *     project,
- *     matchVersion: /^v(?<version>.*)$/, // Strip "v" prefix from tags
- *   });
+ *   return std.liveUpdateFromNpmPackages({ project });
  * }
  * ```
  */
@@ -62,8 +57,6 @@ export function liveUpdateFromNpmPackages(
   options: LiveUpdateFromNpmPackagesOptions,
 ): std.Recipe<std.Directory> {
   const { packageName } = parseNpmPackage(options.project.extra);
-  const matchVersion =
-    options.matchVersion ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
@@ -94,7 +87,7 @@ export function liveUpdateFromNpmPackages(
       env: {
         project: JSON.stringify(options.project),
         packageName,
-        matchVersion: matchVersion.source,
+        matchVersion: DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH.source,
       },
       dependencies: [nushell],
     });

--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -12,7 +12,7 @@ import { runBash } from "./run_bash.bri";
  *
  * @returns A new recipe with the transformed pkg-config files.
  *
- * @remark This function looks for pkg-config files in the standard locations
+ * @remarks This function looks for pkg-config files in the standard locations
  *   `lib/pkgconfig` and `share/pkgconfig` relative to the `$BRIOCHE_OUTPUT`
  *   output directory.
  */


### PR DESCRIPTION
Following discussion in https://github.com/brioche-dev/brioche-packages/pull/717, I removed the field `matchVersion` from `LiveUpdateFromNpmPackagesOptions`. And I also fixed an issue around a few NPM packages live-update when the package name was containing an `@` or `/` character. Plus, I updated the live update of the recently added `sqlx_cli` package to resolve an issue when extracting the version from the tag. All of that will be soon refactor in a new dedicated std method.