### PR TITLE
feat(cargo_binstall): add package

### DIFF
--- a/packages/cargo_binstall/brioche.lock
+++ b/packages/cargo_binstall/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-binstall/1.14.1/download": {
+      "type": "sha256",
+      "value": "65a476971549d1bdf867eaae59785e55c5e2fcba727ea2b0b90df2383697e760"
+    }
+  }
+}

--- a/packages/cargo_binstall/project.bri
+++ b/packages/cargo_binstall/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_binstall",
+  version: "1.14.1",
+  extra: {
+    crateName: "cargo-binstall",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoBinstall(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-binstall",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo binstall -V | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoBinstall)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_binstall`](https://github.com/cargo-bins/cargo-binstall): binary installation for rust projects.

```bash
Build finished, completed (no new jobs) in 2.61s
Result: 43577aaba7452f21306fe9f3c9dc912e2feb1bf9ceba967ee54a5892858230bc

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 8.71s
Running brioche-run
{
  "name": "cargo_binstall",
  "version": "1.14.1",
  "extra": {
    "crateName": "cargo-binstall"
  }
}

⏵ Task `Run package live-update` finished successfully
```