### PR TITLE
feat(fribidi): add package

### DIFF
--- a/packages/fribidi/brioche.lock
+++ b/packages/fribidi/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/fribidi/fribidi/releases/download/v1.0.16/fribidi-1.0.16.tar.xz": {
+      "type": "sha256",
+      "value": "1b1cde5b235d40479e91be2f0e88a309e3214c8ab470ec8a2744d82a5a9ea05c"
+    }
+  }
+}

--- a/packages/fribidi/project.bri
+++ b/packages/fribidi/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+
+export const project = {
+  name: "fribidi",
+  version: "1.0.16",
+  repository: "https://github.com/fribidi/fribidi",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/fribidi-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function fribidi(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-static
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/fribidi"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion fribidi | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, fribidi)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`fribidi`](https://github.com/fribidi/fribidi): a Free Implementation of the Unicode Bidirectional Algorithm

```bash
Build finished, completed (no new jobs) in 9.81s
Running brioche-run
{
  "name": "fribidi",
  "version": "1.0.16",
  "repository": "https://github.com/fribidi/fribidi"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.89s
Result: 1984c98f02e559d1896e575debd824abddc1cdfb9f1458381d05b62367e2f0a1

⏵ Task `Run package test` finished successfully
```