### PR TITLE
Add GitHub tags live update

### DIFF
--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 import python from "python";
 
 export const project = {
@@ -102,22 +101,11 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/asciinema/asciinema/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
+  // GitHub releases live method is able to retrieve a list of releases
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^v(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
+  });
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import python from "python";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "aws_cli",
@@ -124,24 +123,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/aws/aws-cli/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }
 
 // Copied from `python.fixShebangs`

--- a/packages/boost/project.bri
+++ b/packages/boost/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 import cmake from "cmake";
 
 export const project = {
@@ -66,22 +65,11 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/boostorg/boost/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/boost-(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
+  // GitHub releases live method is able to retrieve a list of releases
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^boost-(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
+  });
 }

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import rust, { cargoBuild } from "rust";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "cargo_bloat",
@@ -36,22 +35,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/RazrFalcon/cargo-bloat/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import openssl from "openssl";
 import curl from "curl";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "git",
@@ -49,24 +48,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/git/git/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }
 
 /**

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -1,9 +1,9 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "go",
   version: "1.24.5",
+  repository: "https://github.com/golang/go",
 };
 
 function goPrebuilt(): std.Recipe<std.Directory> {
@@ -76,24 +76,11 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/golang/go/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/go(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^go(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
+  });
 }
 
 type ModOptions = "readonly" | "vendor" | "mod";

--- a/packages/joshuto/project.bri
+++ b/packages/joshuto/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "joshuto",
@@ -39,23 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    # Version can either be prefixed with 'v' or not
-    let version = http get https://api.github.com/repos/kamiyaa/joshuto/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "nasm",
@@ -46,22 +45,9 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/netwide-assembler/nasm/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/nasm-(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^nasm-(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
+  });
 }

--- a/packages/pyrefly/project.bri
+++ b/packages/pyrefly/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "pyrefly",
@@ -44,22 +43,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/facebook/pyrefly/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -2,11 +2,11 @@ import * as std from "std";
 import cargoChef from "cargo_chef";
 import * as TOML from "smol_toml";
 import * as t from "typer";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "rust",
   version: "1.88.0",
+  repository: "https://github.com/rust-lang/rust",
 };
 
 const ManifestPkgTarget = t.discriminatedUnion("available", [
@@ -127,24 +127,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/rust-lang/rust/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }
 
 /**

--- a/packages/s2argv_execs/project.bri
+++ b/packages/s2argv_execs/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "s2argv_execs",
@@ -72,22 +71,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/virtualsquare/s2argv-execs/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)(\\.(?P<patch>[\\d]+))?)$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/sqlx_cli/project.bri
+++ b/packages/sqlx_cli/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
 import openssl from "openssl";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "sqlx_cli",
@@ -39,22 +38,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/launchbadge/sqlx/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+)(?P<label>-.+)?)'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -1,4 +1,5 @@
 import * as std from "/core";
+import { parseGithubRepo } from "./github_global.bri";
 import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
 import type {} from "nushell";
 
@@ -87,50 +88,4 @@ export function liveUpdateFromGithubReleases(
       normalizeVersion: normalizeVersion.toString(),
     });
   });
-}
-
-/**
- * Interface representing the parsed GitHub repository information.
- */
-interface GithubRepoInfo {
-  readonly repoOwner: string;
-  readonly repoName: string;
-}
-
-function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
-  const match = repo.match(
-    /^(?:https?:\/\/)?(www\.)?(?:github\.com\/)?(?<repoOwner>[\w\.-]+)\/(?<repoName>[\w\.-]+)\/?$/,
-  );
-
-  const { repoOwner, repoName: matchedRepoName } = match?.groups ?? {};
-  if (repoOwner == null || matchedRepoName == null) {
-    return null;
-  }
-
-  let repoName = matchedRepoName;
-  if (repoName.endsWith(".git")) {
-    repoName = repoName.slice(0, -4);
-  }
-
-  return { repoOwner, repoName };
-}
-
-/**
- * Parse a GitHub repository URL to extract the repository owner and name.
- *
- * @param repo - The GitHub repository URL to parse.
- *
- * @returns An object containing the repository owner and name.
- *
- * @throws If the repository URL cannot be parsed.
- */
-function parseGithubRepo(repo: string): GithubRepoInfo {
-  const info = tryParseGithubRepo(repo);
-  if (info == null) {
-    throw new Error(
-      `Could not parse repo name and owner from ${JSON.stringify(repo)}`,
-    );
-  }
-
-  return info;
 }

