### PR TITLE
feat(tinycbor): add package

### DIFF
--- a/packages/tinycbor/brioche.lock
+++ b/packages/tinycbor/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/intel/tinycbor.git": {
+      "v0.6.1": "c0aad2fb2137a31b9845fbaae3653540c410f215"
+    }
+  }
+}

--- a/packages/tinycbor/project.bri
+++ b/packages/tinycbor/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+
+export const project = {
+  name: "tinycbor",
+  version: "0.6.1",
+  repository: "https://github.com/intel/tinycbor.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function tinycbor(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make
+    make install "prefix=/" DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/cbordump"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion tinycbor | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, tinycbor)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  // HACK: tinycbor 0.6.1 returns a version number of 0.6.0
+  const expected = project.version === "0.6.1" ? "0.6.0" : project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package `tinycbor`:

```bash
Build finished, completed (no new jobs) in 0.82s
Result: 14bd58c4b9fa0eb117e8a487d5b0b36102a26300dfd3b45d3eba8939eef48b6a

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 6.08s
Running brioche-run
{
  "name": "tinycbor",
  "version": "0.6.1",
  "repository": "https://github.com/intel/tinycbor.git"
}

⏵ Task `Run package live-update` finished successfully
```