### PR TITLE
Update GitHub CI files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
       day: "friday"
       time: "17:00"
       timezone: "America/Los_Angeles"
-    groups:
-      github-actions:
-        patterns:
-          - "*"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -135,4 +135,4 @@ jobs:
     needs: [build]
     runs-on: ubuntu-24.04
     steps:
-      - run: ':'
+      - run: ":"


### PR DESCRIPTION
This PR makes minor updates to CI configuration files by using the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) to format the files and by ungrouping GitHub Actions updates if more than once are updated at the same time by Dependabot (which shouldn't be too common).

By default the YAML LSP format the strings with double quotes, there is a setting to use single quote. But I'm assuming that we should stay to the default settings, plus we are sometimes using double quote strings in https://github.com/brioche-dev/brioche-packages.