### PR TITLE
[renovate] Work around failing build with Node.js v22.18.0

### DIFF
--- a/packages/renovate/project.bri
+++ b/packages/renovate/project.bri
@@ -37,6 +37,12 @@ export default function renovate(): std.Recipe<std.Directory> {
     mv dist "$BRIOCHE_OUTPUT"
   `
     .workDir(npmPackage)
+    .env({
+      // NOTE: The Renovate build fails when Node.js type stripping is
+      // enabled (as of Renovate v41.48.0). Node.js enabled this option
+      // by default in v22.18.0. So for now, we manually disable it
+      NODE_OPTIONS: "--no-experimental-strip-types",
+    })
     .dependencies(pnpm)
     .toDirectory();
 


### PR DESCRIPTION
[Node.js v22.18.0](https://nodejs.org/en/blog/release/v22.18.0) was released on Thursday, and today we had a live-update PR to update to this new version in the `nodejs` package (#944). The build failed (but was inadvertently auto-merged; see #963).

Here was the error from the build:

```
> renovate@0.0.0-semantic-release create-json-schema /home/brioche-runner-d15ac752d340eb70693ad58ede3dbb3feb13280b3297f2cd5bbe1688c16689bb/work
> tsx tools/generate-schema.ts && prettier --write --cache 'renovate-schema.json'

/home/brioche-runner-d15ac752d340eb70693ad58ede3dbb3feb13280b3297f2cd5bbe1688c16689bb/work/lib/modules/manager/bazel-module/extract.ts:1
import { dirname } from 'upath';
         ^

SyntaxError: The requested module 'upath' does not provide an export named 'dirname'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v22.18.0
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "create-json-schema" exited with 1.
 ELIFECYCLE  Command failed with exit code 1.
[process exited with code 1]
```

I checked the Node.js release notes and noticed that the `--experimental-strip-types` feature was enabled by default. Anyway, I tried disabling this feature by setting the `$NODE_OPTIONS` env var to `--no-experimental-strip-types` to explicitly disable it, and that resolved the error.

Now, I don't know _why_ `--experimental-strip-types` breaks the build, but it does. It seems like it's some quirk for the `upath` package-- I checked its source and saw it was doing some funky stuff with Node.js's built-in `path` module. No idea if it's a bug in `upath`, or if it's a bug in Node.js, or if it's a secret third thing