### PR TITLE
feat(cargo_quickinstall): add package

### DIFF
--- a/packages/cargo_quickinstall/brioche.lock
+++ b/packages/cargo_quickinstall/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-quickinstall/0.3.22/download": {
+      "type": "sha256",
+      "value": "c98c7ea097c4d1f0d264fdccf1995fea577f7de06b56eca99da9532ea545e1c7"
+    }
+  }
+}

--- a/packages/cargo_quickinstall/project.bri
+++ b/packages/cargo_quickinstall/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_quickinstall",
+  version: "0.3.22",
+  extra: {
+    crateName: "cargo-quickinstall",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoQuickinstall(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-quickinstall",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo quickinstall --print-version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoQuickinstall)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `\`cargo quickinstall\` version: ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_quickinstall`](https://github.com/cargo-bins/cargo-quickinstall):  pre-compiled binary packages for `cargo install`

```bash
Build finished, completed (no new jobs) in 9.83s
Running brioche-run
{
  "name": "cargo_quickinstall",
  "version": "0.3.22",
  "extra": {
    "crateName": "cargo-quickinstall"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 3.61s
Result: 8602134e9b171fc8ec955f37c096dc11a2b662e8ed083423437749d4e0c69585

⏵ Task `Run package test` finished successfully
```