### PR TITLE
refactor(libunistring): use `nushellRunnable` in the live update method

### DIFF
--- a/packages/libunistring/project.bri
+++ b/packages/libunistring/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import nushell from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "libunistring",
@@ -66,8 +66,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
   return script;
 }
 
-export function liveUpdate(): std.WithRunnable {
-  const src = std.file(std.indoc`
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/libunistring
       | lines
       | where {|it| ($it | str contains "libunistring-") and (not ($it | str contains ".sig")) }
@@ -79,12 +79,5 @@ export function liveUpdate(): std.WithRunnable {
       | from json
       | update version $version
       | to json
-  `);
-
-  return std.withRunnable(std.directory(), {
-    command: "nu",
-    args: [src],
-    env: { project: JSON.stringify(project) },
-    dependencies: [nushell],
-  });
+  `.env({ project: JSON.stringify(project) });
 }


### PR DESCRIPTION
It was the last one that was not migrated to the new `nushellRunnable` helper.