### PR TITLE
chore(live-update): better handle when the field `repo` is not present

### DIFF
--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -17,8 +17,8 @@ import type {} from "nushell";
  *   tag will be checked if it's a semver or semver-like version number.
  */
 interface LiveUpdateFromGithubReleasesOptions {
-  project: { version: string; repository: string };
-  matchTag?: RegExp;
+  project: { version: string; readonly repository: string };
+  readonly matchTag?: RegExp;
 }
 
 /**
@@ -76,8 +76,8 @@ export function liveUpdateFromGithubReleases(
  * Interface representing the parsed GitHub repository information.
  */
 interface GithubRepoInfo {
-  repoOwner: string;
-  repoName: string;
+  readonly repoOwner: string;
+  readonly repoName: string;
 }
 
 function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
@@ -108,10 +108,6 @@ function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
  * @throws If the repository URL cannot be parsed.
  */
 function parseGithubRepo(repo: string): GithubRepoInfo {
-  if (repo == null) {
-    throw new Error("Repository URL cannot be null or undefined");
-  }
-
   const info = tryParseGithubRepo(repo);
   if (info == null) {
     throw new Error(

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -108,6 +108,10 @@ function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
  * @throws If the repository URL cannot be parsed.
  */
 function parseGithubRepo(repo: string): GithubRepoInfo {
+  if (repo == null) {
+    throw new Error("Repository URL cannot be null or undefined");
+  }
+
   const info = tryParseGithubRepo(repo);
   if (info == null) {
     throw new Error(

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -108,6 +108,10 @@ function tryParseGitlabRepo(repo: string): GitlabRepoInfo | null {
  * @throws If the repository URL cannot be parsed.
  */
 function parseGitlabRepo(repo: string): GitlabRepoInfo {
+  if (repo == null) {
+    throw new Error("Repository URL cannot be null or undefined");
+  }
+
   const info = tryParseGitlabRepo(repo);
   if (info == null) {
     throw new Error(

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -17,8 +17,8 @@ import type {} from "nushell";
  *   tag will be checked if it's a semver or semver-like version number.
  */
 interface LiveUpdateFromGitlabReleasesOptions {
-  project: { version: string; repository: string };
-  matchTag?: RegExp;
+  project: { version: string; readonly repository: string };
+  readonly matchTag?: RegExp;
 }
 
 /**
@@ -76,8 +76,8 @@ export function liveUpdateFromGitlabReleases(
  * Interface representing the parsed GitLab repository information.
  */
 interface GitlabRepoInfo {
-  repoOwner: string;
-  repoName: string;
+  readonly repoOwner: string;
+  readonly repoName: string;
 }
 
 function tryParseGitlabRepo(repo: string): GitlabRepoInfo | null {
@@ -108,10 +108,6 @@ function tryParseGitlabRepo(repo: string): GitlabRepoInfo | null {
  * @throws If the repository URL cannot be parsed.
  */
 function parseGitlabRepo(repo: string): GitlabRepoInfo {
-  if (repo == null) {
-    throw new Error("Repository URL cannot be null or undefined");
-  }
-
   const info = tryParseGitlabRepo(repo);
   if (info == null) {
     throw new Error(

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -12,7 +12,7 @@ import type {} from "nushell";
  * @param packageName - The name of the NPM package to update.
  */
 interface LiveUpdateFromNpmPackagesExtraOptions {
-  packageName: string;
+  readonly packageName: string;
 }
 
 /**
@@ -22,7 +22,10 @@ interface LiveUpdateFromNpmPackagesExtraOptions {
  *   `extra.packageName` property containing the name of the NPM package.
  */
 interface LiveUpdateFromNpmPackagesOptions {
-  project: { version: string; extra: LiveUpdateFromNpmPackagesExtraOptions };
+  project: {
+    version: string;
+    readonly extra: LiveUpdateFromNpmPackagesExtraOptions;
+  };
 }
 
 /**
@@ -78,7 +81,7 @@ export function liveUpdateFromNpmPackages(
  * Interface representing the parsed NPM package information.
  */
 interface NpmPackageInfo {
-  packageName: string;
+  readonly packageName: string;
 }
 
 function tryParseNpmPackage(


### PR DESCRIPTION
~~Improve the stack trace when the field `repo` is missing and the live update method is executed.~~ Improve the detection when the field `repo` is missing by ensuring to detect it during static checking. The [previous behavior](https://github.com/brioche-dev/brioche-packages/pull/786/commits/bfb06bdc7b96bccd76f0216649217d4a1c0b5681) which was relying on the nullability check wasn't that easy to implement without modifying the way the constant variable `project` is cast to `LiveUpdateFromGithubReleasesOptions` or `LiveUpdateFromGitlabReleasesOptions`.

Before:

```bash
Error: error when calling liveUpdate

Caused by:
    TypeError: Cannot read properties of undefined (reading 'match')
        at tryParseGithubRepo (file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/extra/live_update/from_github_releases.bri:84:22)
        at parseGithubRepo (file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/extra/live_update/from_github_releases.bri:111:16)
        at Module.liveUpdateFromGithubReleases (file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/extra/live_update/from_github_releases.bri:53:35)
        at Module.liveUpdate (file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/curl/project.bri:96:14)
```

After (same stack trace), but the checker this time detected the issue:

```bash
[Error] file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/curl/project.bri:98:5
Property 'repository' is missing in type '{ name: string; version: string; }' but required in type '{ version: string; readonly repository: string; }'.
```