### PR TITLE
feat(mpfr): add package

### DIFF
--- a/packages/mpfr/brioche.lock
+++ b/packages/mpfr/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz": {
+      "type": "sha256",
+      "value": "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
+    }
+  }
+}

--- a/packages/mpfr/project.bri
+++ b/packages/mpfr/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "mpfr",
+  version: "4.2.2",
+};
+
+const source = Brioche.download(
+  `https://ftp.gnu.org/gnu/mpfr/mpfr-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function mpfr(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-thread-safe
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion mpfr | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, mpfr)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://ftp.gnu.org/gnu/mpfr
+      | lines
+      | where {|it| ($it | str contains "mpfr-") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="mpfr-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add an already package part of the `std.toolchain()`: [`mpfr`](https://www.mpfr.org), a C library for multiple-precision floating-point computations with correct rounding

```bash
26691  │ 4.2.2
 0.01s ✓ Process 26691
Build finished, completed 1 job in 1.56s
Result: f7e53840f6259c7cdd87dfa6770bf41b7d3439ed11cdfe69432bfad9a891ecc8

⏵ Task `Run package test` finished successfully
```

```bash
 0.02s ✓ Process 3643
Build finished, completed 1 job in 6.42s
Running brioche-run
{
  "name": "mpfr",
  "version": "4.2.2"
}

⏵ Task `Run package live-update` finished successfully
```