### PR TITLE
feat(wasm_tools): add package

### DIFF
--- a/packages/wasm_tools/brioche.lock
+++ b/packages/wasm_tools/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/wasm-tools/1.235.0/download": {
+      "type": "sha256",
+      "value": "1c9185dd58f2f03e5f32a3605c71fc352cc813c1b60955d823b0734492ed7821"
+    }
+  }
+}

--- a/packages/wasm_tools/project.bri
+++ b/packages/wasm_tools/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "wasm_tools",
+  version: "1.235.0",
+  extra: {
+    crateName: "wasm-tools",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function wasmTools(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/wasm-tools",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wasm-tools --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmTools)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `wasm-tools ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`wasm_tools`](https://github.com/bytecodealliance/wasm-tools): a CLI and Rust libraries for low-level manipulation of WebAssembly modules

```bash
Build finished, completed (no new jobs) in 8.29s
Running brioche-run
{
  "name": "wasm_tools",
  "version": "1.235.0",
  "extra": {
    "crateName": "wasm-tools"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.35s
Result: d007e1db5686c76ec66c86c9cc3905f8e3fd41713760bcfce8a806c8edaf413d

⏵ Task `Run package test` finished successfully
```