### PR TITLE
feat(wasm_language_tools): add package

### DIFF
--- a/packages/wasm_language_tools/brioche.lock
+++ b/packages/wasm_language_tools/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/g-plane/wasm-language-tools.git": {
+      "v0.5.1": "ee284e796a1f88858fcaf666bb17ff90c8f83bae"
+    }
+  }
+}

--- a/packages/wasm_language_tools/project.bri
+++ b/packages/wasm_language_tools/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "wasm_language_tools",
+  version: "0.5.1",
+  repository: "https://github.com/g-plane/wasm-language-tools.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function wasmLanguageTools(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "crates/server",
+    runnable: "bin/wat_server",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wat_server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmLanguageTools)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `wat_server v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`wasm_language_tools`](https://github.com/g-plane/wasm-language-tools): a Language server and other tools for WebAssembly.

```bash
Build finished, completed (no new jobs) in 1.80s
Result: de18c8398836444f0adeb86526a3a7dc30df106d975e6ddecfaf12ba37c29675

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 1 job in 7.37s
Running brioche-run
{
  "name": "wasm_language_tools",
  "version": "0.5.1",
  "repository": "https://github.com/g-plane/wasm-language-tools.git"
}

⏵ Task `Run package live-update` finished successfully
```