### PR TITLE
feat(xorgproto): add package

### DIFF
--- a/packages/xorgproto/brioche.lock
+++ b/packages/xorgproto/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/proto/xorgproto-2024.1.tar.xz": {
+      "type": "sha256",
+      "value": "372225fd40815b8423547f5d890c5debc72e88b91088fbfb13158c20495ccb59"
+    }
+  }
+}

--- a/packages/xorgproto/project.bri
+++ b/packages/xorgproto/project.bri
@@ -1,0 +1,79 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "xorgproto",
+  version: "2024.1",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/proto/xorgproto-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function xorgproto(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // This package contains multiple header files for X11 protocol and its extensions.
+  // The version can be obtained per extension, but not for the entire package.
+  // Here, we just check that we can build a simple program using the header files.
+  const src = std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <X11/X.h>
+
+      int main(void)
+      {
+          printf("%d.%d", X_PROTOCOL, X_PROTOCOL_REVISION);
+
+          return EXIT_SUCCESS;
+      }
+  `);
+
+  const script = std.runBash`
+    cp "$src" main.c
+    gcc main.c -o main $(pkg-config --cflags xproto)
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto)
+    .env({ src: src })
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/proto
+      | lines
+      | where {|it| ($it | str contains "xorgproto") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="xorgproto-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`xorgproto`](https://gitlab.freedesktop.org/xorg/proto/xorgproto): provides the headers and specification documents defining
the core protocol and (many) extensions for the X Window System

```bash
Build finished, completed (no new jobs) in 0.76s
Result: c97ee1074bde800ac2c363dd745f82681a19639c4bfc878ef0fde195a66f2f1c

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "xorgproto",
  "version": "2024.1"
}

⏵ Task `Run package live-update` finished successfully
```