### PR TITLE
feat(pyrefly): add package

### DIFF
--- a/packages/pyrefly/brioche.lock
+++ b/packages/pyrefly/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/facebook/pyrefly.git": {
+      "0.21.0": "87ec2dc28e7c08beb81d3b83574bbb9871450849"
+    }
+  }
+}

--- a/packages/pyrefly/project.bri
+++ b/packages/pyrefly/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+import nushell from "nushell";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "pyrefly",
+  version: "0.21.0",
+  repository: "https://github.com/facebook/pyrefly.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function pyrefly(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    env: {
+      // Requires unstable features on stable Rust
+      RUSTC_BOOTSTRAP: "1",
+    },
+    path: "pyrefly",
+    runnable: "bin/pyrefly",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pyrefly --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pyrefly)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `pyrefly ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://api.github.com/repos/facebook/pyrefly/git/matching-refs/tags
+      | get ref
+      | each {|ref|
+        $ref
+        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
+        | get -i 0
+      }
+      | sort-by -n major minor patch
+      | last
+      | get tag
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package `pyrefly`: a fast type checker and IDE for Python

```bash
Build finished, completed (no new jobs) in 6.91s
Running brioche-run
{
  "name": "pyrefly",
  "version": "0.21.0",
  "repository": "https://github.com/facebook/pyrefly.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.95s
Result: a15e6a814b4c10182566b39ff12c0cb2614ccdb28dd248c2542953bca75ffc7f

⏵ Task `Run package test` finished successfully
```