### PR TITLE
feat(wrangler): add package

### DIFF
--- a/packages/wrangler/brioche.lock
+++ b/packages/wrangler/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/wrangler/project.bri
+++ b/packages/wrangler/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "wrangler",
+  version: "4.25.1",
+  extra: {
+    packageName: "wrangler",
+  },
+};
+
+export default function wrangler(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/wrangler"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wrangler --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wrangler)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`wrangler`](https://github.com/cloudflare/workers-sdk): a command line tool for building [Cloudflare Workers](https://workers.cloudflare.com/).

```bash
 0.01s ✓ Process 334318
Build finished, completed 1 job in 9.35s
Running brioche-run
{
  "name": "wrangler",
  "version": "4.25.1",
  "extra": {
    "packageName": "wrangler"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 8.62s
Result: 5408bb4f5946b0c935e76405671aa98cbf7d4c17d7b19c7995d13f3f7e2b128e

⏵ Task `Run package test` finished successfully
```