### PR TITLE
feat(live-update): add a new std helper to check the latest release of a Rust crate

### DIFF
--- a/packages/std/extra/live_update/from_rust_crates.bri
+++ b/packages/std/extra/live_update/from_rust_crates.bri
@@ -1,0 +1,116 @@
+import * as std from "/core";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import type {} from "nushell";
+
+// HACK: The `import type` line above is a workaround for this issue:
+// https://github.com/brioche-dev/brioche/issues/242
+
+/**
+ * Additional options for the project to update.
+ *
+ * @param crateName - The name of the rust crate to update.
+ */
+interface LiveUpdateFromRustCratesProjectExtraOptions {
+  readonly crateName: string;
+}
+
+/**
+ * Options for the live update from Rust crates.
+ *
+ * @param project - The project export that should be updated. Must include a
+ *   `extra.crateName` property containing the name of the Rust crate.
+ */
+interface LiveUpdateFromRustCratesOptions {
+  project: {
+    version: string;
+    readonly extra: LiveUpdateFromRustCratesProjectExtraOptions;
+  };
+}
+
+/**
+ * Return a runnable recipe to live-update a project based on the latest release
+ * version from the crates.io registry. The project's version will be set based on a
+ * regex match against the latest version. The crate name is inferred from the
+ * extra options of the project.
+ *
+ * @remarks The version schema of a Rust crate should follow the SemVer
+ * specification.
+ *
+ * @param options - Options for the live update from Rust crates.
+ *
+ * @returns A runnable recipe to live-update the project
+ *
+ * @example
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   extra: {
+ *     crateName: "brioche",
+ *   },
+ * };
+ *
+ * export function liveUpdate(): std.Recipe<std.Directory> {
+ *   return std.liveUpdateFromRustCrates({ project });
+ * }
+ * ```
+ */
+export function liveUpdateFromRustCrates(
+  options: LiveUpdateFromRustCratesOptions,
+): std.Recipe<std.Directory> {
+  const { crateName } = parseRustCrate(options.project.extra);
+
+  return std.recipe(async () => {
+    const { nushellRunnable } = await import("nushell");
+
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_rust_crates.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      crateName,
+      matchVersion: DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH.source,
+    });
+  });
+}
+
+/**
+ * Interface representing the parsed Rust crate information.
+ */
+interface RustCrateInfo {
+  readonly crateName: string;
+}
+
+function tryParseRustCrate(
+  extraOptions: LiveUpdateFromRustCratesProjectExtraOptions,
+): RustCrateInfo | null {
+  const match = extraOptions.crateName.match(/^(?<crateName>[\w\.@/-]+)$/);
+
+  const { crateName } = match?.groups ?? {};
+  if (crateName == null) {
+    return null;
+  }
+
+  return { crateName };
+}
+
+/**
+ * Parse the Rust crate information to extract the crate name.
+ *
+ * @param extraOptions - The extra options containing the crate name.
+ *
+ * @returns An object containing the crate name.
+ *
+ * @throws If the crate name cannot be parsed.
+ */
+function parseRustCrate(
+  extraOptions: LiveUpdateFromRustCratesProjectExtraOptions,
+): RustCrateInfo {
+  const info = tryParseRustCrate(extraOptions);
+  if (info == null) {
+    throw new Error(
+      `Could not parse Rust crate from ${JSON.stringify(extraOptions)}`,
+    );
+  }
+
+  return info;
+}

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -1,6 +1,7 @@
 export * from "./from_github_releases.bri";
 export * from "./from_gitlab_releases.bri";
 export * from "./from_npm_packages.bri";
+export * from "./from_rust_crates.bri";
 
 // The default regex used for matching versions. Strips an optional "v" prefix,
 // then matches the rest if it looks like a version number (either semver or

--- a/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
@@ -1,0 +1,28 @@
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the latest release information from crates.io registry
+let releaseInfo = http get $'https://crates.io/api/v1/crates/($env.crateName)'
+
+# Extract the version
+let version = $releaseInfo
+  | get crate.max_version
+
+let parsedVersion = $version
+  | parse --regex $env.matchVersion
+if ($parsedVersion | length) == 0 {
+  error make { msg: $'Latest release ($version) did not match regex ($env.matchVersion)' }
+}
+
+let version = $parsedVersion.0.version?
+if $version == null {
+  error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
+}
+
+$project = $project
+  | update version $version
+
+# Return back the project metadata encoded as JSON
+$project
+  | to json


### PR DESCRIPTION
I worked on the idea proposed in [this PR](https://github.com/brioche-dev/brioche-packages/pull/836#issuecomment-3070741297). This PR adds a new std helper to check the latest Rust crate version: `std. liveUpdateFromRustCrates()` based on a new extra property: `project.extra.crateName` (similar to what we have today with NPM packages => `project.extra.packageName`).

We could now download and check version release from the same source of truth for the Rust crates. If we merge this PR, I will then update all the Rust crates packaged on Brioche that were published through crates.io initially to switch to the registry instead of using the forge repository.