### PR TITLE
Fix doc comment examples for `runBash` and `runNushell`

### DIFF
--- a/packages/nushell/run_nushell.bri
+++ b/packages/nushell/run_nushell.bri
@@ -16,11 +16,12 @@ import nushell from "/";
  * @param strings - The template string parts for the Nushell script.
  * @param values - The template string values.
  *
- * @returns A process recipe that runs the Nushell script
+ * @returns A process recipe that runs the Nushell script.
  *
  * @example
  * ```typescript
  * import * as std from "std";
+ * import { runNushell } from "nushell";
  *
  * // Running `brioche build -o output` will create a directory `output`
  * // with the file `hello.txt`. The result is cached, so the script won't
@@ -30,9 +31,9 @@ import nushell from "/";
  *
  *   // Return a recipe that will call the script, with `$file` set to
  *   // the absolute path of the file above
- *   return std.runBash`
- *     mkdir -p "$BRIOCHE_OUTPUT"
- *     cp "$file" > "$BRIOCHE_OUTPUT/hello.txt"
+ *   return std.runNushell`
+ *     mkdir $env.BRIOCHE_OUTPUT
+ *     open $env.file | save $'($env.BRIOCHE_OUTPUT)/hello.txt'
  *   `
  *     .env({ file });
  * }

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -32,7 +32,7 @@ import { tools } from "/toolchain";
  *   // the absolute path of the file above
  *   return std.runBash`
  *     mkdir -p "$BRIOCHE_OUTPUT"
- *     cp "$file" > "$BRIOCHE_OUTPUT/hello.txt"
+ *     cat "$file" > "$BRIOCHE_OUTPUT/hello.txt"
  *   `
  *     .env({ file });
  * }


### PR DESCRIPTION
Follow-up to https://github.com/brioche-dev/brioche-packages/pull/787#discussion_r2190797578 to fix the doc comment example for the new `runNushell` function. While looking at this, I also noticed that the example for `std.runBash` was also broken!