--- a/packages/std/extra/live_update/from_github_tags.bri
+++ b/packages/std/extra/live_update/from_github_tags.bri
@@ -1,0 +1,89 @@
+import * as std from "/core";
+import { parseGithubRepo } from "./github_global.bri";
+import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import type {} from "nushell";
+
+// HACK: The `import type` line above is a workaround for this issue:
+// https://github.com/brioche-dev/brioche/issues/242
+
+/**
+ * Additional options for the project to update.
+ *
+ * @param versionDash - The version of the project (converted in dash format).
+ * @param versionUnderscore - The version of the project (converted in underscore format).
+ */
+interface LiveUpdateFromGithubTagsProjectExtraOptions {
+  versionDash?: string;
+  versionUnderscore?: string;
+}
+
+/**
+ * Options for the live update from GitHub tags.
+ *
+ * @param project - The project export that should be updated. Must include a
+ *   `repository` property containing a GitHub repository URL.
+ * @param matchTag - A regex value (`/.../`) to extract the version number from
+ *   a tag name. The regex must include a group named "version". If not
+ *   provided, an optional "v" prefix will be stripped and the rest of the
+ *   tag will be checked if it's a semver or semver-like version number.
+ * @param normalizeVersion - Whether to normalize the version number to
+ *   a semver-like version number. When enabled, the dashes and underscores
+ *   will be replaced with dots.
+ */
+interface LiveUpdateFromGithubTagsOptions {
+  project: {
+    version: string;
+    readonly repository: string;
+    extra?: LiveUpdateFromGithubTagsProjectExtraOptions;
+  };
+  readonly matchTag?: RegExp;
+  readonly normalizeVersion?: boolean;
+}
+
+/**
+ * Return a runnable recipe to live-update a project based on the latest tag
+ * from a GitHub repository. The project's version will be set based on a regex
+ * match against the latest tag name. The repository is inferred from the
+ * `repository` field of the project.
+ *
+ * @param options - Options for the live update from GitHub tags.
+ *
+ * @returns A runnable recipe to live-update the project
+ *
+ * @example
+ * ```typescript
+ * export const project = {
+ *   name: "brioche",
+ *   version: "0.1.0",
+ *   repository: "https://github.com/brioche-dev/brioche.git",
+ * };
+ *
+ * export function liveUpdate(): std.Recipe<std.Directory> {
+ *   return std.liveUpdateFromGithubTags({
+ *     project,
+ *     matchTag: /^v(?<version>.+)$/, // Strip "v" prefix from tags
+ *   });
+ * }
+ * ```
+ */
+export function liveUpdateFromGithubTags(
+  options: LiveUpdateFromGithubTagsOptions,
+): std.Recipe<std.Directory> {
+  const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
+  const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
+  const normalizeVersion = options.normalizeVersion ?? false;
+
+  return std.recipe(async () => {
+    const { nushellRunnable } = await import("nushell");
+
+    return nushellRunnable(
+      Brioche.includeFile("./scripts/live_update_from_github_tags.nu"),
+    ).env({
+      project: JSON.stringify(options.project),
+      repoOwner,
+      repoName,
+      matchTag: matchTag.source,
+      normalizeVersion: normalizeVersion.toString(),
+    });
+  });
+}

--- a/packages/std/extra/live_update/github_global.bri
+++ b/packages/std/extra/live_update/github_global.bri
@@ -1,0 +1,45 @@
+/**
+ * Interface representing the parsed GitHub repository information.
+ */
+interface GithubRepoInfo {
+  readonly repoOwner: string;
+  readonly repoName: string;
+}
+
+function tryParseGithubRepo(repo: string): GithubRepoInfo | null {
+  const match = repo.match(
+    /^(?:https?:\/\/)?(www\.)?(?:github\.com\/)?(?<repoOwner>[\w\.-]+)\/(?<repoName>[\w\.-]+)\/?$/,
+  );
+
+  const { repoOwner, repoName: matchedRepoName } = match?.groups ?? {};
+  if (repoOwner == null || matchedRepoName == null) {
+    return null;
+  }
+
+  let repoName = matchedRepoName;
+  if (repoName.endsWith(".git")) {
+    repoName = repoName.slice(0, -4);
+  }
+
+  return { repoOwner, repoName };
+}
+
+/**
+ * Parse a GitHub repository URL to extract the repository owner and name.
+ *
+ * @param repo - The GitHub repository URL to parse.
+ *
+ * @returns An object containing the repository owner and name.
+ *
+ * @throws If the repository URL cannot be parsed.
+ */
+export function parseGithubRepo(repo: string): GithubRepoInfo {
+  const info = tryParseGithubRepo(repo);
+  if (info == null) {
+    throw new Error(
+      `Could not parse repo name and owner from ${JSON.stringify(repo)}`,
+    );
+  }
+
+  return info;
+}

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -2,6 +2,7 @@ export * from "./from_github_releases.bri";
 export * from "./from_gitlab_releases.bri";
 export * from "./from_npm_packages.bri";
 export * from "./from_rust_crates.bri";
+export * from "./github_global.bri";
 
 // The default regex used for matching versions. Strips an optional "v" prefix,
 // then matches the rest if it looks like a version number (either semver or

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -1,4 +1,5 @@
 export * from "./from_github_releases.bri";
+export * from "./from_github_tags.bri";
 export * from "./from_gitlab_releases.bri";
 export * from "./from_npm_packages.bri";
 export * from "./from_rust_crates.bri";

