### PR TITLE
feat(libunistring): add package

### DIFF
--- a/packages/libunistring/brioche.lock
+++ b/packages/libunistring/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.xz": {
+      "type": "sha256",
+      "value": "f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527"
+    }
+  }
+}

--- a/packages/libunistring/project.bri
+++ b/packages/libunistring/project.bri
@@ -51,7 +51,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
     ./main | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, libunistring)
-    .env({ src: src })
+    .env({ src })
     .toFile();
 
   const result = (await script.read()).trim();

--- a/packages/libunistring/project.bri
+++ b/packages/libunistring/project.bri
@@ -1,0 +1,90 @@
+import * as std from "std";
+import nushell from "nushell";
+
+export const project = {
+  name: "libunistring",
+  version: "1.3",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/libunistring/libunistring-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libunistring(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <unistring/version.h>
+
+      int main(void)
+      {
+          int version = _libunistring_version;
+
+          printf("%d.%d.%d", version >> 16, (version >> 8) & 0xff, version & 0xff);
+
+          return EXIT_SUCCESS;
+      }
+  `);
+
+  const script = std.runBash`
+    cp "$src" main.c
+    gcc main.c -o main -lunistring
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libunistring)
+    .env({ src: src })
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version}.`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.WithRunnable {
+  const src = std.file(std.indoc`
+    let version = http get https://ftp.gnu.org/gnu/libunistring
+      | lines
+      | where {|it| ($it | str contains "libunistring-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libunistring-(?<version>[0-9.]+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `);
+
+  return std.withRunnable(std.directory(), {
+    command: "nu",
+    args: [src],
+    env: { project: JSON.stringify(project) },
+    dependencies: [nushell],
+  });
+}


### PR DESCRIPTION
Add a new package [`libunistring`](https://www.gnu.org/software/libunistring/): it provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.

```bash
Build finished, completed (no new jobs) in 0.77s
Result: 0d8e188ce16ea77c9e261dcdeb8a422445821c4419d6f8f5971a414a414c89e0

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 1 job in 6.81s
Running brioche-run
{
  "name": "libunistring",
  "version": "1.3"
}

⏵ Task `Run package live-update` finished successfully
```