### PR TITLE
chore(live-update): better default for matchTag in std.liveUpdateFromGithubReleases()

### DIFF
--- a/packages/binaryen/project.bri
+++ b/packages/binaryen/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^version_(?<version>.*)$/,
+    matchTag: /^version_(?<version>.+)$/,
   });
 }

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -42,6 +42,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^@biomejs\/biome@(?<version>.*)$/,
+    matchTag: /^@biomejs\/biome@(?<version>.+)$/,
   });
 }

--- a/packages/cargo_audit/project.bri
+++ b/packages/cargo_audit/project.bri
@@ -39,6 +39,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^cargo-audit\/v(?<version>.*)$/,
+    matchTag: /^cargo-audit\/v(?<version>.+)$/,
   });
 }

--- a/packages/cargo_nextest/project.bri
+++ b/packages/cargo_nextest/project.bri
@@ -44,6 +44,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^cargo-nextest-(?<version>.*)$/,
+    matchTag: /^cargo-nextest-(?<version>.+)$/,
   });
 }

--- a/packages/codex/project.bri
+++ b/packages/codex/project.bri
@@ -47,6 +47,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^rust-v(?<version>.*)$/,
+    matchTag: /^rust-v(?<version>.+)$/,
   });
 }

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -96,7 +96,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^curl-(?<version>.*)$/,
+    matchTag: /^curl-(?<version>.+)$/,
     normalizeVersion: true,
   });
 }

--- a/packages/cyrus_sasl/project.bri
+++ b/packages/cyrus_sasl/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^cyrus-sasl-(?<version>.*)$/,
+    matchTag: /^cyrus-sasl-(?<version>.+)$/,
   });
 }

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -59,7 +59,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^R_(?<version>.*)$/,
+    matchTag: /^R_(?<version>.+)$/,
     normalizeVersion: true,
   });
 }

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -93,7 +93,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^release-(?<version>.*)$/,
+    matchTag: /^release-(?<version>.+)$/,
     normalizeVersion: true,
   });
 }

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -45,6 +45,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^jq-(?<version>.*)$/,
+    matchTag: /^jq-(?<version>.+)$/,
   });
 }

--- a/packages/libevent/project.bri
+++ b/packages/libevent/project.bri
@@ -50,6 +50,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^release-(?<version>.*)-stable$/,
+    matchTag: /^release-(?<version>.+)-stable$/,
   });
 }

--- a/packages/llvm/project.bri
+++ b/packages/llvm/project.bri
@@ -89,6 +89,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^llvmorg-(?<version>.*)$/,
+    matchTag: /^llvmorg-(?<version>.+)$/,
   });
 }

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^release-(?<version>.*)$/,
+    matchTag: /^release-(?<version>.+)$/,
   });
 }

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -60,6 +60,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^openssl-(?<version>.*)$/,
+    matchTag: /^openssl-(?<version>.+)$/,
   });
 }

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -64,6 +64,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^pcre2-(?<version>.*)$/,
+    matchTag: /^pcre2-(?<version>.+)$/,
   });
 }

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -55,6 +55,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^php-(?<version>.*)$/,
+    matchTag: /^php-(?<version>.+)$/,
   });
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -62,7 +62,7 @@ interface LiveUpdateFromGithubReleasesOptions {
  * export function liveUpdate(): std.Recipe<std.Directory> {
  *   return std.liveUpdateFromGithubReleases({
  *     project,
- *     matchTag: /^v(?<version>.*)$/, // Strip "v" prefix from tags
+ *     matchTag: /^v(?<version>.+)$/, // Strip "v" prefix from tags
  *   });
  * }
  * ```

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -60,7 +60,7 @@ interface LiveUpdateFromGitlabReleasesOptions {
  * export function liveUpdate(): std.Recipe<std.Directory> {
  *   return std.liveUpdateFromGitlabReleases({
  *     project,
- *     matchTag: /^v(?<version>.*)$/, // Strip "v" prefix from tags
+ *     matchTag: /^v(?<version>.+)$/, // Strip "v" prefix from tags
  *   });
  * }
  * ```


### PR DESCRIPTION
Switch from regex `/^(?<version>.*)$/` to `/^(?<version>.+)$/`. I made the choice of using `+` since we want "one or more characters" and not "zero or more characters". The current regex could suggest that an empty string is valid for a version. 