### PR TITLE
feat(gemini_cli): add package

### DIFF
--- a/packages/gemini_cli/brioche.lock
+++ b/packages/gemini_cli/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/gemini_cli/project.bri
+++ b/packages/gemini_cli/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "gemini_cli",
+  version: "0.1.11",
+  extra: {
+    packageName: "@google/gemini-cli",
+  },
+};
+
+export default function geminiCli(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/gemini"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gemini --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(geminiCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`gemini_cli`](https://github.com/google-gemini/gemini-cli): an open-source AI agent that brings the power of Gemini directly into your terminal

```bash
pointer display width should be up to 2
Build finished, completed (no new jobs) in 6.02s
Result: c71427e0d38ffd1907cdc0124f4d02845bc1e8ecdcd1ec7559d64c55178ffa08

⏵ Task `Run package test` finished successfully
```

```bash
 0.01s ✓ Process 75312
Build finished, completed 1 job in 7.29s
Running brioche-run
{
  "name": "gemini_cli",
  "version": "0.1.11",
  "extra": {
    "packageName": "@google/gemini-cli"
  }
}

⏵ Task `Run package live-update` finished successfully
```