### PR TITLE
Add `deno` package

### DIFF
--- a/packages/deno/brioche.lock
+++ b/packages/deno/brioche.lock
@@ -1,5 +1,15 @@
 {
   "dependencies": {},
+  "downloads": {
+    "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz": {
+      "type": "sha256",
+      "value": "278137daa64dcaa989c85281b94fba7684582f765268431206530bfa14a48fea"
+    },
+    "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz": {
+      "type": "sha256",
+      "value": "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285"
+    }
+  },
   "git_refs": {
     "https://github.com/denoland/deno.git": {
       "v2.2.12": "81da8139af85a0cb7efa9050ae6b5461b3614077"

--- a/packages/deno/brioche.lock
+++ b/packages/deno/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/denoland/deno": {
-      "v2.2.12": "81da8139af85a0cb7efa9050ae6b5461b3614077"
+      "v2.4.4": "5129d036ebd51b229adb7579e2c805859e3f95c0"
     }
   }
 }

--- a/packages/deno/brioche.lock
+++ b/packages/deno/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/denoland/deno.git": {
+      "v2.2.12": "81da8139af85a0cb7efa9050ae6b5461b3614077"
+    }
+  }
+}

--- a/packages/deno/brioche.lock
+++ b/packages/deno/brioche.lock
@@ -11,7 +11,7 @@
     }
   },
   "git_refs": {
-    "https://github.com/denoland/deno.git": {
+    "https://github.com/denoland/deno": {
       "v2.2.12": "81da8139af85a0cb7efa9050ae6b5461b3614077"
     }
   }

--- a/packages/deno/brioche.lock
+++ b/packages/deno/brioche.lock
@@ -1,15 +1,5 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz": {
-      "type": "sha256",
-      "value": "278137daa64dcaa989c85281b94fba7684582f765268431206530bfa14a48fea"
-    },
-    "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz": {
-      "type": "sha256",
-      "value": "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285"
-    }
-  },
   "git_refs": {
     "https://github.com/denoland/deno": {
       "v2.2.12": "81da8139af85a0cb7efa9050ae6b5461b3614077"

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import cmake from "cmake";
+import python from "python";
+import ninja from "ninja";
+import llvm from "llvm";
+
+import { gitCheckout } from "git";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "deno",
+  version: "2.2.12",
+};
+
+const source = gitCheckout(
+  Brioche.gitRef({
+    repository: "https://github.com/denoland/deno.git",
+    ref: `v${project.version}`,
+  }),
+);
+
+const rusty_v8 = std.download({
+  url: "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
+  hash: std.sha256Hash(
+    "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285",
+  ),
+})  .unarchive("tar", "gzip")
+.peel();;
+
+
+const deno = (): std.Recipe<std.Directory> => {
+  return cargoBuild({
+    source,
+		path: "cli",
+    env: {
+      CARGO_TARGET_DIR: "deno_target",
+      RUSTY_V8_ARCHIVE: rusty_v8,
+    },
+    runnable: "bin/deno",
+    dependencies: [std.toolchain(), cmake(), python(), ninja(), llvm()],
+  });
+}
+
+export default deno;

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -41,8 +41,24 @@ export default function deno(): std.Recipe<std.Directory> {
     env: {
       CARGO_TARGET_DIR: "deno_target",
       RUSTY_V8_ARCHIVE: rustyV8Archive,
+      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
+      [`CARGO_TARGET_${targetTripleEnvVar()}_RUSTFLAGS`]:
+        "-Clink-arg=-fuse-ld=bfd",
     },
     runnable: "bin/deno",
     dependencies: [std.toolchain, cmake, python, ninja, llvm],
   });
+}
+
+function targetTripleEnvVar(): string {
+  switch (std.CURRENT_PLATFORM) {
+    case "x86_64-linux":
+      return "X86_64_UNKNOWN_LINUX_GNU";
+    case "aarch64-linux":
+      return "AARCH64_UNKNOWN_LINUX_GNU";
+    default:
+      throw new Error(
+        `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the deno package`,
+      );
+  }
 }

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -19,21 +19,6 @@ const source = gitCheckout(
   }),
 );
 
