### PR TITLE
[nushell] Add `runNushell` and `nushellRunnable` utils

### DIFF
--- a/packages/nushell/nushell_runnable.bri
+++ b/packages/nushell/nushell_runnable.bri
@@ -1,0 +1,143 @@
+import * as std from "std";
+import nushell from "/";
+
+export type NushellRunnable = std.Recipe<std.Directory> & NushellRunnableUtils;
+
+interface NushellRunnableUtils {
+  /**
+   * Set environment variables when the Nushell script gets run.
+   */
+  env(values: Record<string, std.RunnableTemplateEnvValue>): NushellRunnable;
+
+  /**
+   * Include additional dependencies when the Nushell script gets run. This
+   * will set the `$PATH` environment variable.
+   */
+  dependencies(
+    ...dependencies: std.RecipeLike<std.Directory>[]
+  ): NushellRunnable;
+}
+
+/**
+ * Build a Nushell script into a self-contained runnable recipe. This does not
+ * run the Nushell script, but allows it to be run outside of Brioche, such
+ * as by calling `brioche run` or by putting it into an OCI container image.
+ *
+ * Can either be used as a tagged template (like 'nushellRunnable`...`')
+ * or called as a function with the script as a string or file recipe.
+ *
+ * @param strings - The template string parts for the Nushell script.
+ * @param values - The template string values.
+ *
+ * @returns A self-contained runnable recipe containing the Nushell script
+ *
+ * @example
+ *
+ * ```typescript
+ * import * as std from "std";
+ * import { nushellRunnable } from "nushell";
+ *
+ * // Running `brioche run` will print "Hello, world!"
+ * export default function (): std.NushellRunnable {
+ *   return nushellRunnable`
+ *     echo "Hello, world!"
+ *   `;
+ * }
+ * ```
+ */
+export function nushellRunnable(
+  strings: TemplateStringsArray,
+  ...values: string[]
+): NushellRunnable;
+
+/**
+ * Build a Nushell script into a self-contained runnable recipe. This does not
+ * run the Nushell script, but allows it to be run outside of Brioche, such
+ * as by calling `brioche run` or by putting it into an OCI container image.
+ *
+ * Can either be used as a tagged template (like 'nushellRunnable`...`')
+ * or called as a function with the script as a string or file recipe.
+ *
+ * @param script - The script to run, either a string or
+ *   a file recipe.
+ *
+ * @returns A self-contained runnable recipe containing the Nushell script
+ *
+ * @example
+ *
+ * ```typescript
+ * import * as std from "std";
+ * import { nushellRunnable } from "nushell";
+ *
+ * // Running `brioche run` will print "Hello, world!"
+ * export default function (): std.NushellRunnable {
+ *   return nushellRunnable`
+ *     echo "Hello, world!"
+ *   `;
+ * }
+ * ```
+ */
+export function nushellRunnable(
+  script: string | std.RecipeLike<std.File>,
+): NushellRunnable;
+
+export function nushellRunnable(
+  stringsOrScript: TemplateStringsArray | string | std.RecipeLike<std.File>,
+  ...values: string[]
+): NushellRunnable {
+  function isTemplateStringsArray(
+    x: TemplateStringsArray | string | std.RecipeLike<std.File>,
+  ): x is TemplateStringsArray {
+    return Array.isArray(x);
+  }
+
+  const script = isTemplateStringsArray(stringsOrScript)
+    ? std.indoc(stringsOrScript, ...values)
+    : stringsOrScript;
+
+  return makeNushellRunnable({
+    script,
+    root: std.directory(),
+    env: {
+      root: { relativePath: "." },
+    },
+    dependencies: [nushell],
+  });
+}
+
+interface NushellRunnableOptions {
+  script: string | std.RecipeLike<std.File>;
+  root: std.RecipeLike<std.Directory>;
+  env: Record<string, std.RunnableTemplateEnvValue>;
+  dependencies: std.RecipeLike<std.Directory>[];
+}
+
+function makeNushellRunnable(options: NushellRunnableOptions): NushellRunnable {
+  const recipe = std.withRunnable(options.root, {
+    command: "nu",
+    args:
+      typeof options.script === "string"
+        ? ["-c", options.script]
+        : [options.script],
+    env: options.env,
+    dependencies: options.dependencies,
+  });
+
+  return std.mixin(recipe, {
+    env(values: Record<string, std.RunnableTemplateEnvValue>): NushellRunnable {
+      return makeNushellRunnable({
+        ...options,
+        env: { ...options.env, ...values },
+      });
+    },
+
+    dependencies(
+      ...dependencies: std.RecipeLike<std.Directory>[]
+    ): NushellRunnable {
+      return makeNushellRunnable({
+        ...options,
+        dependencies: [...options.dependencies, ...dependencies],
+      });
+    },
+  });
+}

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -2,6 +2,9 @@ import * as std from "std";
 import openssl from "openssl";
 import { cargoBuild } from "rust";
 
