### PR TITLE
fix(npm): resolve typo `a npm` -> `an npm`

### DIFF
--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -194,7 +194,7 @@ export function liveUpdate(): NushellRunnable {
 }
 
 /**
- * Options for building and installing a npm package.
+ * Options for building and installing an npm package.
  *
  * @param source - The npm package dependencies to install.
  */

--- a/packages/std/extra/live_update/from_npm_packages.bri
+++ b/packages/std/extra/live_update/from_npm_packages.bri
@@ -33,7 +33,7 @@ interface LiveUpdateFromNpmPackagesOptions {
  * regex match against the latest version. The package name is inferred from the
  * extra options of the project.
  *
- * @remarks The version schema of a npm package should follow the SemVer
+ * @remarks The version schema of an npm package should follow the SemVer
  * specification.
  *
  * @param options - Options for the live update from npm packages.


### PR DESCRIPTION
Just fix a small typo I introduced