### PR TITLE
refactor(std): move live update methods into a new folder

### DIFF
--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -6,10 +6,7 @@ export * from "./bash_runnable.bri";
 export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
-export * from "./live_update.bri";
-export * from "./live_update_from_github_releases.bri";
-export * from "./live_update_from_gitlab_releases.bri";
-export * from "./live_update_from_npm_packages.bri";
+export * from "./live_update";
 export * from "./pkg_config_make_paths_relative.bri";
 
 import "./extra_global.bri";

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
-import { withRunnable } from "./runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./live_update.bri";
+import { withRunnable } from "../runnable.bri";
+import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -56,35 +56,11 @@ export function liveUpdateFromGithubReleases(
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
 
-    const src = std.file(std.indoc`
-      # Include GitHub Token if present (for increased rate limits)
-      mut gh_headers = []
-      if ($env.GITHUB_TOKEN? | default "") != "" {
-        $gh_headers ++= [Authorization $'Bearer ($env.GITHUB_TOKEN)']
-      }
-
-      let tagName = http get --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
-        | get tag_name
-
-      let parsedTagName = $tagName | parse --regex $env.matchTag
-      if ($parsedTagName | length) == 0 {
-        error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
-      }
-
-      let version = $parsedTagName.0.version?
-      if $version == null {
-        error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
-      }
-
-      $env.project
-        | from json
-        | update version $version
-        | to json
-    `);
-
     return withRunnable(std.directory(), {
       command: "nu",
-      args: [src],
+      args: [
+        Brioche.includeFile("./scripts/live_update_from_github_releases.nu"),
+      ],
       env: {
         project: JSON.stringify(options.project),
         repoOwner,

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
-import { withRunnable } from "./runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./live_update.bri";
+import { withRunnable } from "../runnable.bri";
+import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -56,29 +56,11 @@ export function liveUpdateFromGitlabReleases(
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
 
-    const src = std.file(std.indoc`
-      let tagName = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases/permalink/latest'
-        | get tag_name
-
-      let parsedTagName = $tagName | parse --regex $env.matchTag
-      if ($parsedTagName | length) == 0 {
-        error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
-      }
-
-      let version = $parsedTagName.0.version?
-      if $version == null {
-        error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
-      }
-
-      $env.project
-        | from json
-        | update version $version
-        | to json
-    `);
-
     return withRunnable(std.directory(), {
       command: "nu",
-      args: [src],
+      args: [
+        Brioche.includeFile("./scripts/live_update_from_gitlab_releases.nu"),
+      ],
       env: {
         project: JSON.stringify(options.project),
         repoOwner,

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
-import { withRunnable } from "./runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./live_update.bri";
+import { withRunnable } from "../runnable.bri";
+import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -61,29 +61,9 @@ export function liveUpdateFromNpmPackages(
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
 
-    const src = std.file(std.indoc`
-      let version = http get $'https://registry.npmjs.org/($env.packageName)/latest'
-        | get version
-
-      let parsedVersion = $version | parse --regex $env.matchVersion
-      if ($parsedVersion | length) == 0 {
-        error make { msg: $'Latest release ($version) did not match regex ($env.matchVersion)' }
-      }
-
-      let version = $parsedVersion.0.version?
-      if $version == null {
-        error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
-      }
-
-      $env.project
-        | from json
-        | update version $version
-        | to json
-    `);
-
     return withRunnable(std.directory(), {
       command: "nu",
-      args: [src],
+      args: [Brioche.includeFile("./scripts/live_update_from_npm_packages.nu")],
       env: {
         project: JSON.stringify(options.project),
         packageName,

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -1,3 +1,7 @@
+export * from "./from_github_releases.bri";
+export * from "./from_gitlab_releases.bri";
+export * from "./from_npm_packages.bri";
+
 // The default regex used for matching versions. Strips an optional "v" prefix,
 // then matches the rest if it looks like a version number (either semver or
 // a semver-like version)

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -1,0 +1,24 @@
+# Include GitHub Token if present (for increased rate limits)
+mut gh_headers = []
+if ($env.GITHUB_TOKEN? | default "") != "" {
+  $gh_headers ++= [Authorization $'Bearer ($env.GITHUB_TOKEN)']
+}
+
+let tagName = http get --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+  | get tag_name
+
+let parsedTagName = $tagName
+  | parse --regex $env.matchTag
+if ($parsedTagName | length) == 0 {
+  error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
+}
+
+let version = $parsedTagName.0.version?
+if $version == null {
+  error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
+}
+
+$env.project
+  | from json
+  | update version $version
+  | to json

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -1,0 +1,18 @@
+let tagName = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases/permalink/latest'
+  | get tag_name
+
+let parsedTagName = $tagName
+  | parse --regex $env.matchTag
+if ($parsedTagName | length) == 0 {
+  error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
+}
+
+let version = $parsedTagName.0.version?
+if $version == null {
+  error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
+}
+
+$env.project
+  | from json
+  | update version $version
+  | to json

--- a/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
@@ -1,0 +1,18 @@
+let version = http get $'https://registry.npmjs.org/($env.packageName)/latest'
+  | get version
+
+let parsedVersion = $version
+  | parse --regex $env.matchVersion
+if ($parsedVersion | length) == 0 {
+  error make { msg: $'Latest release ($version) did not match regex ($env.matchVersion)' }
+}
+
+let version = $parsedVersion.0.version?
+if $version == null {
+  error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
+}
+
+$env.project
+  | from json
+  | update version $version
+  | to json


### PR DESCRIPTION
This PR refactors a bit the live update feature that lives in the `std` package. First all the live update methods are moved inside a new folder to better segment the files hierarchy and to not raise the number of files inside one `std.extra` directory. Second, all the Nushell scripts have been extracted into normal Nu files. The advantages of that is: we can now use the usual Nu LSP to work on Nu scripts and we can even run the Nu scripts as standalone scripts to debug them if needed (of course a preliminary environment would need to be setup to at least set all the environment variables the scripts required).

I wanted to rework that before updating and adding new live update methods.