+export { nushellRunnable, type NushellRunnable } from "./nushell_runnable.bri";
+export { runNushell } from "./run_nushell.bri";
+
 export const project = {
   name: "nushell",
   version: "0.105.1",

--- a/packages/nushell/run_nushell.bri
+++ b/packages/nushell/run_nushell.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import nushell from "/";
+
+/**
+ * Create a process recipe that runs the provided Nushell script when baked.
+ * The Nushell script should create the path `$env.BRIOCHE_OUTPUT`, which
+ * will be used as the output of the recipe.
+ *
+ * This function returns `std.Process`, which can be used for passing in
+ * extra dependencies or environment variables using `.dependencies()`
+ * or `.env()`, respectively, along with other process options.
+ *
+ * @description See also `nushellRunnable,` which will return a recipe that
+ * packages up a Nushell script that can be run outside of Brioche.
+ *
+ * @param strings - The template string parts for the Nushell script.
+ * @param values - The template string values.
+ *
+ * @returns A process recipe that runs the Nushell script
+ *
+ * @example
+ * ```typescript
+ * import * as std from "std";
+ *
+ * // Running `brioche build -o output` will create a directory `output`
+ * // with the file `hello.txt`. The result is cached, so the script won't
+ * // re-run unless the script changes or its inputs change.
+ * export default function () {
+ *   const file = std.file("Hello, world!");
+ *
+ *   // Return a recipe that will call the script, with `$file` set to
+ *   // the absolute path of the file above
+ *   return std.runBash`
+ *     mkdir -p "$BRIOCHE_OUTPUT"
+ *     cp "$file" > "$BRIOCHE_OUTPUT/hello.txt"
+ *   `
+ *     .env({ file });
+ * }
+ * ```
+ */
+export function runNushell(
+  strings: TemplateStringsArray,
+  ...values: string[]
+): std.Process {
+  const script = std.indoc(strings, ...values);
+  return std.process({
+    command: "nu",
+    args: ["-c", script],
+    dependencies: [std.tools, nushell],
+  });
+}

--- a/packages/std/extra/bash_runnable.bri
+++ b/packages/std/extra/bash_runnable.bri
@@ -19,7 +19,7 @@ export interface BashRunnableUtils {
   env(values: Record<string, RunnableTemplateEnvValue>): BashRunnable;
 
   /**
-   * Include additonal dependencies when the Bash script gets run. This
+   * Include additional dependencies when the Bash script gets run. This
    * will set the `$PATH` environment variable.
    */
   dependencies(...dependencies: std.RecipeLike<std.Directory>[]): BashRunnable;

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
 import { withRunnable } from "../runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -57,7 +57,7 @@ export function liveUpdateFromGithubReleases(
   options: LiveUpdateFromGithubReleasesOptions,
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
-  const matchTag = options.matchTag ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH;
+  const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
 import { withRunnable } from "../runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -51,7 +51,7 @@ export function liveUpdateFromGitlabReleases(
   options: LiveUpdateFromGitlabReleasesOptions,
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGitlabRepo(options.project.repository);
-  const matchTag = options.matchTag ?? DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH;
+  const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -1,6 +1,6 @@
 import * as std from "/core";
 import { withRunnable } from "../runnable.bri";
-import { DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH } from "./index.bri";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -70,7 +70,7 @@ export function liveUpdateFromNpmPackages(
       env: {
         project: JSON.stringify(options.project),
         packageName,
-        matchVersion: DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH.source,
+        matchVersion: DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH.source,
       },
       dependencies: [nushell],
     });

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -5,5 +5,5 @@ export * from "./from_npm_packages.bri";
 // The default regex used for matching versions. Strips an optional "v" prefix,
 // then matches the rest if it looks like a version number (either semver or
 // a semver-like version)
-export const DEFAULT_LIVE_UDPATE_REGEX_VERSION_MATCH =
+export const DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH =
   /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;


### PR DESCRIPTION
Closes #220

This PR adds 2 new utility functions in the `nushell` package:

- `runNushell` - Takes a Nushell script (called as a tagged template function) that returns a Process recipe to run a Nushell script. Similar to `std.runBash`.
- `nushellRunnable` - Takes a Nushell script (as a tagged template function or with a string or file recipe) that returns a runnable to run a Nushell recipe. Similar to `std.bashRunnable`.

Example:

```typescript
import { runNushell } from "nushell";

export default function() {
  return runNushell`
    echo hello | save $env.BRIOCHE_OUTPUT
  `;
}
```

I made it so `nushellRunnable` can take the script by calling it as a tagged template function, or by passing the script directly (as a string or as a file). After #781, the live update scripts in `std` were moved to standalone files, so passing the `.nu` files directly should be helpful for refactoring there. It might be nice to support passing files for `runNushell`, `std.runBash`, and `std.bashRunnable` too, but there hasn't been a reason to support it anywhere else yet.