### PR TITLE
[renovate] Update Renovate to install via pnpm + GitHub + Node.js v22

### DIFF
--- a/packages/nodejs/brioche.lock
+++ b/packages/nodejs/brioche.lock
@@ -1,6 +1,14 @@
 {
   "dependencies": {},
   "downloads": {
+    "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-arm64.tar.xz": {
+      "type": "sha256",
+      "value": "140aee84be6774f5fb3f404be72adbe8420b523f824de82daeb5ab218dab7b18"
+    },
+    "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-x64.tar.xz": {
+      "type": "sha256",
+      "value": "325c0f1261e0c61bcae369a1274028e9cfb7ab7949c05512c5b1e630f7e80e12"
+    },
     "https://nodejs.org/dist/v24.2.0/node-v24.2.0-linux-arm64.tar.xz": {
       "type": "sha256",
       "value": "cd4f25d2f05d0750159a209915267af6f9970ade4702a8810641120404bf54ee"

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -17,13 +17,13 @@ export const project = {
 
 std.assert(
   project.extra.currentMajorVersion in project.extra.majorVersions,
-  "NodeJS package extra.currentVersion not found in extra.majorVersion",
+  "Node.js package extra.currentVersion not found in extra.majorVersion",
 );
 std.assert(
   Object.keys(project.extra.majorVersions).some((majorVersion) =>
     project.version.startsWith(`${majorVersion}.`),
   ),
-  "NodeJS package version not found in extra.minorVersions",
+  "Node.js package version not found in extra.minorVersions",
 );
 
 type NodeVersion = keyof typeof project.extra.majorVersions;
@@ -68,7 +68,7 @@ function prebuiltBinary(
   const prebuiltBinariesForVersion = prebuiltBinaries[version];
   std.assert(
     prebuiltBinariesForVersion != null,
-    `NodeJS version '${version}' is not supported, expected one of ${JSON.stringify(
+    `Node.js version '${version}' is not supported, expected one of ${JSON.stringify(
       Object.keys(prebuiltBinaries),
     )}`,
   );
@@ -76,7 +76,7 @@ function prebuiltBinary(
   const prebuilt = prebuiltBinariesForVersion[platform];
   std.assert(
     prebuilt != null,
-    `NodeJS ${version} is not supported for ${platform}, expected one of ${JSON.stringify(
+    `Node.js ${version} is not supported for ${platform}, expected one of ${JSON.stringify(
       Object.keys(prebuiltBinariesForVersion),
     )}`,
   );
@@ -236,11 +236,14 @@ export function npmInstall(
  * @param packageName - The name of the npm package to install.
  * @param version - The version of the package to install.
  * @param wrapBins - Whether to wrap the installed binaries.
+ * @param nodejs - The Node.js and npm recipe to use to install the package.
+ *   Can be used to use a specific version of Node.js.
  */
 interface NpmInstallGlobalOptions {
   packageName: string;
   version: string;
   wrapBins?: boolean;
+  nodejs?: std.RecipeLike<std.Directory>;
 }
 
 const BinList = typer.array(
@@ -276,7 +279,12 @@ export function npmInstallGlobal(
   options: NpmInstallGlobalOptions,
 ): std.Recipe<std.Directory> {
   return std.recipe(async () => {
-    const { packageName, version, wrapBins = true } = options;
+    const {
+      packageName,
+      version,
+      wrapBins = true,
+      nodejs: nodejsDep = nodejs,
+    } = options;
 
     let recipe = std.runBash`
       if [ "$(npm view "\${package_name}@\${version}" version)" != "$version" ]; then
@@ -286,7 +294,7 @@ export function npmInstallGlobal(
 
       npm install --global "\${package_name}@\${version}"
     `
-      .dependencies(std.toolchain, nodejs, python)
+      .dependencies(std.toolchain, nodejsDep, python)
       .outputScaffold(std.directory())
       .env({
         package_name: packageName,
@@ -315,7 +323,7 @@ export function npmInstallGlobal(
         return std.addRunnable(std.directory(), name, {
           command: "node",
           args: [{ relativePath: target }],
-          dependencies: [nodejs],
+          dependencies: [nodejsDep],
         });
       });
 

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -6,37 +6,109 @@ import * as typer from "typer";
 export const project = {
   name: "nodejs",
   version: "24.2.0",
-};
+  extra: {
+    currentMajorVersion: "24",
+    majorVersions: {
+      "24": "24.2.0",
+      "22": "22.17.0",
+    },
+  },
+} as const;
 
-function nodejsPrebuilt(): std.Recipe<std.Directory> {
-  switch (std.CURRENT_PLATFORM) {
-    case "x86_64-linux":
-      return Brioche.download(
-        `https://nodejs.org/dist/v${project.version}/node-v${project.version}-linux-x64.tar.xz`,
-      )
-        .unarchive("tar", "xz")
-        .peel();
-    case "aarch64-linux":
-      return Brioche.download(
-        `https://nodejs.org/dist/v${project.version}/node-v${project.version}-linux-arm64.tar.xz`,
-      )
-        .unarchive("tar", "xz")
-        .peel();
-    default:
-      throw new Error(
-        `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the nodejs package`,
-      );
-  }
+std.assert(
+  project.extra.currentMajorVersion in project.extra.majorVersions,
+  "NodeJS package extra.currentVersion not found in extra.majorVersion",
+);
+std.assert(
+  Object.keys(project.extra.majorVersions).some((majorVersion) =>
+    project.version.startsWith(`${majorVersion}.`),
+  ),
+  "NodeJS package version not found in extra.minorVersions",
+);
+
+type NodeVersion = keyof typeof project.extra.majorVersions;
+
+const prebuiltBinaries: Record<
+  string,
+  Record<string, std.Recipe<std.Directory>>
+> = {
+  "22": {
+    "x86_64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["22"]}/node-v${project.extra.majorVersions["22"]}-linux-x64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+    "aarch64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["22"]}/node-v${project.extra.majorVersions["22"]}-linux-arm64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+  },
+  "24": {
+    "x86_64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-x64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+    "aarch64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-arm64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+  },
+} satisfies Record<
+  NodeVersion,
+  Record<std.Platform, std.Recipe<std.Directory>>
+>;
+
+function prebuiltBinary(
+  version: NodeVersion,
+  platform: std.Platform,
+): std.Recipe<std.Directory> {
+  const prebuiltBinariesForVersion = prebuiltBinaries[version];
+  std.assert(
+    prebuiltBinariesForVersion != null,
+    `NodeJS version '${version}' is not supported, expected one of ${JSON.stringify(
+      Object.keys(prebuiltBinaries),
+    )}`,
+  );
+
+  const prebuilt = prebuiltBinariesForVersion[platform];
+  std.assert(
+    prebuilt != null,
+    `NodeJS ${version} is not supported for ${platform}, expected one of ${JSON.stringify(
+      Object.keys(prebuiltBinariesForVersion),
+    )}`,
+  );
+
+  return prebuilt;
 }
 
 /**
- * The main Node.js recipe. Returns a recipe containing the following:
+ * Extra options for Node.js.
  *
- * - `bin/node`
- * - `bin/npm`
+ * @param version - The major version of Node.js to use. Defaults to the
+ *   current stable release (at the time the `nodejs` Brioche package was
+ *   last updated).
  */
-export default function nodejs(): std.Recipe<std.Directory> {
-  return nodejsPrebuilt()
+interface NodeOptions {
+  version?: NodeVersion;
+}
+
+/**
+ * The main Node.js recipe.
+ *
+ * @param options - Extra options for the Node.js recipe.
+ *
+ * @returns A recipe containing Node.js, including the binaries `bin/node`
+ *   and `bin/npm`.
+ */
+export default function nodejs(
+  options: NodeOptions = {},
+): std.Recipe<std.Directory> {
+  const { version = project.extra.currentMajorVersion } = options;
+
+  return prebuiltBinary(version, std.CURRENT_PLATFORM)
     .pipe((node) =>
       std.autopack(node, {
         globs: ["bin/**"],

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -9,8 +9,8 @@ export const project = {
   extra: {
     currentMajorVersion: "24",
     majorVersions: {
-      "24": "24.2.0",
       "22": "22.17.0",
+      "24": "24.2.0",
     },
   },
 } as const;
@@ -135,7 +135,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
 export function liveUpdate(): std.WithRunnable {
   const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/nodejs/node/git/matching-refs/tags
+    # Find Node.js releases by git tags
+    let versionRefs = http get https://api.github.com/repos/nodejs/node/git/matching-refs/tags
       | get ref
       | each {|ref|
         $ref
@@ -143,12 +144,29 @@ export function liveUpdate(): std.WithRunnable {
         | get -i 0
       }
       | sort-by -n major minor patch
-      | last
-      | get tag
+    let latestVersionRef = $versionRefs | last
 
     $env.project
       | from json
-      | update version $version
+      | update extra.majorVersions {|project|
+        # Ensure the newest version is in the list of major versions, then
+        # update the newest minor/patch version of each major version
+        $project.extra.majorVersions
+          | upsert $latestVersionRef.major $latestVersionRef.tag
+          | transpose major version
+          | update version {|row|
+            $versionRefs
+              | where major == $row.major
+              | last
+              | get tag
+          }
+          | transpose -r
+          | into record
+      }
+      # Set the current major version
+      | update extra.currentMajorVersion $latestVersionRef.major
+      # Set the current version
+      | update version $latestVersionRef.tag
       | to json
   `);
 

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -56,11 +56,14 @@ export function liveUpdate(): std.Recipe<std.Directory> {
  * Options for building and installing an npm package with pnpm.
  *
  * @param source - The pnpm package dependencies to install.
+ * @param dependencies - Extra dependencies to include while installing, such
+ *   as build dependencies used for postinstall scripts.
  * @param nodejs - The Node.js recipe to use when installing packages. This
  *   can be used to pick a different Node.js version.
  */
 interface PnpmInstallOptions {
   source: std.RecipeLike<std.Directory>;
+  dependencies?: std.RecipeLike<std.Directory>[];
   nodejs?: std.RecipeLike<std.Directory>;
 }
 
@@ -78,10 +81,18 @@ export function pnpmInstall(
   return std.runBash`
     pnpm install --frozen-lockfile
   `
-    .dependencies(std.toolchain, pnpm({ nodejs: options.nodejs }))
+    .dependencies(
+      ...(options.dependencies ?? []),
+      std.toolchain,
+      pnpm({
+        nodejs: options.nodejs,
+      }),
+    )
     .currentDir(std.outputPath)
     .outputScaffold(options.source)
-    .unsafe({ networking: true })
+    .unsafe({
+      networking: true,
+    })
     .toDirectory();
 }
 

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -9,10 +9,26 @@ export const project = {
   repository: "https://github.com/pnpm/pnpm",
 };
 
-export default function pnpm(): std.Recipe<std.Directory> {
+/**
+ * @param nodejs - The Node.js version used when running pnpm. Can be used to
+ *   pick a different Node.js version.
+ */
+export interface PnpmOptions {
+  nodejs?: std.RecipeLike<std.Directory>;
+}
+
+/**
+ * The main pnpm recipe, including the main pnpm command `bin/pnpm`.
+ *
+ * @param options - Extra options for pnpm.
+ */
+export default function pnpm(
+  options: PnpmOptions = {},
+): std.Recipe<std.Directory> {
   return npmInstallGlobal({
     packageName: project.name,
     version: project.version,
+    nodejs: options.nodejs,
   }).pipe((recipe) => std.withRunnableLink(recipe, "bin/pnpm"));
 }
 
@@ -40,9 +56,12 @@ export function liveUpdate(): std.Recipe<std.Directory> {
  * Options for building and installing an npm package with pnpm.
  *
  * @param source - The pnpm package dependencies to install.
+ * @param nodejs - The Node.js recipe to use when installing packages. This
+ *   can be used to pick a different Node.js version.
  */
 interface PnpmInstallOptions {
   source: std.RecipeLike<std.Directory>;
+  nodejs?: std.RecipeLike<std.Directory>;
 }
 
 /**
@@ -59,7 +78,7 @@ export function pnpmInstall(
   return std.runBash`
     pnpm install --frozen-lockfile
   `
-    .dependencies(std.toolchain, nodejs, pnpm)
+    .dependencies(std.toolchain, pnpm({ nodejs: options.nodejs }))
     .currentDir(std.outputPath)
     .outputScaffold(options.source)
     .unsafe({ networking: true })

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -83,7 +83,6 @@ export function pnpmInstall(
   `
     .dependencies(
       ...(options.dependencies ?? []),
-      std.toolchain,
       pnpm({
         nodejs: options.nodejs,
       }),

--- a/packages/renovate/brioche.lock
+++ b/packages/renovate/brioche.lock
@@ -1,3 +1,8 @@
 {
-  "dependencies": {}
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/renovatebot/renovate.git": {
+      "41.1.4": "00614f9a37f7634440fbe27edcdcaf819bf3680d"
+    }
+  }
 }

--- a/packages/renovate/project.bri
+++ b/packages/renovate/project.bri
@@ -1,19 +1,74 @@
 import * as std from "std";
-import { npmInstallGlobal } from "nodejs";
+import nodejsRecipe from "nodejs";
+import pnpmRecipe, { pnpmInstall } from "pnpm";
+import python from "python";
+import { runNushell } from "nushell";
 
 export const project = {
   name: "renovate",
   version: "41.1.4",
-  extra: {
-    packageName: "renovate",
-  },
+  repository: "https://github.com/renovatebot/renovate.git",
 };
 
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+// Pin to Node.js v22
+const nodejs = nodejsRecipe({ version: "22" });
+const pnpm = pnpmRecipe({ nodejs });
+
 export default function renovate(): std.Recipe<std.Directory> {
-  return npmInstallGlobal({
-    packageName: project.extra.packageName,
-    version: project.version,
-  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/renovate"));
+  // Install dependencies using pnpm
+  // TODO: Can we get rid of dev dependencies (at least for the final output)?
+  const npmPackage = pnpmInstall({
+    source,
+    dependencies: [python],
+    nodejs,
+  });
+
+  // Run the Renovate build. We explicitly update the config to use the
+  // provided version of pnpm instead of trying to download Renovate's
+  // pinned version.
+  const dist = std.runBash`
+    pnpm --config.manage-package-manager-versions=false config set manage-package-manager-versions=false
+    pnpm build
+    mv dist "$BRIOCHE_OUTPUT"
+  `
+    .workDir(npmPackage)
+    .dependencies(pnpm)
+    .toDirectory();
+
+  // Set the release version number in `package.json`.
+  const packageJson = runNushell`
+      open --raw $env.BRIOCHE_OUTPUT
+      | from json
+      | update version { $env.version }
+      | to json
+      | save --force $env.BRIOCHE_OUTPUT
+  `
+    .outputScaffold(npmPackage.get("package.json"))
+    .env({ version: project.version })
+    .toFile();
+
+  // Create the final output. This includes the build output, `node_modules`
+  // for dependencies, and `package.json` for package metadata.
+  return std
+    .directory({
+      dist,
+      node_modules: npmPackage.get("node_modules"),
+      "package.json": packageJson,
+    })
+    .pipe((recipe) =>
+      // Add a runnable for the main Renovate CLI script
+      std.addRunnable(recipe, "bin/renovate", {
+        command: "node",
+        args: [{ relativePath: "dist/renovate.js" }],
+        dependencies: [nodejs],
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/renovate"));
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {
@@ -33,5 +88,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromNpmPackages({ project });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/renovate/project.bri
+++ b/packages/renovate/project.bri
@@ -44,7 +44,7 @@ export default function renovate(): std.Recipe<std.Directory> {
   const packageJson = runNushell`
       open --raw $env.BRIOCHE_OUTPUT
       | from json
-      | update version { $env.version }
+      | update version $env.version
       | to json
       | save --force $env.BRIOCHE_OUTPUT
   `


### PR DESCRIPTION
Closes #747

This PR makes some major changes to how the `renovate` package is built:

- Fetch Renovate via GitHub instead of via the npm registry. The version in the registry doesn't have a lockfile (which we need to make the build pure).
- Install Renovate deps with `pnpmInstall` so pnpm lockfile is respected (see #783).
- Update Renovate to use Node.js v22. This is the version locked in Renovate's lockfile, and it seems that Node.js v24 doesn't work today.
  - I believe Node.js v24 might be blocked by an issue in `tsx`? I _think_ it might be this: https://github.com/privatenumber/tsx/issues/694
  - To handle Node.js v22 and v24, I updated `nodejs` to support passing a major version number, similar to Python. Some functions in `npm` and `pnpm` were also updated to be able to take a custom Node.js recipe.
- Manually build Renovate. Basically boils down to calling `pnpm build` to generate the `dist/` dir, then creating the final output directory manually.
- Patch `package.json`. I found out that `renovate --version` references the `version` field of `package.json`, but the source tree for Renovate [uses a dummy version of `0.0.0-semantic-release`](https://github.com/renovatebot/renovate/blob/613c1e5df6579e4996c0cf06985f5e8e8af7b201/package.json#L4), so I wrote a script that updates the version.