### PR TITLE
Add trunk

### DIFF
--- a/packages/trunk/brioche.lock
+++ b/packages/trunk/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/trunk/0.21.14/download": {
+      "type": "sha256",
+      "value": "4f7fe1b23957a580be9a7a8b305c331b2977989f33695128d663380d09eaea37"
+    }
+  }
+}

--- a/packages/trunk/project.bri
+++ b/packages/trunk/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "trunk",
+  version: "0.21.14",
+  extra: {
+    crateName: "trunk",
+  }
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function trunk(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/trunk",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    trunk --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(trunk)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `trunk ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Waiting first on https://github.com/brioche-dev/brioche-packages/pull/842

Add a new package [`trunk`](https://github.com/trunk-rs/trunk): build, bundle & ship your Rust WASM application to the web.

```bash
Build finished, completed (no new jobs) in 6.89s
Running brioche-run
{
  "name": "trunk",
  "version": "0.21.14",
  "extra": {
    "crateName": "trunk"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.45s
Result: 9d2aac17c8840c39067536c3e40e0b6d372b3a34bfe0979ceb1e8c49b52c4fb1

⏵ Task `Run package test` finished successfully
```