### PR TITLE
feat(cargo_spellcheck): add package

### DIFF
--- a/packages/cargo_spellcheck/brioche.lock
+++ b/packages/cargo_spellcheck/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-spellcheck/0.15.5/download": {
+      "type": "sha256",
+      "value": "d51b887cbe54a21927501426aea66d9a4a4c93fea880e971d06d6d39d60bc1c6"
+    }
+  }
+}

--- a/packages/cargo_spellcheck/project.bri
+++ b/packages/cargo_spellcheck/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import llvm from "llvm";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_spellcheck",
+  version: "0.15.5",
+  extra: {
+    crateName: "cargo-spellcheck",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoSpellcheck(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    dependencies: [llvm],
+    runnable: "bin/cargo-spellcheck",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo spellcheck --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoSpellcheck)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-spellcheck ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_spellcheck`](https://github.com/drahnr/cargo-spellcheck): checks all your documentation for spelling and grammar mistakes with hunspell and a nlprule based checker for grammar.

```bash
Running brioche-run
{
  "name": "cargo_spellcheck",
  "version": "0.15.5",
  "extra": {
    "crateName": "cargo-spellcheck"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 3.01s
Result: 660b71d8bdb98c5bec7a898c521329cf190dfe947bd5918b7eb3b12af90ea37a

⏵ Task `Run package test` finished successfully
```