### PR TITLE
feat(cargo_sort): add package

### DIFF
--- a/packages/cargo_sort/brioche.lock
+++ b/packages/cargo_sort/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/DevinR528/cargo-sort.git": {
+      "v2.0.1": "f066ae80e5e6f5c1d8f0e2b8099461dcb97d9656"
+    }
+  }
+}

--- a/packages/cargo_sort/project.bri
+++ b/packages/cargo_sort/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_sort",
+  version: "2.0.1",
+  repository: "https://github.com/DevinR528/cargo-sort.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cargoSort(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-sort",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo sort --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoSort)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-sort ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_sort`](https://github.com/DevinR528/cargo-sort): a tool to check that your Cargo.toml dependencies are sorted alphabetically.

```bash
Build finished, completed (no new jobs) in 1.95s
Result: 6a373c1ab5d5054a7c123d1c0854d53707cf83f4a084d2d00b91dbf571118d87

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 6.02s
Running brioche-run
{
  "name": "cargo_sort",
  "version": "2.0.1",
  "repository": "https://github.com/DevinR528/cargo-sort.git"
}

⏵ Task `Run package live-update` finished successfully
```