### PR TITLE
fix: update outdated lockfile due to git references update

### DIFF
--- a/packages/aws_cli/brioche.lock
+++ b/packages/aws_cli/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/aws/aws-cli.git": {
+    "https://github.com/aws/aws-cli": {
       "2.27.59": "c368c2e9bc7f06b01e058c4a68882d74cec41294"
     }
   }

--- a/packages/joshuto/brioche.lock
+++ b/packages/joshuto/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/kamiyaa/joshuto.git": {
+    "https://github.com/kamiyaa/joshuto": {
       "v0.9.9": "b8f870fc328fc5c3f4e010683901a5082a6b0790"
     }
   }

--- a/packages/nasm/brioche.lock
+++ b/packages/nasm/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/netwide-assembler/nasm.git": {
+    "https://github.com/netwide-assembler/nasm": {
       "nasm-2.16.03": "cd37b81b320ead83ca5a6bbce5da0a6456663bc6"
     }
   }

--- a/packages/s2argv_execs/brioche.lock
+++ b/packages/s2argv_execs/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/virtualsquare/s2argv-execs.git": {
+    "https://github.com/virtualsquare/s2argv-execs": {
       "1.4": "d357705f8678f5299d90fc33245b8783cfd0d29c"
     }
   }

--- a/packages/tokei/brioche.lock
+++ b/packages/tokei/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/XAMPPRocky/tokei.git": {
+    "https://github.com/XAMPPRocky/tokei": {
       "v12.1.2": "7e0b30ff4c1fe78fe2cc615d1f0f52c7ce6cb761"
     }
   }

--- a/packages/uthash/brioche.lock
+++ b/packages/uthash/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/troydhanson/uthash.git": {
+    "https://github.com/troydhanson/uthash": {
       "v2.3.0": "e493aa90a2833b4655927598f169c31cfcdf7861"
     }
   }

--- a/packages/vdeplug4/brioche.lock
+++ b/packages/vdeplug4/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/rd235/vdeplug4.git": {
+    "https://github.com/rd235/vdeplug4": {
       "v4.0.1": "d482de1719ba198d020e756a9c81fb436f601267"
     }
   }


### PR DESCRIPTION
Follow up of https://github.com/brioche-dev/brioche-packages/pull/918. I missed the update of `brioche.lock` files.