### PR TITLE
Add live update version normalizer

### DIFF
--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -2,12 +2,12 @@ import * as std from "std";
 import brotli from "brotli";
 import libpsl from "libpsl";
 import libssh2 from "libssh2";
-import nushell from "nushell";
 import openssl from "openssl";
 
 export const project = {
   name: "curl",
   version: "8.14.1",
+  repository: "https://github.com/curl/curl.git",
 };
 
 const source = Brioche.download(
@@ -93,24 +93,10 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
-    let version = http get https://api.github.com/repos/curl/curl/releases/latest
-      | get tag_name
-      | str replace --regex '^curl-' ''
-      | str replace --regex '^v' ''
-      | str replace --all '_' '.'
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^curl-(?<version>.*)$/,
+    normalizeVersion: true,
   });
 }

--- a/packages/difftastic/project.bri
+++ b/packages/difftastic/project.bri
@@ -38,7 +38,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
-  return std.liveUpdateFromGithubReleases({
-    project,
-  });
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -17,6 +17,9 @@ import type {} from "nushell";
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
  *   tag will be checked if it's a semver or semver-like version number.
+ * @param normalizeVersion - Whether to normalize the version number to
+ *   a semver-like version number. When enabled, the dashes and underscores
+ *   will be replaced with dots.
  */
 interface LiveUpdateFromGithubReleasesOptions {
   project: {
@@ -25,6 +28,7 @@ interface LiveUpdateFromGithubReleasesOptions {
     extra?: { releaseDate?: string };
   };
   readonly matchTag?: RegExp;
+  readonly normalizeVersion?: boolean;
 }
 
 /**
@@ -58,6 +62,7 @@ export function liveUpdateFromGithubReleases(
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
+  const normalizeVersion = options.normalizeVersion ?? false;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
@@ -72,6 +77,7 @@ export function liveUpdateFromGithubReleases(
         repoOwner,
         repoName,
         matchTag: matchTag.source,
+        normalizeVersion: normalizeVersion.toString(),
       },
       dependencies: [nushell],
     });

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -15,10 +15,14 @@ import type {} from "nushell";
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
  *   tag will be checked if it's a semver or semver-like version number.
+ * @param normalizeVersion - Whether to normalize the version number to
+ *   a semver-like version number. When enabled, the dashes and underscores
+ *   will be replaced with dots.
  */
 interface LiveUpdateFromGitlabReleasesOptions {
   project: { version: string; readonly repository: string };
   readonly matchTag?: RegExp;
+  readonly normalizeVersion?: boolean;
 }
 
 /**
@@ -52,6 +56,7 @@ export function liveUpdateFromGitlabReleases(
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGitlabRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
+  const normalizeVersion = options.normalizeVersion ?? false;
 
   return std.recipe(async () => {
     const { default: nushell } = await import("nushell");
@@ -66,6 +71,7 @@ export function liveUpdateFromGitlabReleases(
         repoOwner,
         repoName,
         matchTag: matchTag.source,
+        normalizeVersion: normalizeVersion.toString(),
       },
       dependencies: [nushell],
     });

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -21,9 +21,14 @@ if ($parsedTagName | length) == 0 {
   error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
 }
 
-let version = $parsedTagName.0.version?
+mut version = $parsedTagName.0.version?
 if $version == null {
   error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
+}
+
+if $env.normalizeVersion == "true" {
+  $version = $version
+    | str replace --all --regex "(-|_)" "."
 }
 
 $project = $project

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -15,9 +15,14 @@ if ($parsedTagName | length) == 0 {
   error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
 }
 
-let version = $parsedTagName.0.version?
+mut version = $parsedTagName.0.version?
 if $version == null {
   error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
+}
+
+if $env.normalizeVersion == "true" {
+  $version = $version
+    | str replace --all --regex "(-|_)" "."
 }
 
 $project = $project


### PR DESCRIPTION
Add a version normalizer for GitHub and GitLab live update releases. This new capability will be used with the following packages:

- curl (this PR)
- expat (will be done in an upcoming PR)
- icu (will be done in an upcoming PR)

`expat` and `icu` require project version formatter to convert `X.Y.Z` to either `X-Y-Z` or `X_Y_Z`. I'm planning to add a new std helper to convert a package version. Why this approach instead of simply using a one line function in each package ?

1. Factorize the code inside a common package (here std)
2. Later we could add function to extract sub part of a version (this is sometimes needed in testing package function, ie: `libcap`)