### PR TITLE
Refactor live-update scripts to use `nushellRunnable`

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -1,4 +1,4 @@
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 import * as std from "std";
 
 export const project = {
@@ -62,8 +62,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.alsa-project.org/files/pub/lib
       | lines
       | where {|it| ($it | str contains "alsa-lib") and (not ($it | str contains ".sig")) }
@@ -75,12 +75,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import python from "python";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "aws_cli",
@@ -123,8 +123,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -140,14 +140,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 // Copied from `python.fixShebangs`

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
-import nushell from "nushell";
 import openssl from "openssl";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "ca_certificates",
@@ -48,8 +48,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://curl.se/docs/caextract.html
       | lines
       | where {|it| $it | str contains 'href="/ca/cacert-' }
@@ -61,12 +61,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import rust, { cargoBuild } from "rust";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "cargo_bloat",
@@ -36,8 +36,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/RazrFalcon/cargo-bloat/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -53,12 +53,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "expat",
@@ -55,8 +55,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let versionUnderscore = http get https://api.github.com/repos/libexpat/libexpat/releases/latest
       | get tag_name
       | str replace --regex '^R_' ''
@@ -69,12 +69,5 @@ export function liveUpdate(): std.WithRunnable {
       | update version $version
       | update extra.versionUnderscore $versionUnderscore
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/gengetopt/project.bri
+++ b/packages/gengetopt/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "gengetopt",
@@ -42,8 +42,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gengetopt
       | lines
       | where {|it| ($it | str contains "gengetopt-") and (not ($it | str contains ".sig")) }
@@ -55,12 +55,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 import openssl from "openssl";
 import curl from "curl";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "git",
@@ -48,8 +48,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/git/git/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -65,14 +65,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 /**

--- a/packages/gmp/project.bri
+++ b/packages/gmp/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "gmp",
@@ -49,8 +49,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gmp
       | lines
       | where {|it| ($it | str contains "gmp-") and ($it | str contains ".xz") and (not ($it | str contains ".sig")) }
@@ -62,12 +62,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "go",
@@ -76,8 +76,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/golang/go/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -93,14 +93,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 type ModOptions = "readonly" | "vendor" | "mod";

--- a/packages/gperf/project.bri
+++ b/packages/gperf/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "gperf",
@@ -42,8 +42,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gperf
       | lines
       | where {|it| ($it | str contains "gperf-") and (not ($it | str contains ".sig")) }
@@ -55,12 +55,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, NushellRunnable } from "nushell";
 
 export const project = {
   name: "icu",
@@ -89,8 +89,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let releaseData = http get https://api.github.com/repos/unicode-org/icu/releases/latest
 
     let versionDash = $releaseData
@@ -109,12 +109,5 @@ export function liveUpdate(): std.WithRunnable {
       | update extra.versionDash $versionDash
       | update extra.versionUnderscore $versionUnderscore
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -1,6 +1,6 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cargoBuild } from "rust";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "joshuto",
@@ -38,8 +38,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     # Version can either be prefixed with 'v' or not
     let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/tags
       | get ref
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -1,9 +1,9 @@
 import * as std from "std";
 import meson from "meson";
 import ninja from "ninja";
-import nushell from "nushell";
 import openssl from "openssl";
 import scdoc from "scdoc";
+import { nushellRunnable, NushellRunnable } from "nushell";
 
 export const project = {
   name: "kmod",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.kernel.org/pub/linux/utils/kernel/kmod
       | lines
       | where {|it| ($it | str contains 'href="kmod-') and ($it | str contains '.tar.gz')}
@@ -59,12 +59,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/krb5/project.bri
+++ b/packages/krb5/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "krb5",
@@ -58,8 +58,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://web.mit.edu/Kerberos/
       | lines
       | where {|it| $it | str contains 'Current release: <A HREF="krb5-' }
@@ -80,12 +80,5 @@ export function liveUpdate(): std.WithRunnable {
         | update extra.majorVersion $majorVersion
         | update extra.minorVersion $minorVersion
         | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libarchive",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.libarchive.de/downloads
       | lines
       | where {|it| $it | str contains "libarchive" }
@@ -59,12 +59,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import jq from "jq";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libcap",
@@ -64,8 +64,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://git.kernel.org/pub/scm/libs/libcap/libcap.git/refs
       | lines
       | where {|it| ($it | str contains "/pub/scm/libs/libcap/libcap.git/tag/?h=cap") and (not ($it | str contains "-rc")) }
@@ -77,14 +77,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 function briocheObjcopy(): std.Recipe<std.Directory> {

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libjpeg",
@@ -53,8 +53,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.ijg.org/files
       | lines
       | where {|it| ($it | str contains "jpegsrc.") }
@@ -66,12 +66,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libpcap",
@@ -45,8 +45,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.tcpdump.org/release
       | lines
       | where {|it| ($it | str contains "libpcap") and (not ($it | str contains ".sig")) }
@@ -58,12 +58,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libpng",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/libpng/files/libpng16
       | lines
       | where {|it| ($it | str contains 'href="/projects/libpng/files/libpng16') and (not ($it | str contains 'older-releases')) }
@@ -66,12 +66,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libsodium",
@@ -45,8 +45,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://download.libsodium.org/libsodium/releases
       | lines
       | where {|it| ($it | str contains "libsodium") and (not ($it | str contains ".sig")) and (not ($it | str contains ".minisig")) }
@@ -58,12 +58,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
-import nushell from "nushell";
 import openssl from "openssl";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libssh2",
@@ -48,8 +48,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.libssh2.org/download
       | lines
       | where {|it| ($it | str contains "libssh2") and (not ($it | str contains ".sig")) }
@@ -61,12 +61,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libtirpc",
@@ -49,8 +49,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/libtirpc/files/libtirpc
       | lines
       | where {|it| $it | str contains 'href="/projects/libtirpc/files/libtirpc/' }
@@ -69,12 +69,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import python from "python";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libxml2",
@@ -57,8 +57,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://download.gnome.org/sources/libxml2
       | lines
       | where {|it| $it | str contains 'href="' }
@@ -86,12 +86,5 @@ export function liveUpdate(): std.WithRunnable {
       | update extra.majorVersion $majorVersion
       | update extra.minorVersion $minorVersion
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 import python from "python";
 import libxml2 from "libxml2";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libxslt",
@@ -58,8 +58,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://download.gnome.org/sources/libxslt
       | lines
       | where {|it| $it | str contains 'href="' }
@@ -87,12 +87,5 @@ export function liveUpdate(): std.WithRunnable {
       | update extra.majorVersion $majorVersion
       | update extra.minorVersion $minorVersion
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/libzip/project.bri
+++ b/packages/libzip/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import nushell from "nushell";
 import openssl from "openssl";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libzip",
@@ -48,8 +48,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://libzip.org/download
       | lines
       | where {|it| $it | str contains 'href="libzip-' }
@@ -61,12 +61,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 import kmod from "kmod";
 import openssl from "openssl";
 import python from "python";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "linux",
@@ -133,8 +133,8 @@ export default function linux(
     .toDirectory();
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://cdn.kernel.org/pub/linux/kernel
       | lines
       | parse --regex '<a href="v(?<version>.+)/">'
@@ -157,14 +157,7 @@ export function liveUpdate(): std.WithRunnable {
       | update version $version
       | update extra.majorVersion $majorVersion
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 type LinuxUpdateConfigValue =

--- a/packages/lzo/project.bri
+++ b/packages/lzo/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "lzo",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.oberhumer.com/opensource/lzo/download
       | lines
       | where {|it| ($it | str contains "lzo-") }
@@ -59,12 +59,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/lzop/project.bri
+++ b/packages/lzop/project.bri
@@ -1,6 +1,6 @@
 import lzo from "lzo";
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "lzop",
@@ -42,8 +42,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.lzop.org/download
       | lines
       | where {|it| ($it | str contains "lzop-") }
@@ -55,12 +55,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -1,8 +1,8 @@
 import * as std from "std";
-import nushell from "nushell";
 import perl from "perl";
 import libxml2 from "libxml2";
 import libxslt from "libxslt";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "moreutils",
@@ -51,8 +51,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://git.joeyh.name/git/moreutils.git/refs/tags
       | lines
       | where {|it| ($it | str contains 'href="') and (not ($it | str contains 'sponge')) }
@@ -64,14 +64,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 const xmlCatalogs = std.directory({

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "nasm",
@@ -45,8 +45,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/netwide-assembler/nasm/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -62,12 +62,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/ncurses/project.bri
+++ b/packages/ncurses/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "ncurses",
@@ -58,8 +58,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/ncurses
       | lines
       | where {|it| ($it | str contains "ncurses-") and (not ($it | str contains ".sig")) }
@@ -71,12 +71,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
-import nushell from "nushell";
-import python from "python";
 import * as typer from "typer";
+import python from "python";
+import nushell, { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "nodejs",
@@ -133,8 +133,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     # Find Node.js releases by git tags
     let versionRefs = http get https://api.github.com/repos/nodejs/node/git/matching-refs/tags
       | get ref
@@ -168,14 +168,7 @@ export function liveUpdate(): std.WithRunnable {
       # Set the current version
       | update version $latestVersionRef.tag
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 /**

--- a/packages/patch/project.bri
+++ b/packages/patch/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "patch",
@@ -42,8 +42,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/patch
       | lines
       | where {|it| ($it | str contains "patch-") and (not ($it | str contains ".sig")) }
@@ -55,12 +55,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "pcre",
@@ -61,8 +61,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/pcre/files/pcre
       | lines
       | where {|it| $it | str contains 'href="/projects/pcre/files/pcre/' }
@@ -81,12 +81,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -3,7 +3,7 @@ import icu from "icu";
 import openssl from "openssl";
 import libxml from "libxml2";
 import libxslt from "libxslt";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 import curl from "curl";
 
 export const project = {
@@ -58,8 +58,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     # Get the URL that '/ftp/latest' redirects to. The resulting URL
     # will have the version number at the end
     let latestUrl = curl --proto '=https' --tlsv1.2 -fsSLI -o /dev/null 'https://www.postgresql.org/ftp/latest' -w '%{url_effective}'
@@ -72,12 +72,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell, curl],
-  });
+  `
+    .env({ project: JSON.stringify(project) })
+    .dependencies(curl);
 }

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "pv",
@@ -43,8 +43,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ivarch.com/programs/pv.shtml
       | lines
       | where {|it| ($it | str contains "/s/pv") and (not ($it | str contains "sig")) }
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/pyrefly/project.bri
+++ b/packages/pyrefly/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
-import nushell from "nushell";
 import { cargoBuild } from "rust";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "pyrefly",
@@ -44,8 +44,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/facebook/pyrefly/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -61,12 +61,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/readline/project.bri
+++ b/packages/readline/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "readline",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/readline
       | lines
       | where {|it| ($it | str contains "readline-") and (not ($it | str contains ".sig")) }
@@ -59,12 +59,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 import cargoChef from "cargo_chef";
 import * as TOML from "smol_toml";
 import * as t from "typer";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "rust",
@@ -127,8 +127,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/rust-lang/rust/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -144,14 +144,7 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }
 
 /**

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -1,6 +1,6 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cmakeBuild } from "cmake";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "s2argv_execs",
@@ -71,8 +71,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/virtualsquare/s2argv-execs/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -88,12 +88,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "scdoc",
@@ -55,8 +55,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://git.sr.ht/~sircmpwn/scdoc/refs
       | lines
       | where {|it| $it | str contains "~sircmpwn/scdoc/refs/" }
@@ -68,12 +68,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/sqlx_cli/project.bri
+++ b/packages/sqlx_cli/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
 import openssl from "openssl";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "sqlx_cli",
@@ -39,8 +39,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/launchbadge/sqlx/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -1,5 +1,4 @@
 import * as std from "/core";
-import { withRunnable } from "../runnable.bri";
 import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
@@ -65,21 +64,16 @@ export function liveUpdateFromGithubReleases(
   const normalizeVersion = options.normalizeVersion ?? false;
 
   return std.recipe(async () => {
-    const { default: nushell } = await import("nushell");
+    const { nushellRunnable } = await import("nushell");
 
-    return withRunnable(std.directory(), {
-      command: "nu",
-      args: [
-        Brioche.includeFile("./scripts/live_update_from_github_releases.nu"),
-      ],
-      env: {
-        project: JSON.stringify(options.project),
-        repoOwner,
-        repoName,
-        matchTag: matchTag.source,
-        normalizeVersion: normalizeVersion.toString(),
-      },
-      dependencies: [nushell],
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_github_releases.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      repoOwner,
+      repoName,
+      matchTag: matchTag.source,
+      normalizeVersion: normalizeVersion.toString(),
     });
   });
 }

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -1,5 +1,4 @@
 import * as std from "/core";
-import { withRunnable } from "../runnable.bri";
 import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
@@ -59,21 +58,16 @@ export function liveUpdateFromGitlabReleases(
   const normalizeVersion = options.normalizeVersion ?? false;
 
   return std.recipe(async () => {
-    const { default: nushell } = await import("nushell");
+    const { nushellRunnable } = await import("nushell");
 
-    return withRunnable(std.directory(), {
-      command: "nu",
-      args: [
-        Brioche.includeFile("./scripts/live_update_from_gitlab_releases.nu"),
-      ],
-      env: {
-        project: JSON.stringify(options.project),
-        repoOwner,
-        repoName,
-        matchTag: matchTag.source,
-        normalizeVersion: normalizeVersion.toString(),
-      },
-      dependencies: [nushell],
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_gitlab_releases.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      repoOwner,
+      repoName,
+      matchTag: matchTag.source,
+      normalizeVersion: normalizeVersion.toString(),
     });
   });
 }

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -1,5 +1,4 @@
 import * as std from "/core";
-import { withRunnable } from "../runnable.bri";
 import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
@@ -62,17 +61,14 @@ export function liveUpdateFromNpmPackages(
   const { packageName } = parseNpmPackage(options.project.extra);
 
   return std.recipe(async () => {
-    const { default: nushell } = await import("nushell");
+    const { nushellRunnable } = await import("nushell");
 
-    return withRunnable(std.directory(), {
-      command: "nu",
-      args: [Brioche.includeFile("./scripts/live_update_from_npm_packages.nu")],
-      env: {
-        project: JSON.stringify(options.project),
-        packageName,
-        matchVersion: DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH.source,
-      },
-      dependencies: [nushell],
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_npm_packages.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      packageName,
+      matchVersion: DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH.source,
     });
   });
 }

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import python from "python";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "talloc",
@@ -47,8 +47,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.samba.org/ftp/talloc
       | lines
       | where {|it| ($it | str contains "talloc") and (not ($it | str contains ".sig")) }
@@ -60,12 +60,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import libpcap from "libpcap";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "tcpdump",
@@ -43,8 +43,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.tcpdump.org/release
       | lines
       | where {|it| ($it | str contains "tcpdump") and (not ($it | str contains ".sig")) }
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "tcsh",
@@ -44,8 +44,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://astron.com/pub/tcsh
       | lines
       | where {|it| ($it | str contains "tcsh") and (not ($it | str contains ".asc")) }
@@ -57,12 +57,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -1,6 +1,6 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "tokei",
@@ -38,8 +38,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     # Version can be suffixed with '-alpha.X'
     let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/tags
       | get ref
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "uthash",
@@ -62,8 +62,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/troydhanson/uthash/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -79,12 +79,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/util_macros/project.bri
+++ b/packages/util_macros/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "util_macros",
@@ -43,8 +43,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/util
       | lines
       | where {|it| ($it | str contains "util-macros") and (not ($it | str contains ".sig")) }
@@ -56,12 +56,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -1,7 +1,7 @@
-import nushell from "nushell";
 import * as std from "std";
 import { cmakeBuild } from "cmake";
 import s2argvExecs from "s2argv_execs";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "vdeplug4",
@@ -72,8 +72,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/rd235/vdeplug4/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -89,12 +89,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -1,5 +1,5 @@
-import nushell from "nushell";
 import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "zlib",
@@ -46,8 +46,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://zlib.net
       | lines
       | where {|it| $it | str contains '<B> zlib ' }
@@ -59,12 +59,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }

--- a/packages/zziplib/project.bri
+++ b/packages/zziplib/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import nushell from "nushell";
 import python from "python";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "zziplib",
@@ -53,8 +53,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://api.github.com/repos/gdraheim/zziplib/git/matching-refs/tags
       | get ref
       | each {|ref|
@@ -70,12 +70,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }


### PR DESCRIPTION
Follow-up to #787

This PR refactors live-update functions throughout the repo to use the new `nushell.nushellRunnable` utility function where possible.

_**Draft:** Many packages and live-update functions still need to be updated_

- [x] Update live-update utils in `std`
- [x] Update all packages
- [x] Use `NushellRunnable` return type where needed