### PR TITLE
chore: always using `project.repository` variable when retrieving sources from GitHub

### DIFF
--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -5,10 +5,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "aws_cli",
   version: "2.27.50",
+  repository: "https://github.com/aws/aws-cli",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/aws/aws-cli.git",
+  repository: project.repository,
   ref: project.version,
 }).pipe((source) =>
   // Patch the source to fix unresolvable `packaging` dependencies

--- a/packages/boost/project.bri
+++ b/packages/boost/project.bri
@@ -9,7 +9,7 @@ export const project = {
 };
 
 const source = Brioche.download(
-  `https://github.com/boostorg/boost/releases/download/boost-${project.version}/boost-${project.version}-b2-nodocs.tar.xz`,
+  `${project.repository}/releases/download/boost-${project.version}/boost-${project.version}-b2-nodocs.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -6,10 +6,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "git",
   version: "2.50.1",
+  repository: "https://github.com/git/git",
 };
 
 const source = Brioche.download(
-  `https://github.com/git/git/archive/refs/tags/v${project.version}.tar.gz`,
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")
   .peel();

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -5,10 +5,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "joshuto",
   version: "0.9.9",
+  repository: "https://github.com/kamiyaa/joshuto",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/kamiyaa/joshuto.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -7,10 +7,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "moreutils",
   version: "0.70",
+  repository: "git://git.joeyh.name/moreutils",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "git://git.joeyh.name/moreutils",
+  repository: project.repository,
   ref: project.version,
 });
 

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -4,10 +4,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "nasm",
   version: "2.16.03",
+  repository: "https://github.com/netwide-assembler/nasm",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/netwide-assembler/nasm.git",
+  repository: project.repository,
   ref: `nasm-${project.version}`,
 });
 

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -3,11 +3,11 @@ import * as std from "std";
 export const project = {
   name: "rpcsvc_proto",
   version: "1.4.4",
-  repository: "https://github.com/thkukuk/rpcsvc-proto.git",
+  repository: "https://github.com/thkukuk/rpcsvc-proto",
 };
 
 const source = Brioche.download(
-  `https://github.com/thkukuk/rpcsvc-proto/releases/download/v${project.version}/rpcsvc-proto-${project.version}.tar.xz`,
+  `${project.repository}/releases/download/v${project.version}/rpcsvc-proto-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
   .peel();

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -5,10 +5,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "s2argv_execs",
   version: "1.4",
+  repository: "https://github.com/virtualsquare/s2argv-execs",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/virtualsquare/s2argv-execs.git",
+  repository: project.repository,
   ref: project.version,
 });
 

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -5,10 +5,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "tokei",
   version: "12.1.2",
+  repository: "https://github.com/XAMPPRocky/tokei",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/XAMPPRocky/tokei.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -4,10 +4,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "uthash",
   version: "2.3.0",
+  repository: "https://github.com/troydhanson/uthash",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/troydhanson/uthash.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -6,10 +6,11 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "vdeplug4",
   version: "4.0.1",
+  repository: "https://github.com/rd235/vdeplug4",
 };
 
 const source = Brioche.gitCheckout({
-  repository: "https://github.com/rd235/vdeplug4.git",
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 


### PR DESCRIPTION
Just to keep consistency in our packages