### PR TITLE
Project version formatting

### DIFF
--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -1,21 +1,22 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "expat",
   version: "2.7.1",
+  repository: "https://github.com/libexpat/libexpat",
   extra: {
     versionUnderscore: "2_7_1",
   },
 };
 
 std.assert(
-  project.extra.versionUnderscore === project.version.replaceAll(".", "_"),
+  project.extra.versionUnderscore ===
+    std.projectVersionToUnderscoreFormat({ project }),
   `expected 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
 );
 
 const source = Brioche.download(
-  `https://github.com/libexpat/libexpat/releases/download/R_${project.extra.versionUnderscore}/expat-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/R_${project.extra.versionUnderscore}/expat-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();
@@ -55,19 +56,10 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let versionUnderscore = http get https://api.github.com/repos/libexpat/libexpat/releases/latest
-      | get tag_name
-      | str replace --regex '^R_' ''
-
-    let version = $versionUnderscore
-      | str replace --all '_' '.'
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.versionUnderscore $versionUnderscore
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^R_(?<version>.*)$/,
+    normalizeVersion: true,
+  });
 }

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -1,9 +1,9 @@
 import * as std from "std";
-import { nushellRunnable, NushellRunnable } from "nushell";
 
 export const project = {
   name: "icu",
   version: "77.1",
+  repository: "https://github.com/unicode-org/icu",
   extra: {
     versionDash: "77-1",
     versionUnderscore: "77_1",
@@ -11,16 +11,17 @@ export const project = {
 };
 
 std.assert(
-  project.extra.versionDash === project.version.replaceAll(".", "-"),
+  project.extra.versionDash === std.projectVersionToDashFormat({ project }),
   `expected 'project.extra.versionDash' field '${project.extra.versionDash}' to match version '${project.version}'`,
 );
 std.assert(
-  project.extra.versionUnderscore === project.version.replaceAll(".", "_"),
+  project.extra.versionUnderscore ===
+    std.projectVersionToUnderscoreFormat({ project }),
   `expected 'project.extra.versionUnderscore' field '${project.extra.versionUnderscore}' to match version '${project.version}'`,
 );
 
 const source = Brioche.download(
-  `https://github.com/unicode-org/icu/releases/download/release-${project.extra.versionDash}/icu4c-${project.extra.versionUnderscore}-src.tgz`,
+  `${project.repository}/releases/download/release-${project.extra.versionDash}/icu4c-${project.extra.versionUnderscore}-src.tgz`,
 ).unarchive("tar", "gzip");
 
 export default function icu(): std.Recipe<std.Directory> {
@@ -89,25 +90,10 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let releaseData = http get https://api.github.com/repos/unicode-org/icu/releases/latest
-
-    let versionDash = $releaseData
-      | get tag_name
-      | str replace --regex '^release-' ''
-
-    let versionUnderscore = $versionDash
-      | str replace '-' '_'
-
-    let version = $versionDash
-      | str replace '-' '.'
-
-    $env.project
-      | from json
-      | update version $version
-      | update extra.versionDash $versionDash
-      | update extra.versionUnderscore $versionUnderscore
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>.*)$/,
+    normalizeVersion: true,
+  });
 }

--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -8,5 +8,6 @@ export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
 export * from "./live_update";
 export * from "./pkg_config_make_paths_relative.bri";
+export * from "./project_version";
 
 import "./extra_global.bri";

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -6,12 +6,23 @@ import type {} from "nushell";
 // https://github.com/brioche-dev/brioche/issues/242
 
 /**
+ * Additional options for the project to update.
+ *
+ * @param versionDash - The version of the project (converted in dash format).
+ * @param versionUnderscore - The version of the project (converted in underscore format).
+ * @param releaseDate - The release date of the project in the format `YYYY-MM-DD`
+ */
+interface LiveUpdateFromGithubReleasesProjectExtraOptions {
+  versionDash?: string;
+  versionUnderscore?: string;
+  releaseDate?: string;
+}
+
+/**
  * Options for the live update from GitHub releases.
  *
  * @param project - The project export that should be updated. Must include a
- *   `repository` property containing a GitHub repository URL. Optionally,
- *   a release date can be provided in the extra field, it should
- *   represent the date of the latest release in the format `YYYY-MM-DD`.
+ *   `repository` property containing a GitHub repository URL.
  * @param matchTag - A regex value (`/.../`) to extract the version number from
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
@@ -24,7 +35,7 @@ interface LiveUpdateFromGithubReleasesOptions {
   project: {
     version: string;
     readonly repository: string;
-    extra?: { releaseDate?: string };
+    extra?: LiveUpdateFromGithubReleasesProjectExtraOptions;
   };
   readonly matchTag?: RegExp;
   readonly normalizeVersion?: boolean;

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -6,6 +6,17 @@ import type {} from "nushell";
 // https://github.com/brioche-dev/brioche/issues/242
 
 /**
+ * Additional options for the project to update.
+ *
+ * @param versionDash - The version of the project (converted in dash format).
+ * @param versionUnderscore - The version of the project (converted in underscore format).
+ */
+interface LiveUpdateFromGitlabReleasesProjectExtraOptions {
+  versionDash?: string;
+  versionUnderscore?: string;
+}
+
+/**
  * Options for the live update from GitLab releases.
  *
  * @param project - The project export that should be updated. Must include a
@@ -19,7 +30,11 @@ import type {} from "nushell";
  *   will be replaced with dots.
  */
 interface LiveUpdateFromGitlabReleasesOptions {
-  project: { version: string; readonly repository: string };
+  project: {
+    version: string;
+    readonly repository: string;
+    extra?: LiveUpdateFromGitlabReleasesProjectExtraOptions;
+  };
   readonly matchTag?: RegExp;
   readonly normalizeVersion?: boolean;
 }

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -6,11 +6,11 @@ import type {} from "nushell";
 // https://github.com/brioche-dev/brioche/issues/242
 
 /**
- * Extra options for the live update from npm packages.
+ * Additional options for the project to update.
  *
  * @param packageName - The name of the npm package to update.
  */
