### PR TITLE
chore(live-update): validate matchTag parameter to ensure it contains 'version'

### DIFF
--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -1,6 +1,9 @@
 import * as std from "/core";
 import { parseGithubRepo } from "./github_global.bri";
-import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import {
+  DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH,
+  validateMatchTag,
+} from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -74,6 +77,8 @@ export function liveUpdateFromGithubReleases(
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
   const normalizeVersion = options.normalizeVersion ?? false;
+
+  validateMatchTag(matchTag);
 
   return std.recipe(async () => {
     const { nushellRunnable } = await import("nushell");

--- a/packages/std/extra/live_update/from_github_tags.bri
+++ b/packages/std/extra/live_update/from_github_tags.bri
@@ -1,6 +1,9 @@
 import * as std from "/core";
 import { parseGithubRepo } from "./github_global.bri";
-import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import {
+  DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH,
+  validateMatchTag,
+} from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -72,6 +75,8 @@ export function liveUpdateFromGithubTags(
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
   const normalizeVersion = options.normalizeVersion ?? false;
+
+  validateMatchTag(matchTag);
 
   return std.recipe(async () => {
     const { nushellRunnable } = await import("nushell");

--- a/packages/std/extra/live_update/from_gitlab_releases.bri
+++ b/packages/std/extra/live_update/from_gitlab_releases.bri
@@ -1,5 +1,8 @@
 import * as std from "/core";
-import { DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH } from "./index.bri";
+import {
+  DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH,
+  validateMatchTag,
+} from "./index.bri";
 import type {} from "nushell";
 
 // HACK: The `import type` line above is a workaround for this issue:
@@ -71,6 +74,8 @@ export function liveUpdateFromGitlabReleases(
   const { repoOwner, repoName } = parseGitlabRepo(options.project.repository);
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
   const normalizeVersion = options.normalizeVersion ?? false;
+
+  validateMatchTag(matchTag);
 
   return std.recipe(async () => {
     const { nushellRunnable } = await import("nushell");

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -10,3 +10,16 @@ export * from "./github_global.bri";
 // a semver-like version)
 export const DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH =
   /^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-(?:(?:[0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
+
+/**
+ * Validate the matchTag parameter to ensure it declares a named "version" group.
+ *
+ * @param matchTag - The parameter to validate.
+ *
+ * @throws If the parameter does not declare a named "version" group.
+ */
+export function validateMatchTag(matchTag: RegExp): void {
+  if (!matchTag.source.includes('(?<version>')) {
+    throw new Error('matchTag must declare a named "version" group');
+  }
+}

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -36,10 +36,7 @@ if ($parsedTagName | length) == 0 {
   error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
 }
 
-mut version = $parsedTagName.0.version?
-if $version == null {
-  error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
-}
+mut version = $parsedTagName.0.version
 
 if $env.normalizeVersion == "true" {
   $version = $version

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -15,10 +15,7 @@ if ($parsedTagName | length) == 0 {
   error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
 }
 
-mut version = $parsedTagName.0.version?
-if $version == null {
-  error make { msg: $'Regex ($env.matchTag) did not include version when matching latest release tag ($tagName)' }
-}
+mut version = $parsedTagName.0.version
 
 if $env.normalizeVersion == "true" {
   $version = $version


### PR DESCRIPTION
This PR is a pre-requisite to update std GitHub release live update methods to fetch all the releases instead of the latest one.

`matchTag` is being used in three std live update methods:

- `std.liveUpdateFromGithubReleases()`
- `std.liveUpdateFromGithubTags()`
- `std.liveUpdateFromGitlabReleases()`

In the methods based on release, the parameter `matchTag` was validated in the Nushell script, but not in the method based on tag. This PR extracts this validation to move it in Typescript. The advantage of doing it this way is, we can now emit at runtime a proper reminder to the end user that if he overrides the default regex used to match tags, this regex must contains a `version` field.