### PR TITLE
feat(isl): add package

### DIFF
--- a/packages/isl/brioche.lock
+++ b/packages/isl/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://libisl.sourceforge.io/isl-0.27.tar.xz": {
+      "type": "sha256",
+      "value": "6d8babb59e7b672e8cb7870e874f3f7b813b6e00e6af3f8b04f7579965643d5c"
+    }
+  }
+}

--- a/packages/isl/project.bri
+++ b/packages/isl/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "isl",
+  version: "0.27",
+};
+
+const source = Brioche.download(
+  `https://libisl.sourceforge.io/isl-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function isl(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion isl | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, isl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://libisl.sourceforge.io
+      | lines
+      | where {|it| $it | str contains "isl" }
+      | parse --regex '<a href="isl-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`isl`](https://libisl.sourceforge.io): a library for manipulating sets and relations of integer points bounded by linear constraints.

```bash
Build finished, completed (no new jobs) in 7.29s
Running brioche-run
{
  "name": "isl",
  "version": "0.27"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.79s
Result: 4b6b1ff7ef56cb280e648701b7b9143ce42121d17811a964cbf9492586ff7623

⏵ Task `Run package test` finished successfully
```