### PR TITLE
Update automatically GitHub release date

### DIFF
--- a/packages/cosign/project.bri
+++ b/packages/cosign/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "cosign",
@@ -62,30 +61,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/sigstore/cosign/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let releaseDate = $releaseData
-      | get created_at
-      | into datetime
-      | format date "%Y-%m-%d"
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.releaseDate $releaseDate
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/github_cli/project.bri
+++ b/packages/github_cli/project.bri
@@ -1,17 +1,17 @@
 import * as std from "std";
-import nushell from "nushell";
 import { goBuild } from "go";
 
 export const project = {
   name: "github_cli",
   version: "2.74.2",
+  repository: "https://github.com/cli/cli.git",
   extra: {
     releaseDate: "2025-06-17",
   },
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/cli/cli.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 
@@ -50,30 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/cli/cli/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let releaseDate = $releaseData
-      | get created_at
-      | into datetime
-      | format date "%Y-%m-%d"
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.releaseDate $releaseDate
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/golangci_lint/project.bri
+++ b/packages/golangci_lint/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "golangci_lint",
@@ -58,30 +57,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/golangci/golangci-lint/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let releaseDate = $releaseData
-      | get created_at
-      | into datetime
-      | format date "%Y-%m-%d"
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.releaseDate $releaseDate
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -1,18 +1,18 @@
 import * as std from "std";
 import { gitCheckout } from "git";
-import nushell from "nushell";
 import { goBuild } from "go";
 
 export const project = {
   name: "process_compose",
   version: "1.64.1",
+  repository: "https://github.com/F1bonacc1/process-compose.git",
   extra: {
     releaseDate: "2025-05-10",
   },
 };
 
 const gitRef = await Brioche.gitRef({
-  repository: "https://github.com/F1bonacc1/process-compose.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 const source = gitCheckout(gitRef);
@@ -59,30 +59,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/F1bonacc1/process-compose/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let releaseDate = $releaseData
-      | get created_at
-      | into datetime
-      | format date "%Y-%m-%d"
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.releaseDate $releaseDate
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -22,7 +22,7 @@ interface LiveUpdateFromGithubReleasesOptions {
   project: {
     version: string;
     repository: string;
-    extra?: { releaseDate: string };
+    extra?: { releaseDate?: string };
   };
   matchTag?: RegExp;
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -10,14 +10,20 @@ import type {} from "nushell";
  * Options for the live update from GitHub releases.
  *
  * @param project - The project export that should be updated. Must include a
- *   `repository` property containing a GitHub repository URL.
+ *   `repository` property containing a GitHub repository URL. Optionally,
+ *   a release date can be provided in the extra field, it should
+ *   represent the date of the latest release in the format `YYYY-MM-DD`.
  * @param matchTag - A regex value (`/.../`) to extract the version number from
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
  *   tag will be checked if it's a semver or semver-like version number.
  */
 interface LiveUpdateFromGithubReleasesOptions {
-  project: { version: string; repository: string };
+  project: {
+    version: string;
+    repository: string;
+    extra?: { releaseDate: string };
+  };
   matchTag?: RegExp;
 }
 

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -1,10 +1,18 @@
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the latest release information from GitHub
 # Include GitHub Token if present (for increased rate limits)
 mut gh_headers = []
 if ($env.GITHUB_TOKEN? | default "") != "" {
   $gh_headers ++= [Authorization $'Bearer ($env.GITHUB_TOKEN)']
 }
 
-let tagName = http get --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+let releaseInfo = http get --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+
+# Extract the version
+let tagName = $releaseInfo
   | get tag_name
 
 let parsedTagName = $tagName
@@ -18,7 +26,22 @@ if $version == null {
   error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
 }
 
-$env.project
-  | from json
+$project = $project
   | update version $version
+
+# Extract the release date (if needed by the project)
+let releaseDate = $project
+  | get extra?.releaseDate?
+if $releaseDate != null {
+  let $createdDate = $releaseInfo
+    | get created_at
+    | into datetime
+    | format date "%Y-%m-%d"
+
+  $project = $project
+    | update extra.releaseDate $createdDate
+}
+
+# Return back the project metadata encoded as JSON
+$project
   | to json

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -1,4 +1,12 @@
-let tagName = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases/permalink/latest'
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the latest release information from GitLab
+let releaseInfo = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases/permalink/latest'
+
+# Extract the version
+let tagName = $releaseInfo
   | get tag_name
 
 let parsedTagName = $tagName
@@ -12,7 +20,9 @@ if $version == null {
   error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
 }
 
-$env.project
-  | from json
+$project = $project
   | update version $version
+
+# Return back the project metadata encoded as JSON
+$project
   | to json

--- a/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
@@ -1,4 +1,12 @@
-let version = http get $'https://registry.npmjs.org/($env.packageName)/latest'
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the latest release information from npm registry
+let releaseInfo = http get $'https://registry.npmjs.org/($env.packageName)/latest'
+
+# Extract the version
+let version = $releaseInfo
   | get version
 
 let parsedVersion = $version
@@ -12,7 +20,9 @@ if $version == null {
   error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
 }
 
-$env.project
-  | from json
+$project = $project
   | update version $version
+
+# Return back the project metadata encoded as JSON
+$project
   | to json

--- a/packages/vegeta/project.bri
+++ b/packages/vegeta/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { gitCheckout } from "git";
 import { goBuild } from "go";
-import nushell from "nushell";
 
 export const project = {
   name: "vegeta",
@@ -56,30 +55,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
-  const src = std.file(std.indoc`
-    let releaseData = http get https://api.github.com/repos/tsenart/vegeta/releases/latest
-
-    let version = $releaseData
-      | get tag_name
-      | str replace --regex '^v' ''
-
-    let releaseDate = $releaseData
-      | get created_at
-      | into datetime
-      | format date "%Y-%m-%d"
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.releaseDate $releaseDate
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }


### PR DESCRIPTION
This PR enhances the GitHub release live update capabilities to also update the release date when the package relies on it in its recipe. With this PR, 3 packages are still using a custom GitHub release implementation:

- curl
- expat
- icu

Bu the good news is we want from 8 custom implementations to now 3. Of course, I'm not counting here the custom implementations we have for GitHub tags, these implementations will be refactored later with a new live update method.

Talking back of GitHub release, all the remaining packages using a custom implementation relies on specific version representation (dash, hyphen, underscore). We could, in a future work, add it to the std GitHub release live update.  