### PR TITLE
Use `--experimental-lazy` option when running builds in GitHub Actions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -80,7 +80,7 @@ jobs:
                 echo "$label: skipping (does not support $PLATFORM)"
               else
                 echo "::group::$label"
-                brioche build -p "$package" -e test --sync --locked
+                brioche build -p "$package" -e test --sync --locked --display plain-reduced
                 echo "::endgroup::"
               fi
             else

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -51,7 +51,7 @@ jobs:
               echo "$label: skipping (does not support $PLATFORM)"
             else
               echo "::group::$label"
-              brioche build -p "$package" --sync --locked --display plain-reduced
+              brioche build -p "$package" --sync --locked --display plain-reduced --experimental-lazy
               echo "::endgroup::"
             fi
           done
@@ -80,7 +80,7 @@ jobs:
                 echo "$label: skipping (does not support $PLATFORM)"
               else
                 echo "::group::$label"
-                brioche build -p "$package" -e test --sync --locked --display plain-reduced
+                brioche build -p "$package" -e test --sync --locked --display plain-reduced --experimental-lazy
                 echo "::endgroup::"
               fi
             else


### PR DESCRIPTION
**Blocked**: Cannot merge until https://github.com/brioche-dev/brioche/pull/294 is merged and included in a nightly build

This PR uses the new `--experimental-lazy` flag` (https://github.com/brioche-dev/brioche/pull/294) when calling `brioche build` in our GitHub Actions workflows.

Hopefully, this will help speed up our workflows, since it'll let us short-circuit calls to `brioche build` when we can determine that the build result has already been saved in the remote cache.