-interface LiveUpdateFromNpmPackagesExtraOptions {
+interface LiveUpdateFromNpmPackagesProjectExtraOptions {
   readonly packageName: string;
 }
 
@@ -23,7 +23,7 @@ interface LiveUpdateFromNpmPackagesExtraOptions {
 interface LiveUpdateFromNpmPackagesOptions {
   project: {
     version: string;
-    readonly extra: LiveUpdateFromNpmPackagesExtraOptions;
+    readonly extra: LiveUpdateFromNpmPackagesProjectExtraOptions;
   };
 }
 
@@ -81,7 +81,7 @@ interface NpmPackageInfo {
 }
 
 function tryParseNpmPackage(
-  extraOptions: LiveUpdateFromNpmPackagesExtraOptions,
+  extraOptions: LiveUpdateFromNpmPackagesProjectExtraOptions,
 ): NpmPackageInfo | null {
   const match = extraOptions.packageName.match(/^(?<packageName>[\w\.@/-]+)$/);
 
@@ -103,7 +103,7 @@ function tryParseNpmPackage(
  * @throws If the package name cannot be parsed.
  */
 function parseNpmPackage(
-  extraOptions: LiveUpdateFromNpmPackagesExtraOptions,
+  extraOptions: LiveUpdateFromNpmPackagesProjectExtraOptions,
 ): NpmPackageInfo {
   const info = tryParseNpmPackage(extraOptions);
   if (info == null) {

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -34,10 +34,24 @@ if $env.normalizeVersion == "true" {
 $project = $project
   | update version $version
 
+if ($project | get extra?.versionDash?) != null {
+  let $versionDash = $version
+    | str replace --all "." "-"
+
+  $project = $project
+    | update extra.versionDash $versionDash
+}
+
+if ($project | get extra?.versionUnderscore?) != null {
+  let $versionUnderscore = $version
+    | str replace --all "." "_"
+
+  $project = $project
+    | update extra.versionUnderscore $versionUnderscore
+}
+
 # Extract the release date (if needed by the project)
-let releaseDate = $project
-  | get extra?.releaseDate?
-if $releaseDate != null {
+if ($project | get extra?.releaseDate?) != null {
   let $createdDate = $releaseInfo
     | get created_at
     | into datetime

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -28,6 +28,22 @@ if $env.normalizeVersion == "true" {
 $project = $project
   | update version $version
 
+if ($project | get extra?.versionDash?) != null {
+  let $versionDash = $version
+    | str replace --all "." "-"
+
+  $project = $project
+    | update extra.versionDash $versionDash
+}
+
+if ($project | get extra?.versionUnderscore?) != null {
+  let $versionUnderscore = $version
+    | str replace --all "." "_"
+
+  $project = $project
+    | update extra.versionUnderscore $versionUnderscore
+}
+
 # Return back the project metadata encoded as JSON
 $project
   | to json

--- a/packages/std/extra/project_version/format.bri
+++ b/packages/std/extra/project_version/format.bri
@@ -1,0 +1,139 @@
+import { PROJECT_VERSION_SEMVER_MATCH } from "./index.bri";
+
+/**
+ * All the possible project version format type.
+ */
+enum ProjectVersionFormatType {
+  DOT = ".",
+  DASH = "-",
+  UNDERSCORE = "_",
+}
+
+/**
+ * Options for the project version format.
+ */
+export interface ProjectVersionFormatOptions {
+  project: {
+    version: string;
+  };
+}
+
+/**
+ * Formats the project version to a dash format.
+ *
+ * @param options - Options for the project version format.
+ *
+ * @returns The formatted project version.
+ *
+ * @throws Error if the project version is not a semver-like version.
+ *
+ * @example
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   extra: {
+ *     versionDash: "0-1-0",
+ *   },
+ * };
+ *
+ * std.assert(
+ *   project.extra.versionDash === std.projectVersionToDashFormat({ project })
+ * };
+ * ```
+ */
+export function projectVersionToDashFormat(
+  options: ProjectVersionFormatOptions,
+): string {
+  const { version: matchedVersion, metadata: matchedMetadata } =
+    extractProjectVersion(options.project.version);
+
+  let finalVersion = matchedVersion.replaceAll(
+    ProjectVersionFormatType.DOT.toString(),
+    ProjectVersionFormatType.DASH.toString(),
+  );
+
+  if (matchedMetadata != null) {
+    finalVersion += `-${matchedMetadata}`;
+  }
+
+  return finalVersion;
+}
+
+/**
+ * Formats the project version to a underscore format.
+ *
+ * @param options - Options for the project version format.
+ *
+ * @returns The formatted project version.
+ *
+ * @throws Error if the project version is not a semver-like version.
+ *
+ * @example
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   extra: {
+ *     versionUnderscore: "0_1_0",
+ *   },
+ * };
+ *
+ * std.assert(
+ *   project.extra.versionUnderscore === std.projectVersionToUnderscoreFormat({ project })
+ * };
+ * ```
+ */
+export function projectVersionToUnderscoreFormat(
+  options: ProjectVersionFormatOptions,
+): string {
+  const { version: matchedVersion, metadata: matchedMetadata } =
+    extractProjectVersion(options.project.version);
+
+  let finalVersion = matchedVersion.replaceAll(
+    ProjectVersionFormatType.DOT.toString(),
+    ProjectVersionFormatType.UNDERSCORE.toString(),
+  );
+
+  if (matchedMetadata != null) {
+    finalVersion += `-${matchedMetadata}`;
+  }
+
+  return finalVersion;
+}
+
+/**
+ * Interface representing the project verions information.
+ */
+interface ProjectVersionInformation {
+  version: string;
+  metadata: string | undefined;
+}
+
+/**
+ * Extracts the project version information from a string.
+ *
+ * @param projectVersion - The project version string to extract information from.
+ *
+ * @returns An object containing the version and metadata.
+ *
+ * @throws Error if the project version is not a semver-like version.
+ */
+function extractProjectVersion(
+  projectVersion: string,
+): ProjectVersionInformation {
+  const match = projectVersion.match(PROJECT_VERSION_SEMVER_MATCH);
+
+  const { version: matchedVersion, metadata: matchedMetadata } =
+    match?.groups ?? {};
+  if (matchedVersion == null) {
+    throw new Error(
+      `Project version '${projectVersion}' is not a semver-like version`,
+    );
+  }
+
+  return {
+    version: matchedVersion,
+    metadata: matchedMetadata,
+  };
+}

--- a/packages/std/extra/project_version/format.bri
+++ b/packages/std/extra/project_version/format.bri
@@ -3,11 +3,11 @@ import { PROJECT_VERSION_SEMVER_MATCH } from "./index.bri";
 /**
  * All the possible project version format type.
  */
-enum ProjectVersionFormatType {
-  DOT = ".",
-  DASH = "-",
-  UNDERSCORE = "_",
-}
+ const ProjectVersionFormatType = {
+   DOT: ".",
+   DASH: "-",
+   UNDERSCORE: "_",
+ } as const;
 
 /**
  * Options for the project version format.

--- a/packages/std/extra/project_version/index.bri
+++ b/packages/std/extra/project_version/index.bri
@@ -1,0 +1,6 @@
+export * from "./format.bri";
+
+// The default regex used for checking if a project version is a either semver or
+// a semver-like version.
+export const PROJECT_VERSION_SEMVER_MATCH =
+  /^(?<version>(?<major_version>(?:0|[1-9]\d*))\.(?<minor_version>(?:0|[1-9]\d*))(?:\.(?<patch_version>(?:0|[1-9]\d*)))?)(?<metadata>(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?$/;


### PR DESCRIPTION
Finally finish what was began in https://github.com/brioche-dev/brioche-packages/pull/785 and https://github.com/brioche-dev/brioche-packages/pull/791.

This PR removes the remaining GitHub release custom live update implementation (found in `icu` and `expat)`. `https://api.github.com/repos/.../releases/latest` can now only be found in the Nushell script of the GitHub release live update. Meaning all the API call for checking the latest release available make use of the GitHub token (at least in the CI), reducing the API throttling, etc.

Also part of this PR, there are new methods in the std package to manipulate the project version:

- `std.projectVersionToDashFormat`
- `std.projectVersionToUnderscoreFormat`

As the name implies, they convert the project version to a specific format. All the packages relying on the dash and underscore formats have been updated.