### PR TITLE
feat(libxc): add package

### DIFF
--- a/packages/libxc/brioche.lock
+++ b/packages/libxc/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://gitlab.com/libxc/libxc.git": {
+      "7.0.0": "7bd5bb41415968db94c499a2f093309c9a2dcf53"
+    }
+  }
+}

--- a/packages/libxc/project.bri
+++ b/packages/libxc/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libxc",
+  version: "7.0.0",
+  repository: "https://gitlab.com/libxc/libxc.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libxc(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    runnable: "bin/xc-info",
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      BUILD_TESTING: "OFF",
+      BUILD_SHARED_LIBS: "ON",
+    },
+    env: {
+      CMAKE_BUILD_PARALLEL_LEVEL: "16",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libxc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libxc`](https://x.org/releases/current/doc/libX11/libX11/libX11.html): Xlib is a C subroutine library that application programs (clients) use to interface with the window system by means of a stream connection.

```bash
Build finished, completed (no new jobs) in 7.90s
Running brioche-run
{
  "name": "libxc",
  "version": "7.0.0",
  "repository": "https://gitlab.com/libxc/libxc.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.93s
Result: 2299509fc71b796f489786b7b9039cc53a424e92710f7a97b6dfafc7c4010c01

⏵ Task `Run package test` finished successfully
```