### PR TITLE
feat(libxcrypt): add package

### DIFF
--- a/packages/libxcrypt/brioche.lock
+++ b/packages/libxcrypt/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz": {
+      "type": "sha256",
+      "value": "80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6"
+    }
+  }
+}

--- a/packages/libxcrypt/project.bri
+++ b/packages/libxcrypt/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+
+export const project = {
+  name: "libxcrypt",
+  version: "4.4.38",
+  repository: "https://github.com/besser82/libxcrypt",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libxcrypt-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxcrypt(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --disable-failure-tokens
+    make
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libxcrypt | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxcrypt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libxcrypt`](https://github.com/besser82/libxcrypt) already part of std but with a newer release and less restrictions in its building options.

```bash
Build finished, completed (no new jobs) in 7.71s
Running brioche-run
{
  "name": "libxcrypt",
  "version": "4.4.38",
  "repository": "https://github.com/besser82/libxcrypt"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.75s
Result: 14737d74043482ebebb93c62afcdbbb68b17abf82000e5ff6bc782a6a3862671

⏵ Task `Run package test` finished successfully
```