### PR TITLE
feat(rust): generate `Cargo.lock` when the file does not exist in the upstream source

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -187,7 +187,7 @@ interface CargoBuildParameters {
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
- * @param generateLockfile - Controls if the crate from `source` should
+ * @param unsafeGenerateLockfile - Controls if the crate from `source` should
  *   generate a `Cargo.lock` file before the build. Defaults to `false`.
  * @param buildParams - Optional build parameters.
  */
@@ -199,7 +199,7 @@ export interface CargoBuildOptions {
   env?: Record<string, std.ProcessTemplateLike>;
   unsafe?: std.ProcessUnsafeOptions;
   cargoChefPrepare?: boolean;
-  generateLockfile?: boolean;
+  unsafeGenerateLockfile?: boolean;
   buildParams?: CargoBuildParameters;
 }
 
@@ -235,7 +235,7 @@ export function cargoBuild(options: CargoBuildOptions) {
   // Vendor the crate's dependencies
   const crate = vendorCrate({
     source: options.source,
-    generateLockfile: options.generateLockfile,
+    unsafeGenerateLockfile: options.unsafeGenerateLockfile,
     cargoChefPrepare: options.cargoChefPrepare,
   });
 
@@ -408,7 +408,7 @@ export function createSkeletonCrate(
  * Options for vendoring a Rust crate's dependencies.
  *
  * @param source - The crate to build.
- * @param generateLockfile - Generate a lockfile if the crate has no
+ * @param unsafeGenerateLockfile - Generate a lockfile if the crate has no
  *   `Cargo.lock` file. Defaults to `false`.
  * @param cargoChefPrepare - Controls if the crate from `source` should get
  *   pre-processed by `cargo chef prepare` before being built, which avoids
@@ -418,7 +418,7 @@ export function createSkeletonCrate(
  */
 interface VendorCrateOptions {
   source: std.RecipeLike<std.Directory>;
-  generateLockfile?: boolean;
+  unsafeGenerateLockfile?: boolean;
   cargoChefPrepare?: boolean;
 }
 
@@ -434,10 +434,14 @@ interface VendorCrateOptions {
 export function vendorCrate(
   options: VendorCrateOptions,
 ): std.Recipe<std.Directory> {
-  const { source, cargoChefPrepare = true, generateLockfile = false } = options;
+  const {
+    source,
+    cargoChefPrepare = true,
+    unsafeGenerateLockfile = false,
+  } = options;
 
   // Generate the Cargo.lock file exists if not already generated
-  const completeSource = createLockfile(source, generateLockfile);
+  const completeSource = createLockfile(source, unsafeGenerateLockfile);
 
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -342,6 +342,31 @@ export function cargoBuild(options: CargoBuildOptions) {
 }
 
 /**
+ * Ensure that Cargo.lock file exists, and if it doesn't, generate it.
+ * Warning: if this file is missing from the upstream source, it breaks
+ * reproducible builds, but we need it to vendor the dependencies.
+ *
+ * @param crate - The crate to ensure the lock file exists for.
+ *
+ * @return The source crate with the lock file.
+ */
+function ensureLockFileExists(
+  crate: std.RecipeLike<std.Directory>,
+): std.Recipe<std.Directory> {
+  return std.runBash`
+    cd "$BRIOCHE_OUTPUT"
+
+    if [ ! -f Cargo.lock ]; then
+      cargo generate-lockfile
+    fi
+  `
+    .dependencies(rust)
+    .outputScaffold(crate)
+    .unsafe({ networking: true })
+    .toDirectory();
+}
+
+/**
  * Create a "skeleton crate" for a Rust crate. This is a crate that has
  * the minimal set of files needed for Cargo to consider it a valid crate,
  * namely so we can vendor dependencies. Without doing this, we would need
@@ -395,9 +420,14 @@ export function vendorCrate(
 ): std.Recipe<std.Directory> {
   const { source, cargoChefPrepare = true } = options;
 
+  // Generate the Cargo.lock file exists if it doesn't exist
+  const completeSource = ensureLockFileExists(source);
+
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies
-  const skeletonCrate = cargoChefPrepare ? createSkeletonCrate(source) : source;
+  const skeletonCrate = cargoChefPrepare
+    ? createSkeletonCrate(completeSource)
+    : completeSource;
 
   // Vendor the dependencies with network access and save the Cargo config.toml
   // file, so the vendored dependencies are used

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -187,6 +187,8 @@ interface CargoBuildParameters {
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
+ * @param generateLockFile - Controls if the crate from `source` should
+ *   generate a `Cargo.lock` file before the build. Defaults to `false`.
  * @param buildParams - Optional build parameters.
  */
 export interface CargoBuildOptions {
@@ -197,6 +199,7 @@ export interface CargoBuildOptions {
   env?: Record<string, std.ProcessTemplateLike>;
   unsafe?: std.ProcessUnsafeOptions;
   cargoChefPrepare?: boolean;
+  generateLockFile?: boolean;
   buildParams?: CargoBuildParameters;
 }
 
@@ -232,6 +235,7 @@ export function cargoBuild(options: CargoBuildOptions) {
   // Vendor the crate's dependencies
   const crate = vendorCrate({
     source: options.source,
+    generateLockFile: options.generateLockFile,
     cargoChefPrepare: options.cargoChefPrepare,
   });
 
@@ -342,26 +346,35 @@ export function cargoBuild(options: CargoBuildOptions) {
 }
 
 /**
- * Ensure that Cargo.lock file exists, and if it doesn't, generate it.
+ * Generate the Cargo.lock file if it doesn't exist.
  * Warning: if this file is missing from the upstream source, it breaks
  * reproducible builds, but we need it to vendor the dependencies.
  *
- * @param crate - The crate to ensure the lock file exists for.
+ * @param crate - The crate to ensure the lock file will be generated for.
+ * @param allowLockFileGeneration - Whether to generate the lock file.
  *
  * @return The source crate with the lock file.
  */
-function ensureLockFileExists(
+function createLockFile(
   crate: std.RecipeLike<std.Directory>,
+  allowLockFileGeneration: boolean,
 ): std.Recipe<std.Directory> {
   return std.runBash`
-    cd "$BRIOCHE_OUTPUT"
+    if [ "$allowLockFileGeneration" = "true" ]; then
+      cd "$BRIOCHE_OUTPUT"
 
-    if [ ! -f Cargo.lock ]; then
+      # Check if the Cargo.lock file exists, if yes, exit on error
+      if [ -f Cargo.lock ]; then
+        echo "Cannot generate Cargo.lock file because it already exists"
+        exit 1
+      fi
+
       cargo generate-lockfile
     fi
   `
     .dependencies(rust)
     .outputScaffold(crate)
+    .env({ allowLockFileGeneration: allowLockFileGeneration.toString() })
     .unsafe({ networking: true })
     .toDirectory();
 }
@@ -395,6 +408,8 @@ export function createSkeletonCrate(
  * Options for vendoring a Rust crate's dependencies.
  *
  * @param source - The crate to build.
+ * @param generateLockFile - Generate a lock file if the crate has no
+ *   `Cargo.lock` file. Defaults to `false`.
  * @param cargoChefPrepare - Controls if the crate from `source` should get
  *   pre-processed by `cargo chef prepare` before being built, which avoids
  *   unnecessarily re-downloading dependencies when the source changes.
@@ -403,6 +418,7 @@ export function createSkeletonCrate(
  */
 interface VendorCrateOptions {
   source: std.RecipeLike<std.Directory>;
+  generateLockFile?: boolean;
   cargoChefPrepare?: boolean;
 }
 
@@ -418,10 +434,10 @@ interface VendorCrateOptions {
 export function vendorCrate(
   options: VendorCrateOptions,
 ): std.Recipe<std.Directory> {
-  const { source, cargoChefPrepare = true } = options;
+  const { source, cargoChefPrepare = true, generateLockFile = false } = options;
 
-  // Generate the Cargo.lock file exists if it doesn't exist
-  const completeSource = ensureLockFileExists(source);
+  // Generate the Cargo.lock file exists if not already generated
+  const completeSource = createLockFile(source, generateLockFile);
 
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -187,7 +187,7 @@ interface CargoBuildParameters {
  *   unnecessarily re-downloading dependencies when the source changes.
  *   Defaults to `true` (should only be disabled when there's an upstream
  *   issue with `cargo chef`).
- * @param generateLockFile - Controls if the crate from `source` should
+ * @param generateLockfile - Controls if the crate from `source` should
  *   generate a `Cargo.lock` file before the build. Defaults to `false`.
  * @param buildParams - Optional build parameters.
  */
@@ -199,7 +199,7 @@ export interface CargoBuildOptions {
   env?: Record<string, std.ProcessTemplateLike>;
   unsafe?: std.ProcessUnsafeOptions;
   cargoChefPrepare?: boolean;
-  generateLockFile?: boolean;
+  generateLockfile?: boolean;
   buildParams?: CargoBuildParameters;
 }
 
@@ -235,7 +235,7 @@ export function cargoBuild(options: CargoBuildOptions) {
   // Vendor the crate's dependencies
   const crate = vendorCrate({
     source: options.source,
-    generateLockFile: options.generateLockFile,
+    generateLockfile: options.generateLockfile,
     cargoChefPrepare: options.cargoChefPrepare,
   });
 
@@ -350,17 +350,17 @@ export function cargoBuild(options: CargoBuildOptions) {
  * Warning: if this file is missing from the upstream source, it breaks
  * reproducible builds, but we need it to vendor the dependencies.
  *
- * @param crate - The crate to ensure the lock file will be generated for.
- * @param allowLockFileGeneration - Whether to generate the lock file.
+ * @param crate - The crate to ensure the lockfile will be generated for.
+ * @param allowLockfileGeneration - Whether to generate the lockfile.
  *
- * @return The source crate with the lock file.
+ * @return The source crate with the lockfile.
  */
-function createLockFile(
+function createLockfile(
   crate: std.RecipeLike<std.Directory>,
-  allowLockFileGeneration: boolean,
+  allowLockfileGeneration: boolean,
 ): std.Recipe<std.Directory> {
   return std.runBash`
-    if [ "$allowLockFileGeneration" = "true" ]; then
+    if [ "$allowLockfileGeneration" = "true" ]; then
       cd "$BRIOCHE_OUTPUT"
 
       # Check if the Cargo.lock file exists, if yes, exit on error
@@ -374,7 +374,7 @@ function createLockFile(
   `
     .dependencies(rust)
     .outputScaffold(crate)
-    .env({ allowLockFileGeneration: allowLockFileGeneration.toString() })
+    .env({ allowLockfileGeneration: allowLockfileGeneration.toString() })
     .unsafe({ networking: true })
     .toDirectory();
 }
@@ -408,7 +408,7 @@ export function createSkeletonCrate(
  * Options for vendoring a Rust crate's dependencies.
  *
  * @param source - The crate to build.
- * @param generateLockFile - Generate a lock file if the crate has no
+ * @param generateLockfile - Generate a lockfile if the crate has no
  *   `Cargo.lock` file. Defaults to `false`.
  * @param cargoChefPrepare - Controls if the crate from `source` should get
  *   pre-processed by `cargo chef prepare` before being built, which avoids
@@ -418,7 +418,7 @@ export function createSkeletonCrate(
  */
 interface VendorCrateOptions {
   source: std.RecipeLike<std.Directory>;
-  generateLockFile?: boolean;
+  generateLockfile?: boolean;
   cargoChefPrepare?: boolean;
 }
 
@@ -434,10 +434,10 @@ interface VendorCrateOptions {
 export function vendorCrate(
   options: VendorCrateOptions,
 ): std.Recipe<std.Directory> {
-  const { source, cargoChefPrepare = true, generateLockFile = false } = options;
+  const { source, cargoChefPrepare = true, generateLockfile = false } = options;
 
   // Generate the Cargo.lock file exists if not already generated
-  const completeSource = createLockFile(source, generateLockFile);
+  const completeSource = createLockfile(source, generateLockfile);
 
   // Create a skeleton crate so we have enough information to vendor the
   // dependencies


### PR DESCRIPTION
Sometimes the upstream source of a Rust package does not contain any `Cargo.lock` file which is not recommended, since we cannot ensure build reproducibility. I think, we should try generating the lock file when we encounter such rust packages. It's more a workaround, and usually this issue should be fixed upstream.

Here is a list of packages for example that do not contain any lock files:

- https://github.com/taiki-e/cargo-hack
- https://github.com/taiki-e/cargo-llvm-cov
- https://github.com/taiki-e/cargo-minimal-versions
- https://github.com/taiki-e/cargo-no-dev-deps