### PR TITLE
feat(actionlint): add package

### DIFF
--- a/packages/actionlint/brioche.lock
+++ b/packages/actionlint/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rhysd/actionlint.git": {
+      "v1.7.7": "03d0035246f3e81f36aed592ffb4bebf33a03106"
+    }
+  }
+}

--- a/packages/actionlint/project.bri
+++ b/packages/actionlint/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "actionlint",
+  version: "1.7.7",
+  repository: "https://github.com/rhysd/actionlint.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function actionlint(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/rhysd/actionlint.version=${project.version}`,
+      ],
+    },
+    path: "./cmd/actionlint",
+    runnable: "bin/actionlint",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    actionlint -version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(actionlint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`actionlint`](https://github.com/rhysd/actionlint): a static checker for GitHub Actions workflow files

```bash
Build finished, completed 1 job in 9.17s
Running brioche-run
{
  "name": "actionlint",
  "version": "1.7.7",
  "repository": "https://github.com/rhysd/actionlint.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.80s
Result: 44f741a604eaa1449254dc8b68254889a241477a07b21efb93dd3e3bff722187

⏵ Task `Run package test` finished successfully
```