### PR TITLE
Add cargo llvm cov

### DIFF
--- a/packages/cargo_llvm_cov/brioche.lock
+++ b/packages/cargo_llvm_cov/brioche.lock
@@ -1,8 +1,9 @@
 {
   "dependencies": {},
-  "git_refs": {
-    "https://github.com/taiki-e/cargo-llvm-cov.git": {
-      "v0.6.17": "6c8640e8d2ddb8a4d072a4c16c1b5ff47ac0c210"
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-llvm-cov/0.6.17/download": {
+      "type": "sha256",
+      "value": "5d99e575343630676845541dad8d99b46706b58df7438c1b1297a5472faf6ce4"
     }
   }
 }

--- a/packages/cargo_llvm_cov/brioche.lock
+++ b/packages/cargo_llvm_cov/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/taiki-e/cargo-llvm-cov.git": {
+      "v0.6.17": "6c8640e8d2ddb8a4d072a4c16c1b5ff47ac0c210"
+    }
+  }
+}

--- a/packages/cargo_llvm_cov/project.bri
+++ b/packages/cargo_llvm_cov/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_llvm_cov",
+  version: "0.6.17",
+  repository: "https://github.com/taiki-e/cargo-llvm-cov.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoLlvmCov(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-llvm-cov",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo llvm-cov --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoLlvmCov)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-llvm-cov ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/cargo_llvm_cov/project.bri
+++ b/packages/cargo_llvm_cov/project.bri
@@ -4,7 +4,6 @@ import rust, { cargoBuild } from "rust";
 export const project = {
   name: "cargo_llvm_cov",
   version: "0.6.17",
-  repository: "https://github.com/taiki-e/cargo-llvm-cov.git",
   extra: {
     crateName: "cargo-llvm-cov",
   },
@@ -40,5 +39,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
-  return std.liveUpdateFromGithubReleases({ project });
+  return std.liveUpdateFromRustCrates({ project });
 }

--- a/packages/cargo_llvm_cov/project.bri
+++ b/packages/cargo_llvm_cov/project.bri
@@ -5,12 +5,16 @@ export const project = {
   name: "cargo_llvm_cov",
   version: "0.6.17",
   repository: "https://github.com/taiki-e/cargo-llvm-cov.git",
+  extra: {
+    crateName: "cargo-llvm-cov",
+  },
 };
 
