### PR TITLE
feat(kubectl_view_allocations): add package

### DIFF
--- a/packages/kubectl_view_allocations/brioche.lock
+++ b/packages/kubectl_view_allocations/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/davidB/kubectl-view-allocations.git": {
+      "0.22.1": "342414b148e064396cc06adc7025c32e7e6d37f9"
+    }
+  }
+}

--- a/packages/kubectl_view_allocations/project.bri
+++ b/packages/kubectl_view_allocations/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "kubectl_view_allocations",
+  version: "0.22.1",
+  repository: "https://github.com/davidB/kubectl-view-allocations.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function kubectlViewAllocations(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/kubectl-view-allocations",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    kubectl-view-allocations --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(kubectlViewAllocations)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `kubectl-view-allocations ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`kubectl_view_allocations`](https://github.com/davidB/kubectl-view-allocations): a kubectl plugin to list allocations

```bash
 0.02s ✓ Process 35617
Build finished, completed 1 job in 9.01s
Running brioche-run
{
  "name": "kubectl_view_allocations",
  "version": "0.22.1",
  "repository": "https://github.com/davidB/kubectl-view-allocations.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.38s
Result: 0c0dcfa7fbca07c94361d846a7f2ed3b6a871c8887f52ac5fb9124d4d2d16b79

⏵ Task `Run package test` finished successfully
```