### PR TITLE
build(rust): Update package to use xz decompression for toolchain archives

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -12,8 +12,8 @@ export const project = {
 const ManifestPkgTarget = t.discriminatedUnion("available", [
   t.object({
     available: t.literal(true),
-    hash: t.string(),
-    url: t.string(),
+    xz_hash: t.string(),
+    xz_url: t.string(),
   }),
   t.object({
     available: t.literal(false),
@@ -62,20 +62,20 @@ export default async function rust(): Promise<std.Recipe<std.Directory>> {
       continue;
     }
 
-    // FIXME: We unarchive within the process because unarchiving `rust-docs`
-    // fails for some reason
-    const pkgTargetArchive = std.download({
-      url: pkgTarget.url,
-      hash: std.sha256Hash(pkgTarget.hash),
-    });
+    const pkgTargetSource = std
+      .download({
+        url: pkgTarget.xz_url,
+        hash: std.sha256Hash(pkgTarget.xz_hash),
+      })
+      .unarchive("tar", "xz")
+      .peel();
 
     const installedPkg = std.runBash`
-      tar -xf $pkgTargetArchive --strip-components=1
       ./install.sh \\
         --prefix="$BRIOCHE_OUTPUT" \\
         --disable-ldconfig
     `
-      .env({ pkgTargetArchive })
+      .workDir(pkgTargetSource)
       .toDirectory();
 
     recipe = std.merge(recipe, installedPkg);


### PR DESCRIPTION
Move from gzip to xz archives compression for Rust toolchain. It can saved between 30-40% in download size when building the Rust toolchain, due to higher compression ratio using xz.

```bash
172560 │ rustc 1.89.0 (29483883e 2025-08-04)
 0.05s ✓ Process 172560
Build finished, completed 1 job in 1.63s
Result: d061736ebcd489ce544fd212cb13a1e305c039b2dfd2feb37230ff63a211033e

⏵ Task `Run package test` finished successfully
```

Also move from process decompression to usual Brioche decompression methods. The problem with `rust-docs` seems to be resolved.