-const rustyV8Archive = std
-  .download({
-    url: "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
-    hash: std.sha256Hash(
-      "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285",
-    ),
-  })
-  .pipe((gzip) =>
-    std.runBash`
-      zcat "$gzip" > "$BRIOCHE_OUTPUT"
-    `
-      .env({ gzip })
-      .toFile(),
-  );
-
 export default function deno(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
@@ -48,6 +33,31 @@ export default function deno(): std.Recipe<std.Directory> {
     runnable: "bin/deno",
     dependencies: [std.toolchain, cmake, python, ninja, llvm],
   });
+}
+
+function rustyV8Archive(): std.Recipe<std.File> {
+  switch (std.CURRENT_PLATFORM) {
+    case "x86_64-linux":
+      return Brioche.download(
+        "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
+      ).pipe(gunzip);
+    case "aarch64-linux":
+      return Brioche.download(
+        "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz",
+      ).pipe(gunzip);
+    default:
+      throw new Error(
+        `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the deno package`,
+      );
+  }
+}
+
+function gunzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
+  return std.runBash`
+    gunzip -c "$file" > "$BRIOCHE_OUTPUT"
+  `
+    .env({ file })
+    .toFile();
 }
 
 function targetTripleEnvVar(): string {

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -19,26 +19,25 @@ const source = gitCheckout(
   }),
 );
 
-const rusty_v8 = std.download({
-  url: "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
-  hash: std.sha256Hash(
-    "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285",
-  ),
-})  .unarchive("tar", "gzip")
-.peel();;
+const rustyV8Archive = std
+  .download({
+    url: "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
+    hash: std.sha256Hash(
+      "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285",
+    ),
+  })
+  .unarchive("tar", "gzip")
+  .peel();
 
