### PR TITLE
Add gopls

### DIFF
--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -107,6 +107,7 @@ interface GoBuildParameters {
  *   `go.sum` if external dependencies are needed.
  * @param dependencies - Optionally add additional dependencies to the build.
  * @param env - Optionally set environment variables for the build.
+ * @param currentDir - Optionally set the current working directory for the build.
  * @param buildParams - Optional build parameters.
  * @param path - Optionally set the package path to build (e.g. `./cmd/foo`).
  * @param runnable - Optionally set a path to the binary to run
@@ -116,6 +117,7 @@ interface GoBuildOptions {
   source: std.RecipeLike<std.Directory>;
   dependencies?: std.RecipeLike<std.Directory>[];
   env?: Record<string, std.ProcessTemplateLike>;
+  currentDir?: string;
   buildParams?: GoBuildParameters;
   path?: string;
   runnable?: string;
@@ -157,9 +159,13 @@ interface GoBuildOptions {
  * ```
  */
 export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
-  const modules = goModDownload(options.source);
+  const currentDir = options.currentDir ?? ".";
+
+  const modules = goModDownload(options.source, currentDir);
 
   let buildResult = std.runBash`
+    cd $current_dir
+
     # Run generate if requested
     if [ "$go_generate" = "true" ]; then
       go generate ./...
@@ -186,6 +192,7 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,
+      current_dir: currentDir,
       go_generate: options.buildParams?.generate ?? false ? "true" : "false",
       ldflags: ldflagsWrapper(options.buildParams?.ldflags ?? []),
       trimpath: options.buildParams?.trimpath ?? false ? "true" : "false",
@@ -204,10 +211,13 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
 
 function goModDownload(
   goModule: std.RecipeLike<std.Directory>,
+  currentDir: string,
 ): std.Recipe<std.Directory> {
   // Includes all the modules in the specified directory and its subdirectories
   // If a workspace file exists also include it
   return std.runBash`
+    cd $current_dir
+
     go mod download all
   `
     .workDir(
@@ -219,7 +229,10 @@ function goModDownload(
       ]),
     )
     .dependencies(go)
-    .env({ GOMODCACHE: std.outputPath })
+    .env({
+      GOMODCACHE: std.outputPath,
+      current_dir: currentDir,
+    })
     .unsafe({ networking: true })
     .toDirectory();
 }

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -159,13 +159,9 @@ interface GoBuildOptions {
  * ```
  */
 export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
-  const currentDir = options.currentDir ?? ".";
-
-  const modules = goModDownload(options.source, currentDir);
+  const modules = goModDownload(options.source, options.currentDir);
 
   let buildResult = std.runBash`
-    cd $current_dir
-
     # Run generate if requested
     if [ "$go_generate" = "true" ]; then
       go generate ./...
@@ -188,11 +184,15 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
     go install "\${goargs[@]}" "$package_path"
   `
     .workDir(options.source)
+    .currentDir(
+      options.currentDir != null
+        ? std.tpl`${std.workDir}/${options.currentDir}`
+        : std.workDir,
+    )
     .dependencies(go, ...(options.dependencies ?? []))
     .env({
       GOMODCACHE: modules,
       GOBIN: std.tpl`${std.outputPath}/bin`,
-      current_dir: currentDir,
       go_generate: options.buildParams?.generate ?? false ? "true" : "false",
       ldflags: ldflagsWrapper(options.buildParams?.ldflags ?? []),
       trimpath: options.buildParams?.trimpath ?? false ? "true" : "false",
@@ -211,13 +211,11 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
 
 function goModDownload(
   goModule: std.RecipeLike<std.Directory>,
-  currentDir: string,
+  currentDir: string | undefined,
 ): std.Recipe<std.Directory> {
   // Includes all the modules in the specified directory and its subdirectories
   // If a workspace file exists also include it
   return std.runBash`
-    cd $current_dir
-
     go mod download all
   `
     .workDir(
@@ -231,8 +229,10 @@ function goModDownload(
     .dependencies(go)
     .env({
       GOMODCACHE: std.outputPath,
-      current_dir: currentDir,
     })
+    .currentDir(
+      currentDir != null ? std.tpl`${std.workDir}/${currentDir}` : std.workDir,
+    )
     .unsafe({ networking: true })
     .toDirectory();
 }

--- a/packages/gopls/brioche.lock
+++ b/packages/gopls/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/golang/tools.git": {
+      "gopls/v0.19.1": "f795b4104f92bdc4966a4e4d75f6c7803d87b7cb"
+    }
+  }
+}

--- a/packages/gopls/project.bri
+++ b/packages/gopls/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "gopls",
+  version: "0.19.1",
+  repository: "https://github.com/golang/tools.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `gopls/v${project.version}`,
+});
+
+export default function gopls(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    currentDir: "./gopls",
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    runnable: "bin/gopls",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gopls version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gopls)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `golang.org/x/tools/gopls ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^gopls\/v(?<version>.*)$/,
+  });
+}

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -58,6 +58,9 @@ export interface ProcessUtils {
    */
   env(values: Record<string, ProcessTemplateLike>): Process;
 
+  /**
+   * Returns a new process with a different working directory.
+   */
   currentDir(currentDir: ProcessTemplateLike): Process;
 
   /**
@@ -67,7 +70,7 @@ export interface ProcessUtils {
   dependencies(...dependencies: RecipeLike<Directory>[]): Process;
 
   /**
-   * Returns a new process with a different working directory.
+   * Returns a new process with a different starting working directory.
    */
   workDir(workDir: RecipeLike<Directory>): Process;
 

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -18,11 +18,14 @@ import { castToFile, castToDirectory, castToSymlink } from "./cast.bri";
  *   string referencing a command from `dependencies`.
  * @param args - An array of arguments to pass to the command.
  * @param env - An object containing environment variables to set for the process.
- * @param currentDir - Set the process's current working directory.
+ * @param currentDir - Set starting working directory for a process. Defaults
+ *   to the work directory, which can be populated with the `workDir` option.
  * @param dependencies - An array of dependencies to call the process with.
  *   Dependencies will be merged into the process's environment.
  * @param workDir - Set to a directory recipe that will be copied into the
- *   process's starting working directory.
+ *   process's work directory. This is the default starting working
+ *   directory for the process, unless overridden with the `currentDir`
+ *   option.
  * @param outputScaffold - Set to a recipe that will be be used to initialize
  *   `$BRIOCHE_OUTPUT`, which the process can then manipulate.
  * @param unsafe - A nested object with extra unsafe options that can be enabled.
@@ -59,7 +62,9 @@ export interface ProcessUtils {
   env(values: Record<string, ProcessTemplateLike>): Process;
 
   /**
-   * Returns a new process with a different working directory.
+   * Returns a new process with a different starting working directory.
+   * Defaults to the work directory, which can be populated with the
+   * `.workDir()` method.
    */
   currentDir(currentDir: ProcessTemplateLike): Process;
 
@@ -70,7 +75,9 @@ export interface ProcessUtils {
   dependencies(...dependencies: RecipeLike<Directory>[]): Process;
 
   /**
-   * Returns a new process with a different starting working directory.
+   * Returns a new process with a different work directory. This is the
+   * default starting working directory for the process, unless overridden
+   * with `.currentDir()`.
    */
   workDir(workDir: RecipeLike<Directory>): Process;
 


### PR DESCRIPTION
Add a new package [`gopls`](https://go.dev/gopls/): the official language server for Go, developed by the Go team. It provides a wide variety of IDE features to any LSP compatible editor.

```bash
Build finished, completed (no new jobs) in 0.89s
Result: b22847e146be9519ac50601f75843ceba843422ca1d004af952ff04310921e18

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 8.94s
Running brioche-run
{
  "name": "gopls",
  "version": "0.19.1",
  "repository": "https://github.com/golang/tools.git"
}

⏵ Task `Run package live-update` finished successfully
```

Also this PR adds support to set the stat working directory with `goBuild()` method through a new argument `currentDir` that mimics what can already been done with `std.runBash()`.