### PR TITLE
feat(eigen): add package

### DIFF
--- a/packages/eigen/brioche.lock
+++ b/packages/eigen/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://gitlab.com/libeigen/eigen.git": {
+      "3.4.0": "3147391d946bb4b6c68edd901f2add6ac1f31f8c"
+    }
+  }
+}

--- a/packages/eigen/project.bri
+++ b/packages/eigen/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "eigen",
+  version: "3.4.0",
+  repository: "https://gitlab.com/libeigen/eigen.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function eigen(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion eigen3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, eigen)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`eigen`](https://gitlab.com/libeigen/eigen): a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

```bash
 INFO run_build: brioche::run: updated lockfiles num_lockfiles_updated=1
 0.01s ✓ Process 27261
Build finished, completed 1 job in 7.03s
Running brioche-run
{
  "name": "eigen",
  "version": "3.4.0",
  "repository": "https://gitlab.com/libeigen/eigen.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
27956  │ 3.4.0
 0.01s ✓ Process 27956
Build finished, completed 1 job in 1.69s
Result: cd0a15baa375125f5ae280872e4501d7a8f21840139a99bfb306f34f93ef5b8f

⏵ Task `Run package test` finished successfully
```