-const source = Brioche.gitCheckout({
-  repository: project.repository,
-  ref: `v${project.version}`,
-});
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
 
 export default function cargoLlvmCov(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/std/extra/live_update/from_rust_crates.bri
+++ b/packages/std/extra/live_update/from_rust_crates.bri
@@ -1,0 +1,116 @@
+import * as std from "/core";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import type {} from "nushell";
+
+// HACK: The `import type` line above is a workaround for this issue:
+// https://github.com/brioche-dev/brioche/issues/242
+
+/**
+ * Additional options for the project to update.
+ *
+ * @param crateName - The name of the rust crate to update.
+ */
+interface LiveUpdateFromRustCratesProjectExtraOptions {
+  readonly crateName: string;
+}
+
+/**
+ * Options for the live update from Rust crates.
+ *
+ * @param project - The project export that should be updated. Must include a
+ *   `extra.crateName` property containing the name of the Rust crate.
+ */
+interface LiveUpdateFromRustCratesOptions {
+  project: {
+    version: string;
+    readonly extra: LiveUpdateFromRustCratesProjectExtraOptions;
+  };
+}
+
+/**
+ * Return a runnable recipe to live-update a project based on the latest release
+ * version from the crates.io registry. The project's version will be set based on a
+ * regex match against the latest version. The crate name is inferred from the
+ * extra options of the project.
+ *
+ * @remarks The version schema of a Rust crate should follow the SemVer
+ * specification.
+ *
+ * @param options - Options for the live update from Rust crates.
+ *
+ * @returns A runnable recipe to live-update the project
+ *
+ * @example
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   extra: {
+ *     crateName: "brioche",
+ *   },
+ * };
+ *
+ * export function liveUpdate(): std.Recipe<std.Directory> {
+ *   return std.liveUpdateFromRustCrates({ project });
+ * }
+ * ```
+ */
+export function liveUpdateFromRustCrates(
+  options: LiveUpdateFromRustCratesOptions,
+): std.Recipe<std.Directory> {
+  const { crateName } = parseRustCrate(options.project.extra);
+
+  return std.recipe(async () => {
+    const { nushellRunnable } = await import("nushell");
+
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_rust_crates.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      crateName,
+      matchVersion: DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH.source,
+    });
+  });
+}
+
+/**
+ * Interface representing the parsed Rust crate information.
+ */
+interface RustCrateInfo {
+  readonly crateName: string;
+}
+
+function tryParseRustCrate(
+  extraOptions: LiveUpdateFromRustCratesProjectExtraOptions,
+): RustCrateInfo | null {
+  const match = extraOptions.crateName.match(/^(?<crateName>[\w\.@/-]+)$/);
+
+  const { crateName } = match?.groups ?? {};
+  if (crateName == null) {
+    return null;
+  }
+
+  return { crateName };
+}
+
+/**
+ * Parse the Rust crate information to extract the crate name.
+ *
+ * @param extraOptions - The extra options containing the crate name.
+ *
+ * @returns An object containing the crate name.
+ *
+ * @throws If the crate name cannot be parsed.
+ */
+function parseRustCrate(
+  extraOptions: LiveUpdateFromRustCratesProjectExtraOptions,
+): RustCrateInfo {
+  const info = tryParseRustCrate(extraOptions);
+  if (info == null) {
+    throw new Error(
+      `Could not parse Rust crate from ${JSON.stringify(extraOptions)}`,
+    );
+  }
+
+  return info;
+}

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -1,6 +1,7 @@
 export * from "./from_github_releases.bri";
 export * from "./from_gitlab_releases.bri";
 export * from "./from_npm_packages.bri";
+export * from "./from_rust_crates.bri";
 
 // The default regex used for matching versions. Strips an optional "v" prefix,
 // then matches the rest if it looks like a version number (either semver or

--- a/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
@@ -1,0 +1,28 @@
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the latest release information from crates.io registry
+let releaseInfo = http get $'https://crates.io/api/v1/crates/($env.crateName)'
+
+# Extract the version
+let version = $releaseInfo
+  | get crate.max_version
+
+let parsedVersion = $version
+  | parse --regex $env.matchVersion
+if ($parsedVersion | length) == 0 {
+  error make { msg: $'Latest release ($version) did not match regex ($env.matchVersion)' }
+}
+
+let version = $parsedVersion.0.version?
+if $version == null {
+  error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
+}
+
+$project = $project
+  | update version $version
+
+# Return back the project metadata encoded as JSON
+$project
+  | to json

--- a/packages/std/extra/project_version/format.bri
+++ b/packages/std/extra/project_version/format.bri
@@ -3,11 +3,11 @@ import { PROJECT_VERSION_SEMVER_MATCH } from "./index.bri";
 /**
  * All the possible project version format type.
  */
- const ProjectVersionFormatType = {
-   DOT: ".",
-   DASH: "-",
-   UNDERSCORE: "_",
- } as const;
+const ProjectVersionFormatType = {
+  DOT: ".",
+  DASH: "-",
+  UNDERSCORE: "_",
+} as const;
 
 /**
  * Options for the project version format.


### PR DESCRIPTION
~~Wait until #834 is merged.~~

Add a new package [`cargo_llvm_cov`](https://github.com/taiki-e/cargo-llvm-cov): a Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage)

```bash
Build finished, completed (no new jobs) in 2.15s
Result: b04823e9d3dcacfad4916f190b48ac85679f100d2488357c73ba3138244bd21e

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 7.81s
Running brioche-run
{
  "name": "cargo_llvm_cov",
  "version": "0.6.17",
  "repository": "https://github.com/taiki-e/cargo-llvm-cov.git"
}

⏵ Task `Run package live-update` finished successfully
```