### PR TITLE
feat(wasm_pack): add package

### DIFF
--- a/packages/wasm_pack/brioche.lock
+++ b/packages/wasm_pack/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rustwasm/wasm-pack.git": {
+      "v0.13.1": "24bdca457abad34e444912e6165eb71422a51046"
+    }
+  }
+}

--- a/packages/wasm_pack/project.bri
+++ b/packages/wasm_pack/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "wasm_pack",
+  version: "0.13.1",
+  repository: "https://github.com/rustwasm/wasm-pack.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function wasmPack(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/wasm-pack",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wasm-pack --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmPack)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `wasm-pack ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`wasm_pack`](https://github.com/rustwasm/wasm-pack): a tool seeks to be a one-stop shop for building and working with rust- generated WebAssembly that you would like to interop with JavaScript, in the browser or with Node.js.

```bash
Build finished, completed (no new jobs) in 2.43s
Result: 475b5725abd013f21512efda0727a9c6305d92e405736fd0796c1a3a58b371f8

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 11.76s
Running brioche-run
{
  "name": "wasmtime",
  "version": "0.13.1",
  "repository": "https://github.com/rustwasm/wasm-pack.git"
}

⏵ Task `Run package live-update` finished successfully
```