### PR TITLE
feat(iosevka): 📦️ add font package

### DIFF
--- a/packages/font_iosevka/brioche.lock
+++ b/packages/font_iosevka/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/be5invis/Iosevka/releases/download/v33.2.7/PkgTTC-Iosevka-33.2.7.zip": {
+      "type": "sha256",
+      "value": "df022efe10206934a56d8b84b278e9e802a3af5f93aaccebc76630ce8f3cfc7c"
+    }
+  }
+}

--- a/packages/font_iosevka/project.bri
+++ b/packages/font_iosevka/project.bri
@@ -1,0 +1,23 @@
+import * as std from "std";
+
+export const project = {
+  name: "font_iosevka",
+  repository: "https://github.com/be5invis/Iosevka",
+  version: "33.2.7",
+};
+
+export const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/PkgTTC-Iosevka-${project.version}.zip`,
+).unarchive("zip");
+
+export default function fontIosevka(): std.Recipe<std.Directory> {
+  return std.directory({
+    share: std.directory({
+      fonts: std.glob(source, ["**/*.ttc"]),
+    }),
+  });
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
howdy! thanks for sharing this project! <3

i've had an attempt at putting together a font package, for https://typeof.net/Iosevka/

`brioche install iosevka` here will install the font files in ~/.local/share/brioche/installed/share/fonts

after `brioche install ...` i then made a link so that ~/.local/share/fonts/brioche is symlinked to ~/.local/share/brioche/installed/share/fonts , and then ran `fc-cache -fv`

that isn't so different to having to add ~/.local/share/brioche/installed/bin to PATH, but it's not great either

i'm just not sure if that UX can be improved (and surely if users get this far they can figure out either fontconfig's settings or how to create symlinks :)

anyhow, let me know what you think!