### PR TITLE
feat(gengetopt): add package

### DIFF
--- a/packages/gengetopt/brioche.lock
+++ b/packages/gengetopt/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz": {
+      "type": "sha256",
+      "value": "b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac"
+    }
+  }
+}

--- a/packages/gengetopt/project.bri
+++ b/packages/gengetopt/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "gengetopt",
+  version: "2.23",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/gengetopt/gengetopt-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function gengetopt(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/gengetopt"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gengetopt --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gengetopt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `GNU gengetopt ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/gengetopt
+      | lines
+      | where {|it| ($it | str contains "gengetopt-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="gengetopt-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`gengetopt`](https://www.gnu.org/software/gengetopt/gengetopt.html): a tool to write command line option parsing code for C programs.

```bash
61357  │ GNU gengetopt 2.23
       │ Copyright (C) 1999-2011  Free Software Foundation Inc.
       │ This program comes with ABSOLUTELY NO WARRANTY; for details
       │ please see the file 'COPYING' supplied with the source code.
       │ This is free software, and you are welcome to redistribute it
       │ under certain conditions; again, see 'COPYING' for details.
       │ This program is released under the GNU General Public License.
 0.02s ✓ Process 61357
Build finished, completed 1 job in 1.44s
Result: afc3b228f23e9979542b3a58d90204db7f39e546a44b5603739498ca68f21be3

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 7 jobs in 38.83s
Running brioche-run
{
  "name": "gengetopt",
  "version": "2.23"
}

⏵ Task `Run package live-update` finished successfully
```