### PR TITLE
feat(wasm_server_runner): add package

### DIFF
--- a/packages/wasm_server_runner/brioche.lock
+++ b/packages/wasm_server_runner/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/wasm-server-runner/1.0.0/download": {
+      "type": "sha256",
+      "value": "c6514267eaf0de2e788db59877ef277f5e6680db91ef3d4b76c1b92ca5639e25"
+    }
+  }
+}

--- a/packages/wasm_server_runner/project.bri
+++ b/packages/wasm_server_runner/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "wasm_server_runner",
+  version: "1.0.0",
+  extra: {
+    crateName: "wasm-server-runner",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function wasmServerRunner(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/wasm-server-runner",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no command line interface, so just checking that the binary exists
+  // and returns the expected error message
+  const script = std.runBash`
+    (wasm-server-runner --help 2>&1 || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmServerRunner)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = `Error: expected to be run with a wasm target`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`wasm_server_runner`](https://github.com/jakobhellermann/wasm-server-runner): allows you to run programs in the browser using web assembly using a simple cargo run

```bash
Build finished, completed (no new jobs) in 9.45s
Running brioche-run
{
  "name": "wasm_server_runner",
  "version": "1.0.0",
  "extra": {
    "crateName": "wasm-server-runner"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 3.38s
Result: 5eca6eaef0d04ef28425fc8a958bcdd31a745feeb041ab5c482823fd660301bf

⏵ Task `Run package test` finished successfully
```