### PR TITLE
feat(wasm_bindgen_cli): add package

### DIFF
--- a/packages/wasm_bindgen_cli/brioche.lock
+++ b/packages/wasm_bindgen_cli/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/wasm-bindgen-cli/0.2.100/download": {
+      "type": "sha256",
+      "value": "9e7f06f41580c87b6f4f84176d033f09c0838db1523a8d1899064b53cbb92c59"
+    }
+  }
+}

--- a/packages/wasm_bindgen_cli/project.bri
+++ b/packages/wasm_bindgen_cli/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "wasm_bindgen_cli",
+  version: "0.2.100",
+  extra: {
+    crateName: "wasm-bindgen-cli",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function wasmBindgenCli(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/wasm-bindgen",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wasm-bindgen --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wasmBindgenCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `wasm-bindgen ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`wasm_bindgen_cli`](https://github.com/rustwasm/wasm-bindgen): this package facilitates high-level interactions between Wasm modules and JavaScript.

```bash
Build finished, completed (no new jobs) in 9.04s
Running brioche-run
{
  "name": "wasm_bindgen_cli",
  "version": "0.2.100",
  "extra": {
    "crateName": "wasm-bindgen-cli"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.73s
Result: 5d878cf90c3fb16802bccde903f7b9656b75d6117c38d80dc034682b99bec2a3

⏵ Task `Run package test` finished successfully
```