### PR TITLE
feat(cargo_minimal_versions): add package

### DIFF
--- a/packages/cargo_minimal_versions/brioche.lock
+++ b/packages/cargo_minimal_versions/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-minimal-versions/0.1.31/download": {
+      "type": "sha256",
+      "value": "fbb724d8abee2b31d1acf553448aca5915cb29987d5e177cb0cf404747d0d01d"
+    }
+  }
+}

--- a/packages/cargo_minimal_versions/project.bri
+++ b/packages/cargo_minimal_versions/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_minimal_versions",
+  version: "0.1.31",
+  extra: {
+    crateName: "cargo-minimal-versions",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoMinimalVersions(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-minimal-versions",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo minimal-versions --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoMinimalVersions)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-minimal-versions ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_minimal_versions`](https://github.com/taiki-e/cargo-minimal-versions): a Cargo subcommand for proper use of -Z minimal-versions and -Z direct-minimal-versions.

```bash
Build finished, completed (no new jobs) in 2.46s
Result: 6b15de0079e0d7aebc3566578054e658e54f49d55f4196ce92ae18f4beec0180

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 7.84s
Running brioche-run
{
  "name": "cargo_minimal_versions",
  "version": "0.1.31",
  "extra": {
    "crateName": "cargo-minimal-versions"
  }
}

⏵ Task `Run package live-update` finished successfully
```