### PR TITLE
Add `iperf3` package

### DIFF
--- a/packages/iperf3/brioche.lock
+++ b/packages/iperf3/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/esnet/iperf.git": {
+      "3.19": "57396df3c19227741b8cd40c24b105d28672b6f7"
+    }
+  }
+}

--- a/packages/iperf3/project.bri
+++ b/packages/iperf3/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+
+export const project = {
+  name: "iperf3",
+  version: "3.19",
+  repository: "https://github.com/esnet/iperf.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function iperf3(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory();
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    iperf3 --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(iperf3)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `iperf ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+  });
+}


### PR DESCRIPTION
This PR adds a package for [iperf3](https://github.com/esnet/iperf), a TCP, UDP, and SCTP network bandwidth measurement tool 