### PR TITLE
chore(icu): add ICU_ROOT environment variable to the recipe

### DIFF
--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -39,6 +39,7 @@ export default function icu(): std.Recipe<std.Directory> {
       std.pkgConfigMakePathsRelative,
       (recipe) =>
         std.setEnv(recipe, {
+          ICU_ROOT: { fallback: { path: "." } },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           CPATH: { append: [{ path: "include" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },


### PR DESCRIPTION
CMake used the `ICU_ROOT` environment variable in its recipe `FindICU.cmake` to find the root directory of `ICU` to populate `ICU_INCLUDE_DIR`, etc. Without it CMake fails to get the location of this dependency. Here is an example of such failure on a not yet upstream package:

```bash
process stack trace:
- file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/core/recipes/process.bri:247:14
- file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/cmake/project.bri:212:6
- file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/nuspell/project.bri:18:10

[0.00s] [spawned process with pid 545381, preparation took 0.00s]
[0.32s] -- The CXX compiler identification is GNU 13.2.0
[0.34s] -- Detecting CXX compiler ABI info
[0.45s] -- Detecting CXX compiler ABI info - done
[0.46s] -- Check for working CXX compiler: /home/brioche-runner-66245c77725849a390b8743aa042af8a684d7dc7e7a01505adc81fcc830073b9/.local/share/brioche/locals/0c44b1839d42666e7aa552608175108258207e0cd7bfb1a86772b17f547c4cf4/bin/c++ - skipped
[0.46s] -- Detecting CXX compile features
[0.46s] -- Detecting CXX compile features - done
[0.49s] CMake Error at /home/brioche-runner-66245c77725849a390b8743aa042af8a684d7dc7e7a01505adc81fcc830073b9/.local/share/brioche/locals/1e73993f26ee07cd420b6ec5b99fbec4a95576d944ede8d2bf66ce10ebbd239e/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
[0.49s]   Failed to find all ICU components (missing: ICU_INCLUDE_DIR) (Required is
[0.49s]   at least version "60")
[0.49s] Call Stack (most recent call first):
[0.49s]   /home/brioche-runner-66245c77725849a390b8743aa042af8a684d7dc7e7a01505adc81fcc830073b9/.local/share/brioche/locals/1e73993f26ee07cd420b6ec5b99fbec4a95576d944ede8d2bf66ce10ebbd239e/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
[0.49s]   /home/brioche-runner-66245c77725849a390b8743aa042af8a684d7dc7e7a01505adc81fcc830073b9/.local/share/brioche/locals/1e73993f26ee07cd420b6ec5b99fbec4a95576d944ede8d2bf66ce10ebbd239e/share/cmake-4.0/Modules/FindICU.cmake:299 (find_package_handle_standard_args)
[0.49s]   CMakeLists.txt:15 (find_package)
[0.49s]
[0.49s]
[0.49s] -- Configuring incomplete, errors occurred!
[0.49s] [process exited with code 1]
```