### PR TITLE
Tweak process event artifact naming for failed GH Actions jobs

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -101,7 +101,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: process-events
+          name: process-events-${{ github.run_id }}-${{ matrix.host.platform }}
           path: ~/.local/share/brioche/process-temp/*/events.bin.zst
           compression-level: 0
 


### PR DESCRIPTION
This PR updates the artifact naming when `events.bin.zst` files are uploaded for failed GitHub Actions build jobs. This ensures that multiple jobs failing in the workflow will use unique artifact names. I also chose to add the job ID to the name, which will make it so each download should have a unique name (which will make it easier to find in my downloads folder!)

This resolves an issue when both the aarch64 and x86-64 build fail, since they both would try to use the same artifact name, which would conflict. See [Live Update#447](https://github.com/brioche-dev/brioche-packages/actions/runs/15944050614/job/44975857146) as an example:

!["Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run"](https://github.com/user-attachments/assets/6cf44a03-d497-4597-b00a-2336faa78a30)
