### PR TITLE
feat(libice): add package

### DIFF
--- a/packages/libice/brioche.lock
+++ b/packages/libice/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libICE-1.1.2.tar.xz": {
+      "type": "sha256",
+      "value": "974e4ed414225eb3c716985df9709f4da8d22a67a2890066bc6dfc89ad298625"
+    }
+  }
+}

--- a/packages/libice/project.bri
+++ b/packages/libice/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import xorgproto from "xorgproto";
+import xtrans from "xtrans";
+
+export const project = {
+  name: "libice",
+  version: "1.1.2",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libICE-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libice(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, xtrans)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion ice | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libice)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libICE") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libICE-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libice`](https://www.x.org/releases/X11R7.7/doc/libICE/ICElib.html): the Inter-Client Exchange (ICE) protocol is intended to provide a framework for building such protocols, allowing them to make use of common negotiation mechanisms and to be multiplexed over a single transport connection.

```bash
Build finished, completed 4 jobs in 22.72s
Result: 6159ca39b5d704605fb3be7d46567fbcb00d77db1586a83302cbb5490c7e5620

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 3 jobs in 18.31s
Running brioche-run
{
  "name": "libice",
  "version": "1.1.2"
}

⏵ Task `Run package live-update` finished successfully
```