### PR TITLE
feat(dagger): add package

### DIFF
--- a/packages/dagger/brioche.lock
+++ b/packages/dagger/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/dagger/dagger.git": {
+      "v0.18.12": "60a0f44023632f89f3c8701435d0c8a3ed57e644"
+    }
+  }
+}

--- a/packages/dagger/project.bri
+++ b/packages/dagger/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "dagger",
+  version: "0.18.12",
+  repository: "https://github.com/dagger/dagger.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function dagger(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/dagger/dagger/engine.Version=v${project.version}`,
+        // The engine can be downloaded from `docker-image://registry.dagger.io/engine`.
+        // Here, we need to enforce the correct tag for the engine.
+        // Which is the same as the CLI version.
+        "-X",
+        `github.com/dagger/dagger/engine.Tag=v${project.version}`,
+      ],
+    },
+    path: "./cmd/dagger",
+    runnable: "bin/dagger",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dagger version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dagger)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `dagger v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`dagger`](https://github.com/dagger/dagger): an open-source runtime for composable workflows. Great for AI agents and CI/CD

```bash
Build finished, completed (no new jobs) in 0.91s
Result: f89e1507ae6053965e184078ebc8cbc23cc44bdfb2627c07bdfabaa9f645be6f

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 6.41s
Running brioche-run
{
  "name": "dagger",
  "version": "0.18.12",
  "repository": "https://github.com/dagger/dagger.git"
}

⏵ Task `Run package live-update` finished successfully
```