### PR TITLE
feat(hugo): add package

### DIFF
--- a/packages/hugo/brioche.lock
+++ b/packages/hugo/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/gohugoio/hugo.git": {
+      "v0.148.1": "98ba786f2f5dca0866f47ab79f394370bcb77d2f"
+    }
+  }
+}

--- a/packages/hugo/project.bri
+++ b/packages/hugo/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "hugo",
+  version: "0.148.1",
+  repository: "https://github.com/gohugoio/hugo.git",
+  extra: {
+    releaseDate: "2025-07-17",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function hugo(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/gohugoio/hugo/common/hugo.commitHash=${gitRef.commit}`,
+        "-X",
+        `github.com/gohugoio/hugo/common/hugo.buildDate=${project.extra.releaseDate}`,
+      ],
+    },
+    path: ".",
+    runnable: "bin/hugo",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    hugo version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(hugo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `hugo v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`hugo`](https://gohugo.io): the world’s fastest framework for building websites.

```bash
Build finished, completed (no new jobs) in 0.85s
Result: c9ba36de1b98802ff23d436845b6169cf9376864116efddacba8a78e11e335dd

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 8.22s
Running brioche-run
{
  "name": "hugo",
  "version": "0.148.2",
  "repository": "https://github.com/gohugoio/hugo.git",
  "extra": {
    "releaseDate": "2025-07-27"
  }
}

⏵ Task `Run package live-update` finished successfully
```