### PR TITLE
chore(renovate): reformat Nushell embedded script

### DIFF
--- a/packages/renovate/project.bri
+++ b/packages/renovate/project.bri
@@ -49,10 +49,10 @@ export default function renovate(): std.Recipe<std.Directory> {
   // Set the release version number in `package.json`.
   const packageJson = runNushell`
       open --raw $env.BRIOCHE_OUTPUT
-      | from json
-      | update version $env.version
-      | to json
-      | save --force $env.BRIOCHE_OUTPUT
+        | from json
+        | update version $env.version
+        | to json
+        | save --force $env.BRIOCHE_OUTPUT
   `
     .outputScaffold(npmPackage.get("package.json"))
     .env({ version: project.version })


### PR DESCRIPTION
Simply reformat the Nushell embedded script found in the `renovate` recipe