### PR TITLE
Update live update GitHub releases

### DIFF
--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -102,9 +102,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
-  // GitHub releases live method is able to retrieve a list of releases
-  return std.liveUpdateFromGithubTags({
+  return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^v(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
   });

--- a/packages/boost/project.bri
+++ b/packages/boost/project.bri
@@ -66,9 +66,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
-  // GitHub releases live method is able to retrieve a list of releases
-  return std.liveUpdateFromGithubTags({
+  return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^boost-(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
   });

--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -27,6 +27,7 @@ interface LiveUpdateFromGithubReleasesProjectExtraOptions {
  *
  * @param project - The project export that should be updated. Must include a
  *   `repository` property containing a GitHub repository URL.
+ * @param includePrerelease - Whether to include prerelease versions.
  * @param matchTag - A regex value (`/.../`) to extract the version number from
  *   a tag name. The regex must include a group named "version". If not
  *   provided, an optional "v" prefix will be stripped and the rest of the
@@ -41,6 +42,7 @@ interface LiveUpdateFromGithubReleasesOptions {
     readonly repository: string;
     extra?: LiveUpdateFromGithubReleasesProjectExtraOptions;
   };
+  readonly includePrerelease?: boolean;
   readonly matchTag?: RegExp;
   readonly normalizeVersion?: boolean;
 }
@@ -75,6 +77,7 @@ export function liveUpdateFromGithubReleases(
   options: LiveUpdateFromGithubReleasesOptions,
 ): std.Recipe<std.Directory> {
   const { repoOwner, repoName } = parseGithubRepo(options.project.repository);
+  const includePrerelease = options.includePrerelease ?? false;
   const matchTag = options.matchTag ?? DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH;
   const normalizeVersion = options.normalizeVersion ?? false;
 
@@ -89,6 +92,7 @@ export function liveUpdateFromGithubReleases(
       project: JSON.stringify(options.project),
       repoOwner,
       repoName,
+      includePrerelease: includePrerelease.toString(),
       matchTag: matchTag.source,
       normalizeVersion: normalizeVersion.toString(),
     });

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -19,7 +19,7 @@ export const DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH =
  * @throws If the parameter does not declare a named "version" group.
  */
 export function validateMatchTag(matchTag: RegExp): void {
-  if (!matchTag.source.includes('(?<version>')) {
+  if (!matchTag.source.includes("(?<version>")) {
     throw new Error('matchTag must declare a named "version" group');
   }
 }

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -28,7 +28,7 @@ let releases = $httpResponse.body
 
 # Extract the version
 let releasesInfo = $releases
-  | where {|release| not $release.prerelease }
+  | where {|release| ($env.includePrerelease == "true") or (not $release.prerelease) }
   | each {|release|
     let parsedTag = $release.tag_name
       | parse --regex $env.matchTag

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -9,7 +9,7 @@ if ($env.GITHUB_TOKEN? | default "") != "" {
   $gh_headers ++= [Authorization $'Bearer ($env.GITHUB_TOKEN)']
 }
 
-let httpResponse = http get --full --allow-errors --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases/latest'
+let httpResponse = http get --full --allow-errors --headers $gh_headers $'https://api.github.com/repos/($env.repoOwner)/($env.repoName)/releases'
 match $httpResponse.status {
   200 => {
     # Success
@@ -24,19 +24,31 @@ match $httpResponse.status {
     error make { msg: $'Failed to call GitHub API: ($httpResponse.status)' }
   }
 }
-let releaseInfo = $httpResponse.body
+let releases = $httpResponse.body
 
 # Extract the version
-let tagName = $releaseInfo
-  | get tag_name
+let releasesInfo = $releases
+  | where {|release| not $release.prerelease }
+  | each {|release|
+    let parsedTag = $release.tag_name
+      | parse --regex $env.matchTag
 
-let parsedTagName = $tagName
-  | parse --regex $env.matchTag
-if ($parsedTagName | length) == 0 {
-  error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
+    # If no tag is matched, a nil value will be returned
+    # and this value will be ignored by 'each'
+    if ($parsedTag | length) != 0 {
+      { version: $parsedTag.0.version, created_at: $release.created_at }
+    }
+  }
+  | sort-by --natural version
+
+if ($releasesInfo | length) == 0 {
+  error make { msg: $'No tag did match regex ($env.matchTag)' }
 }
 
-mut version = $parsedTagName.0.version
+let releaseInfo = $releasesInfo
+  | last
+
+mut version = $releaseInfo.version
 
 if $env.normalizeVersion == "true" {
   $version = $version

--- a/packages/tokei/project.bri
+++ b/packages/tokei/project.bri
@@ -39,9 +39,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  // TODO: to be later replaced with `std.liveUpdateFromGithubReleases()`, once
-  // GitHub releases live method is able to retrieve a list of releases
-  return std.liveUpdateFromGithubTags({
+  return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^v(?<version>([\d]+)\.([\d]+)\.([\d]+))$/,
   });


### PR DESCRIPTION
`std.liveUpdateFromGithubReleases()` does now fetch all the releases as its name suggests: 'releaseS' and not 'latestRelease'. As of today, this function was only retrieving the latest GitHub Release for a package but it caused issues in the past since for a few packages. It can happen that the latest release is not a final release (see https://github.com/asciinema/asciinema/releases/tag/v3.0.0-rc.5 for example). This PR does not necessarily resolved this specific issue, since `std.liveUpdateFromGithubReleases()` and `std.liveUpdateFromGithubTags()` (without `matchTag` overriding) will both return the wrong tag -> the real issue comes from the maintainers not having tagged properly the tag v3.0.0-rc.5 as a pre-release. But now, we can move from `std.liveUpdateFromGithubTags()` to `std.liveUpdateFromGithubReleases()` when releases are available for a package, behind the scene, both methods have now a similar behavior -> both of them now retrieved a list of tags and not the latest one.

Bonus point: we can now include pre-released versions when fetching the list of releases with `std.liveUpdateFromGithubReleases()`