### PR TITLE
feat(cargo_dist): add package

### DIFF
--- a/packages/cargo_dist/brioche.lock
+++ b/packages/cargo_dist/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/axodotdev/cargo-dist.git": {
+      "v0.28.0": "b96f4b7d6f3e9e5c36e25b08a63306df83d8893f"
+    }
+  }
+}

--- a/packages/cargo_dist/project.bri
+++ b/packages/cargo_dist/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_dist",
+  version: "0.28.0",
+  repository: "https://github.com/axodotdev/cargo-dist.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoDist(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    path: "cargo-dist",
+    runnable: "bin/dist",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dist --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cargoDist)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-dist ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_dist`](https://github.com/axodotdev/cargo-dist): a shippable application packaging 

```bash
Build finished, completed (no new jobs) in 7.02s
Running brioche-run
{
  "name": "cargo_dist",
  "version": "0.28.0",
  "repository": "https://github.com/axodotdev/cargo-dist.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
74843  │ cargo-dist 0.28.0
 0.03s ✓ Process 74843
Build finished, completed 1 job in 2.40s
Result: c9062ea15ec6c8a683395fe67576399d16437fc87a2cf8f52db15d99a6cdd6a0

⏵ Task `Run package test` finished successfully
```