### PR TITLE
feat(terragrunt): add package

### DIFF
--- a/packages/terragrunt/brioche.lock
+++ b/packages/terragrunt/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/gruntwork-io/terragrunt.git": {
+      "v0.84.1": "2a5b90df9f7386794756ed4dc071d40c7ee9bb5b"
+    }
+  }
+}

--- a/packages/terragrunt/project.bri
+++ b/packages/terragrunt/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "terragrunt",
+  version: "0.84.1",
+  repository: "https://github.com/gruntwork-io/terragrunt.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function terragrunt(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/gruntwork-io/go-commons/version.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/terragrunt",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    terragrunt --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(terragrunt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `terragrunt version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`terragrunt`](https://terragrunt.gruntwork.io): a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.

```bash
Build finished, completed 1 job in 9.06s
Running brioche-run
{
  "name": "terragrunt",
  "version": "0.84.1",
  "repository": "https://github.com/gruntwork-io/terragrunt.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.11s
Result: 85947e794033e4a8f612f624dd4b9458eff67a5132772e8924e08e1b80fef8be

⏵ Task `Run package test` finished successfully
```