### PR TITLE
feat(libsm): add package

### DIFF
--- a/packages/libsm/brioche.lock
+++ b/packages/libsm/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libSM-1.2.6.tar.xz": {
+      "type": "sha256",
+      "value": "be7c0abdb15cbfd29ac62573c1c82e877f9d4047ad15321e7ea97d1e43d835be"
+    }
+  }
+}

--- a/packages/libsm/project.bri
+++ b/packages/libsm/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import libice from "libice";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import xorgproto from "xorgproto";
+import xtrans from "xtrans";
+
+export const project = {
+  name: "libsm",
+  version: "1.2.6",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libSM-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libsm(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-docs=no
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, xtrans, libice)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sm | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libsm)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libSM") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libSM-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libsm`](https://www.x.org/releases/X11R7.7/doc/libSM/SMlib.html): the X Session Management Protocol (XSMP) is to provide a uniform mechanism for users to save and restore their sessions.

```bash
Running brioche-run
{
  "name": "libsm",
  "version": "1.2.6"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.81s
Result: ed23977807711a5b8a29a2e5cf6350b0573444f56cb4902483e6fd692c189fba

⏵ Task `Run package test` finished successfully
```