### PR TITLE
chore(pkgConfig): tweak the recipe to make paths relative

### DIFF
--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -39,7 +39,7 @@ export function pkgConfigMakePathsRelative(
 
     find "\${find_roots[@]}" -name '*.pc' -type f -print0 \
       | while IFS= read -r -d $'\\0' file; do
-        sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+        sed -i 's|=/|=\${pcfiledir}/../..|' "$file"
       done
   `
     .outputScaffold(recipe)

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -414,7 +414,7 @@ function pkgConfigMakePathsRelative(
         std.indoc`
           find "$BRIOCHE_OUTPUT"/lib/pkgconfig -name '*.pc' -type f -print0 \
             | while IFS= read -r -d $'\\0' file; do
-              sed -i 's|=/|=\${pcfiledir}/../../|' "$file"
+              sed -i 's|=/|=\${pcfiledir}/../..|' "$file"
             done
         `,
       ],


### PR DESCRIPTION
This PR tweaks the script transforming pkg-config paths to relative paths by removing a leading `/` that is not necessary. In practice, it should change nothing, since both path construction point to the same location. It's just to ensure well-constructed paths. Here is a comparison for `alsa_lib` package:

### Before

```bash
> cat /tmp/output/lib/pkgconfig/alsa.pc
prefix=${pcfiledir}/../../
exec_prefix=${pcfiledir}/../../
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: alsa
Description: Advanced Linux Sound Architecture (ALSA) - Library
Version: 1.2.14
Requires:
Libs: -L${libdir} -lasound
Libs.private: -lm -lpthread -lrt
Cflags: -I${includedir}
```

The following pkg-configs are not well-constructed:

```bash
libdir = ${pcfiledir}/../..//lib
includedir=${pcfiledir}/../..//include
```

### After

```bash
> cat /tmp/output/lib/pkgconfig/alsa.pc
prefix=${pcfiledir}/../..
exec_prefix=${pcfiledir}/../..
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: alsa
Description: Advanced Linux Sound Architecture (ALSA) - Library
Version: 1.2.14
Requires:
Libs: -L${libdir} -lasound
Libs.private: -lm -lpthread -lrt
Cflags: -I${includedir}
```

The following pkg-configs are now well-constructed:

```bash
libdir = ${pcfiledir}/../../lib
includedir=${pcfiledir}/../../include
```