### PR TITLE
Add nodejs supported versions

### DIFF
--- a/packages/nodejs/brioche.lock
+++ b/packages/nodejs/brioche.lock
@@ -1,6 +1,14 @@
 {
   "dependencies": {},
   "downloads": {
+    "https://nodejs.org/dist/v20.19.3/node-v20.19.3-linux-arm64.tar.xz": {
+      "type": "sha256",
+      "value": "72a3036618fb47d8aaa3050477d9577747a9e550c39be46b53202a3b3e797e83"
+    },
+    "https://nodejs.org/dist/v20.19.3/node-v20.19.3-linux-x64.tar.xz": {
+      "type": "sha256",
+      "value": "c210e1a547efad55e93af1e04fb80d2f7131b13872f2de4e9ebdfecb8e06caad"
+    },
     "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-arm64.tar.xz": {
       "type": "sha256",
       "value": "140aee84be6774f5fb3f404be72adbe8420b523f824de82daeb5ab218dab7b18"

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -130,20 +130,28 @@ export default function nodejs(
     .pipe((node) => std.withRunnableLink(node, "bin/node"));
 }
 
-export async function test(): Promise<std.Recipe<std.File>> {
-  const script = std.runBash`
-    node --version | tee "$BRIOCHE_OUTPUT"
-  `
-    .dependencies(nodejs)
-    .toFile();
+export function test(): std.Recipe<std.Directory> {
+  const nodeVersions = Object.keys(
+    project.extra.majorVersions,
+  ) as NodeVersion[];
 
-  const result = (await script.read()).trim();
+  const tests = nodeVersions.map(async (version) => {
+    const script = std.runBash`
+      node --version | tee "$BRIOCHE_OUTPUT"
+    `
+      .dependencies(nodejs({ version }))
+      .toFile();
 
-  // Check that the result contains the expected version
-  const expected = `v${project.version}`;
-  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+    const result = (await script.read()).trim();
 
-  return script;
+    // Check that the result contains the expected version
+    const expected = `v${project.extra.majorVersions[version]}`;
+    std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+    return std.directory().insert(version, script);
+  });
+
+  return std.merge(...tests);
 }
 
 export function liveUpdate(): NushellRunnable {

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -9,8 +9,9 @@ export const project = {
   extra: {
     currentMajorVersion: "24",
     majorVersions: {
-      "22": "22.17.0",
       "24": "24.2.0",
+      "22": "22.17.0",
+      "20": "20.19.3",
     },
   },
 } as const;
@@ -32,6 +33,18 @@ const prebuiltBinaries: Record<
   string,
   Record<string, std.Recipe<std.Directory>>
 > = {
+  "24": {
+    "x86_64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-x64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+    "aarch64-linux": Brioche.download(
+      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-arm64.tar.xz`,
+    )
+      .unarchive("tar", "xz")
+      .peel(),
+  },
   "22": {
     "x86_64-linux": Brioche.download(
       `https://nodejs.org/dist/v${project.extra.majorVersions["22"]}/node-v${project.extra.majorVersions["22"]}-linux-x64.tar.xz`,
@@ -44,14 +57,14 @@ const prebuiltBinaries: Record<
       .unarchive("tar", "xz")
       .peel(),
   },
-  "24": {
+  "20": {
     "x86_64-linux": Brioche.download(
-      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-x64.tar.xz`,
+      `https://nodejs.org/dist/v${project.extra.majorVersions["20"]}/node-v${project.extra.majorVersions["20"]}-linux-x64.tar.xz`,
     )
       .unarchive("tar", "xz")
       .peel(),
     "aarch64-linux": Brioche.download(
-      `https://nodejs.org/dist/v${project.extra.majorVersions["24"]}/node-v${project.extra.majorVersions["24"]}-linux-arm64.tar.xz`,
+      `https://nodejs.org/dist/v${project.extra.majorVersions["20"]}/node-v${project.extra.majorVersions["20"]}-linux-arm64.tar.xz`,
     )
       .unarchive("tar", "xz")
       .peel(),
@@ -162,6 +175,7 @@ export function liveUpdate(): NushellRunnable {
           }
           | transpose -r
           | into record
+          | sort -r
       }
       # Set the current major version
       | update extra.currentMajorVersion $latestVersionRef.major

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -29,11 +29,11 @@ std.assert(
 type PythonVersion = keyof typeof project.extra.minorVersions;
 
 const sources: { [version: string]: std.Recipe<std.File> } = {
-  "3.12": Brioche.download(
-    `https://www.python.org/ftp/python/${project.extra.minorVersions["3.12"]}/Python-${project.extra.minorVersions["3.12"]}.tar.xz`,
-  ),
   "3.13": Brioche.download(
     `https://www.python.org/ftp/python/${project.version}/Python-${project.version}.tar.xz`,
+  ),
+  "3.12": Brioche.download(
+    `https://www.python.org/ftp/python/${project.extra.minorVersions["3.12"]}/Python-${project.extra.minorVersions["3.12"]}.tar.xz`,
   ),
 } satisfies Record<PythonVersion, std.Recipe<std.File>>;
 


### PR DESCRIPTION
We now also support Node.js 20 version in addition to 22 and 24 (per https://nodejs.org/en/about/previous-releases, that's all the current supported versions).

Also we now properly test each Node.js to make sure the installation went well.

```bash
Build finished, completed (no new jobs) in 6.47s
Running brioche-run
{
  "name": "nodejs",
  "version": "24.4.0",
  "extra": {
    "currentMajorVersion": "24",
    "majorVersions": {
      "24": "24.4.0",
      "22": "22.17.0",
      "20": "20.19.3"
    }
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.75s
Result: 9de45ffdb2439747bab26d8c50cb6683405abd2b3d9d1d8f889e1fc2eba081b0

⏵ Task `Run package test` finished successfully
```