### PR TITLE
feat(cmake): add unsafe option to cmake build function to allow non-hermetic builds when necessary

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -92,6 +92,10 @@ export default function cmake(): std.Recipe<std.Directory> {
  * @param dependencies - Optionally add dependencies to the build. Most projects
  *   will want to include `std.toolchain()` or a similar toolchain.
  * @param env - Optionally set environment variables for the build.
+ * @param unsafe - Optional unsafe options to enable when building. For example,
+ *   passing `{ networking: true }` will allow to download files during the build.
+ *   You must take extra care to ensure the build is hermetic when setting these
+ *   options!
  * @param set - Optionally set CMake cache variables during the build, as if
  *   by passing `-D...`.
  * @param disablePostBuildSteps - If set, the post build steps will not run. By
@@ -105,6 +109,7 @@ export interface CMakeBuildInstallOptions {
   dependencies?: std.RecipeLike<std.Directory>[];
   config?: string;
   env?: Record<string, std.ProcessTemplateLike>;
+  unsafe?: std.ProcessUnsafeOptions;
   set?: Record<string, CMakeVariable>;
   disablePostBuildSteps?: boolean;
   runnable?: string;
@@ -204,6 +209,7 @@ export function cmakeBuild(
       cmake_num_set_entries: setEntriesWithIndices.length.toString(),
       ...env,
     })
+    .unsafe(options.unsafe)
     .toDirectory();
 
   if (options.disablePostBuildSteps == null || !options.disablePostBuildSteps) {


### PR DESCRIPTION
It could happen that a `CMakeLists.txt` wants to download a git dependency. For this purpose, I added the unsafe option to `cmakeBuild()` which breaks the hermetic build, but this is enforce by the way the option is named `unsafe`. It's basically a copy paste of the current option available with `cargoBuild()`.

Here is an example of its usage in a not yet upstream package:

```typescript
export default function nuspell(): std.Recipe<std.Directory> {
  return cmakeBuild({
    source,
    dependencies: [std.toolchain, git, icu],
    set: {
      BUILD_DOCS: "OFF",
    },
    unsafe: {
      networking: true,
    },
    runnable: "bin/nuspell",
  }).pipe(std.pkgConfigMakePathsRelative, (recipe) =>
    std.setEnv(recipe, {
      CPATH: { append: [{ path: "include" }] },
      LIBRARY_PATH: { append: [{ path: "lib" }] },
      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
    }),
  );
}
``` 