--- a/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
@@ -1,0 +1,76 @@
+# Get project metadata
+mut project = $env.project
+  | from json
+
+# Retrieve the list of tags from GitHub
+# Include GitHub Token if present (for increased rate limits)
+mut gh_headers = []
+if ($env.GITHUB_TOKEN? | default "") != "" {
+  $gh_headers ++= [Authorization $'Bearer ($env.GITHUB_TOKEN)']
+}
+
+let httpResponse = http get --full --allow-errors --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/git/matching-refs/tags'
+match $httpResponse.status {
+  200 => {
+    # Success
+  }
+  401 => {
+    error make { msg: $'Unauthorized access to GitHub API' }
+  }
+  403 | 429 => {
+    error make { msg: $'GitHub API rate limit exceeded' }
+  }
+  _ => {
+    error make { msg: $'Failed to call GitHub API: ($httpResponse.status)' }
+  }
+}
+let tags = $httpResponse.body
+
+# Exract the tag
+let parsedTags = $tags
+  | get ref
+  | each {|ref|
+    $ref
+      # 'refs/tags/' is the prefix for tags in GitHub API responses
+      # and is followed by the tag name, remove it
+      | str substring 10..-1
+      | parse --regex $env.matchTag
+      | get -o 0
+  }
+  | sort-by --natural version
+
+if ($parsedTags | length) == 0 {
+  error make { msg: $'No tag did match regex ($env.matchTag)' }
+}
+
+mut version = $parsedTags
+  | last
+  | get version
+
+if $env.normalizeVersion == "true" {
+  $version = $version
+    | str replace --all --regex "(-|_)" "."
+}
+
+$project = $project
+  | update version $version
+
+if ($project | get extra?.versionDash?) != null {
+  let $versionDash = $version
+    | str replace --all "." "-"
+
+  $project = $project
+    | update extra.versionDash $versionDash
+}
+
+if ($project | get extra?.versionUnderscore?) != null {
+  let $versionUnderscore = $version
+    | str replace --all "." "_"
+
+  $project = $project
+    | update extra.versionUnderscore $versionUnderscore
+}
+
+# Return back the project metadata encoded as JSON
+$project
+  | to json

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -1,6 +1,5 @@
 import * as std from "std";
 import { cargoBuild } from "rust";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "tokei",
@@ -39,23 +38,11 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    # Version can be suffixed with '-alpha.X'
-    let version = http get https://api.github.com/repos/XAMPPRocky/tokei/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
+  // GitHub releases live method is able to retrieve a list of releases
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^v(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
+  });
 }

--- a/packages/uthash/project.bri
+++ b/packages/uthash/project.bri
@@ -1,5 +1,4 @@
 import * as std from "std";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "uthash",
@@ -63,22 +62,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/troydhanson/uthash/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/vdeplug4/project.bri
+++ b/packages/vdeplug4/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
 import s2argvExecs from "s2argv_execs";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "vdeplug4",
@@ -73,22 +72,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/rd235/vdeplug4/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/zziplib/project.bri
+++ b/packages/zziplib/project.bri
@@ -1,7 +1,6 @@
 import * as std from "std";
 import { cmakeBuild } from "cmake";
 import python from "python";
-import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "zziplib",
@@ -53,22 +52,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): NushellRunnable {
-  return nushellRunnable`
-    let version = http get https://api.github.com/repos/gdraheim/zziplib/git/matching-refs/tags
-      | get ref
-      | each {|ref|
-        $ref
-        | parse --regex '^refs/tags/v?(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
-        | get -o 0
-      }
-      | sort-by -n major minor patch
-      | last
-      | get tag
-
-    $env.project
-      | from json
-      | update version $version
-      | to json
-  `.env({ project: JSON.stringify(project) });
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }


### PR DESCRIPTION
As discussed earlier, here is the new `std.liveUpdateFromGithubTags()` helper for live update check through GitHub tags. The interface is pretty similar to `std.liveUpdateFromGithubReleases()`. I tweaked the previous Nushell script to make it easier to filter per tag:

```nu
# Previous
http get https://api.github.com/repos/asciinema/asciinema/git/matching-refs/tags
      | get ref
      | each {|ref|
        $ref
        | parse --regex '^refs/tags/v(?P<tag>(?P<major>[\\d]+)\\.(?P<minor>[\\d]+)\\.(?P<patch>[\\d]+))$'
        | get -o 0
      }
      | sort-by -n major minor patch

# New
http get https://api.github.com/repos/asciinema/asciinema/git/matching-refs/tags
  | get ref
  | each {|ref|
    $ref
      # 'refs/tags/' is the prefix for tags in GitHub API responses
      # and is followed by the tag name, remove it
      | str substring 10..-1
      | parse --regex $env.matchTag
      | get -o 0
  }
  | sort-by --natural version
```

One package wasn't updated, that's `nodejs` since we handle multiple versions in this one. But I'll update the logic to make it compatible with the new helper in an upcoming PR. It'll then let us enable checking for multiple versions in other packages:

- `go_mockery`
- `python` 