### PR TITLE
feat(vacuum): add package

### DIFF
--- a/packages/vacuum/brioche.lock
+++ b/packages/vacuum/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/daveshanley/vacuum.git": {
+      "v0.17.6": "27e04d9f8e29ebf5fbbde4ad452b2396d14b5746"
+    }
+  }
+}

--- a/packages/vacuum/project.bri
+++ b/packages/vacuum/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "vacuum",
+  version: "0.17.6",
+  repository: "https://github.com/daveshanley/vacuum.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function vacuum(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    path: "./vacuum.go",
+    runnable: "bin/vacuum",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    vacuum version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(vacuum)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`vacuum`](https://github.com/daveshanley/vacuum): fast OpenAPI 3, OpenAPI 2 / Swagger linter and quality analysis tool.

```bash
Build finished, completed (no new jobs) in 0.95s
Result: 9bee4b7597eecb5c79bc65a4e76e55045dadb41979dc57a9911f078429855d5b

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 1 job in 11.32s
Running brioche-run
{
  "name": "vacuum",
  "version": "0.17.6",
  "repository": "https://github.com/daveshanley/vacuum.git"
}

⏵ Task `Run package live-update` finished successfully
```