### PR TITLE
feat(cargo_no_dev_deps): add package

### DIFF
--- a/packages/cargo_no_dev_deps/brioche.lock
+++ b/packages/cargo_no_dev_deps/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-no-dev-deps/0.2.16/download": {
+      "type": "sha256",
+      "value": "52fc3c2952f6f426092e90e88c707c5ed881e1fde03d8c64587f5e17cb51be82"
+    }
+  }
+}

--- a/packages/cargo_no_dev_deps/project.bri
+++ b/packages/cargo_no_dev_deps/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_no_dev_deps",
+  version: "0.2.16",
+  extra: {
+    crateName: "cargo-no-dev-deps",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoNoDevDeps(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-no-dev-deps",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo no-dev-deps --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoNoDevDeps)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-no-dev-deps ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_no_dev_deps`](https://github.com/taiki-e/cargo-no-dev-deps): a Cargo subcommand for running cargo without dev-dependencies.

```bash
Build finished, completed (no new jobs) in 8.54s
Running brioche-run
{
  "name": "cargo_no_dev_deps",
  "version": "0.2.16",
  "extra": {
    "crateName": "cargo-no-dev-deps"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.43s
Result: c7c65d553e2c6893fa70669dc1357aab92a47f6a8eed4f388875dc22280a3230

⏵ Task `Run package test` finished successfully
```
 