### PR TITLE
feat(xtrans): add package

### DIFF
--- a/packages/xtrans/brioche.lock
+++ b/packages/xtrans/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/xtrans-1.6.0.tar.xz": {
+      "type": "sha256",
+      "value": "faafea166bf2451a173d9d593352940ec6404145c5d1da5c213423ce4d359e92"
+    }
+  }
+}

--- a/packages/xtrans/project.bri
+++ b/packages/xtrans/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "xtrans",
+  version: "1.6.0",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/xtrans-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function xtrans(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-docs=no
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xtrans | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xtrans)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "xtrans") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="xtrans-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`xtrans`](https://www.x.org/releases/X11R7.7/doc/xtrans/xtrans.html): a library of code that is shared among various X packages to handle network protocol transport in a modular fashion, allowing a single place to add new transport types.

```bash
Build finished, completed (no new jobs) in 0.79s
Result: 3c8d20634dc8b220ae420e85fb99e42455ab298838cfef24ab62a9f5e298af9a

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "xtrans",
  "version": "1.6.0"
}

⏵ Task `Run package live-update` finished successfully
```