### PR TITLE
feat(hunspell): add package

### DIFF
--- a/packages/hunspell/brioche.lock
+++ b/packages/hunspell/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/hunspell/hunspell/releases/download/v1.7.2/hunspell-1.7.2.tar.gz": {
+      "type": "sha256",
+      "value": "11ddfa39afe28c28539fe65fc4f1592d410c1e9b6dd7d8a91ca25d85e9ec65b8"
+    }
+  }
+}

--- a/packages/hunspell/project.bri
+++ b/packages/hunspell/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+
+export const project = {
+  name: "hunspell",
+  version: "1.7.2",
+  repository: "https://github.com/hunspell/hunspell",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/hunspell-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function hunspell(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --with-readline
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/hunspell"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    hunspell --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(hunspell)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Hunspell ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`hunspell`](https://github.com/hunspell/hunspell): a spellchecking library.

```bash
Build finished, completed (no new jobs) in 0.96s
Result: 8c7def9d723638ba82af84ec60ecab3decbf0cbdce883919f4583666afede12d

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 7.74s
Running brioche-run
{
  "name": "hunspell",
  "version": "1.7.2",
  "repository": "https://github.com/hunspell/hunspell"
}

⏵ Task `Run package live-update` finished successfully
```
