### PR TITLE
chore(kor): use variable `project.repository` when fetching the patch

### DIFF
--- a/packages/kor/brioche.lock
+++ b/packages/kor/brioche.lock
@@ -7,7 +7,7 @@
     }
   },
   "git_refs": {
-    "https://github.com/yonahd/kor.git": {
+    "https://github.com/yonahd/kor": {
       "v0.6.2": "0db53ee5c17df48c5cee81c9e6560ddc8f1e9fe5"
     }
   }

--- a/packages/kor/project.bri
+++ b/packages/kor/project.bri
@@ -4,7 +4,7 @@ import { goBuild } from "go";
 export const project = {
   name: "kor",
   version: "0.6.2",
-  repository: "https://github.com/yonahd/kor.git",
+  repository: "https://github.com/yonahd/kor",
 };
 
 const source = Brioche.gitCheckout({
@@ -15,7 +15,7 @@ const source = Brioche.gitCheckout({
   std.applyPatch({
     source,
     patch: Brioche.download(
-      "https://github.com/yonahd/kor/commit/6c02951894e587c023e57a7ab2654136024bff70.patch",
+      `${project.repository}/commit/6c02951894e587c023e57a7ab2654136024bff70.patch`,
     ),
     strip: 1,
   }),


### PR DESCRIPTION
The inspiration of this PR was taken from https://github.com/brioche-dev/brioche-packages/pull/1004/commits/b8eb598e5e35d08515e199d3bf59ae6563a3b84f