-
-const deno = (): std.Recipe<std.Directory> => {
+export default function deno(): std.Recipe<std.Directory> {
   return cargoBuild({
     source,
-		path: "cli",
+    path: "cli",
     env: {
       CARGO_TARGET_DIR: "deno_target",
-      RUSTY_V8_ARCHIVE: rusty_v8,
+      RUSTY_V8_ARCHIVE: rustyV8Archive,
     },
     runnable: "bin/deno",
-    dependencies: [std.toolchain(), cmake(), python(), ninja(), llvm()],
+    dependencies: [std.toolchain, cmake, python, ninja, llvm],
   });
 }
-
-export default deno;

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -34,6 +34,13 @@ export default function deno(): std.Recipe<std.Directory> {
       [`CARGO_TARGET_${cargoTargetTripleEnvVar()}_RUSTFLAGS`]:
         "-Clink-arg=-fuse-ld=bfd",
     },
+    buildParams: {
+      // The `release` profile builds with full LTO, which uses more memory
+      // than what's available on Brioche's aarch64 runner for CI builds. So
+      // we use the `release-lite` profile instead, which uses thin LTO,
+      // which uses way less memory and builds a lot faster
+      profile: "release-lite",
+    },
     unsafe: {
       networking: true,
     },

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -24,8 +24,16 @@ export default function deno(): std.Recipe<std.Directory> {
     source,
     path: "cli",
     env: {
+      // Pre-built V8 library used for building Deno
       RUSTY_V8_ARCHIVE: rustyV8Archive,
+
+      // Build-time scripts dynamically load `libclang`, so ensure the standard
+      // system libraries can be dynamically loaded
       LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
+
+      // Deno currently uses the linker flag `--export-dynamic-symbol-list`, so
+      // ensure we use ld.bfd since ld.gold doesn't support this flag (at
+      // the time of writing)
       [`CARGO_TARGET_${cargoTargetTripleEnvVar()}_RUSTFLAGS`]:
         "-Clink-arg=-fuse-ld=bfd",
     },
@@ -51,6 +59,9 @@ function rustyV8Archive(): std.Recipe<std.File> {
   }
 }
 
+/**
+ * Decompress a gzip-compressed recipe.
+ */
 function gunzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
   return std.runBash`
     gunzip -c "$file" > "$BRIOCHE_OUTPUT"
@@ -59,6 +70,10 @@ function gunzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
     .toFile();
 }
 
+/**
+ * Return the current platform's target triple in `SCREAMING_SNAKE_CASE`, which
+ * Cargo uses for target-specific environment variables.
+ */
 function cargoTargetTripleEnvVar(): string {
   switch (std.CURRENT_PLATFORM) {
     case "x86_64-linux":

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -9,7 +9,7 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "deno",
-  version: "2.2.12",
+  version: "2.4.4",
   repository: "https://github.com/denoland/deno",
 };
 

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -10,11 +10,12 @@ import { cargoBuild } from "rust";
 export const project = {
   name: "deno",
   version: "2.2.12",
+  repository: "https://github.com/denoland/deno",
 };
 
 const source = gitCheckout(
   Brioche.gitRef({
-    repository: "https://github.com/denoland/deno.git",
+    repository: project.repository,
     ref: `v${project.version}`,
   }),
 );
@@ -40,6 +41,29 @@ export default function deno(): std.Recipe<std.Directory> {
     runnable: "bin/deno",
     dependencies: [std.toolchain, cmake, python, ninja, llvm],
   });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    deno --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(deno)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `deno ${project.version} `;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
 }
 
 function rustyV8Archive(): std.Recipe<std.File> {

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -24,10 +24,9 @@ export default function deno(): std.Recipe<std.Directory> {
     source,
     path: "cli",
     env: {
-      CARGO_TARGET_DIR: "deno_target",
       RUSTY_V8_ARCHIVE: rustyV8Archive,
       LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
-      [`CARGO_TARGET_${targetTripleEnvVar()}_RUSTFLAGS`]:
+      [`CARGO_TARGET_${cargoTargetTripleEnvVar()}_RUSTFLAGS`]:
         "-Clink-arg=-fuse-ld=bfd",
     },
     runnable: "bin/deno",
@@ -60,7 +59,7 @@ function gunzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
     .toFile();
 }
 
-function targetTripleEnvVar(): string {
+function cargoTargetTripleEnvVar(): string {
   switch (std.CURRENT_PLATFORM) {
     case "x86_64-linux":
       return "X86_64_UNKNOWN_LINUX_GNU";

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -1,11 +1,10 @@
 import * as std from "std";
+import { gitCheckout } from "git";
+import { cargoBuild } from "rust";
 import cmake from "cmake";
 import python from "python";
 import ninja from "ninja";
 import llvm from "llvm";
-
-import { gitCheckout } from "git";
-import { cargoBuild } from "rust";
 
 export const project = {
   name: "deno",

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -26,8 +26,13 @@ const rustyV8Archive = std
       "406a453645473bd8f8b9a818342e57dc95627fcd1155ace9eb7a2aadd5985285",
     ),
   })
-  .unarchive("tar", "gzip")
-  .peel();
+  .pipe((gzip) =>
+    std.runBash`
+      zcat "$gzip" > "$BRIOCHE_OUTPUT"
+    `
+      .env({ gzip })
+      .toFile(),
+  );
 
 export default function deno(): std.Recipe<std.Directory> {
   return cargoBuild({

--- a/packages/deno/project.bri
+++ b/packages/deno/project.bri
@@ -25,9 +25,6 @@ export default function deno(): std.Recipe<std.Directory> {
     source,
     path: "cli",
     env: {
-      // Pre-built V8 library used for building Deno
-      RUSTY_V8_ARCHIVE: rustyV8Archive,
-
       // Build-time scripts dynamically load `libclang`, so ensure the standard
       // system libraries can be dynamically loaded
       LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
@@ -37,6 +34,9 @@ export default function deno(): std.Recipe<std.Directory> {
       // the time of writing)
       [`CARGO_TARGET_${cargoTargetTripleEnvVar()}_RUSTFLAGS`]:
         "-Clink-arg=-fuse-ld=bfd",
+    },
+    unsafe: {
+      networking: true,
     },
     runnable: "bin/deno",
     dependencies: [std.toolchain, cmake, python, ninja, llvm],
@@ -64,34 +64,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({ project });
-}
-
-function rustyV8Archive(): std.Recipe<std.File> {
-  switch (std.CURRENT_PLATFORM) {
-    case "x86_64-linux":
-      return Brioche.download(
-        "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz",
-      ).pipe(gunzip);
-    case "aarch64-linux":
-      return Brioche.download(
-        "https://github.com/denoland/rusty_v8/releases/download/v135.1.0/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz",
-      ).pipe(gunzip);
-    default:
-      throw new Error(
-        `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the deno package`,
-      );
-  }
-}
-
-/**
- * Decompress a gzip-compressed recipe.
- */
-function gunzip(file: std.RecipeLike<std.File>): std.Recipe<std.File> {
-  return std.runBash`
-    gunzip -c "$file" > "$BRIOCHE_OUTPUT"
-  `
-    .env({ file })
-    .toFile();
 }
 
 /**

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -148,6 +148,7 @@ interface CargoBuildParameters {
   features?: string[];
   defaultFeatures?: boolean;
   allFeatures?: boolean;
+  profile?: string;
   bins?: boolean | string[];
   examples?: boolean | string[];
 }
@@ -247,6 +248,10 @@ export function cargoBuild(options: CargoBuildOptions) {
 
   if (options.buildParams?.allFeatures ?? false) {
     extraArgs.push("--all-features");
+  }
+
+  if (options.buildParams?.profile != null) {
+    extraArgs.push("--profile", options.buildParams.profile);
   }
 
   const bins = options.buildParams?.bins;


### PR DESCRIPTION
Closes #336 

This PR adds a package for [Deno](https://github.com/denoland/deno), a modern runtime for JavaScript and TypeScript.

Thanks to @rawkode and @nz366 for work-in-progress code towards Deno! This PR started from https://github.com/brioche-dev/brioche-packages/issues/336#issuecomment-3146436138 as a base and grew from there. A few notes:

- I needed to set `$LD_LIBRARY_PATH` during the build. Something (I think bindgen?) dynamically loads `libclang`, which failed by default due to not finding standard libraries like `libz.so.1`-- setting `$LD_LIBRARY_PATH` resolves this.
- I set an env var to pass the Rust flag `-Clink-arg=-fuse-ld=bfd`, which switches to using `ld.bfd` instead of `ld.gold`. The Deno build uses the linker option `--export-dynamic-symbol-list` (see [`ext/napi/lib.rs`](https://github.com/denoland/deno/blob/80c0998a0391ed22f325e0184a119ae17916891e/ext/napi/lib.rs#L708)), which `ld.gold` does not support.
- I removed the manual `RUSTY_V8_ARCHIVE` download, and instead enabled the `unsafe.networking` option to let Deno download the V8 archive itself. I couldn't think of an easy way to update the V8 archive URL as part of the live-update script, so this change sacrifices some hermeticity for maintainability for now.
  - I'm open to flipping this back if someone contributes a live-update script to update the V8 archive URL, but my long-term preference would be to build V8 from source instead (but that poses its own challenges in the short-term)
- **Update**: Switched to using the `release-lite` profile when building Deno. From what I can tell, the main difference from the `release` profile is that it uses thin LTO instead of full LTO, so it builds _much_ quicker and with less memory (since I was having problems getting the build to finish on our aarch64 runner, see comments for more context)