### PR TITLE
Add `coturn` package

### DIFF
--- a/packages/coturn/brioche.lock
+++ b/packages/coturn/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/coturn/coturn.git": {
+      "4.7.0": "678996a52954ddc7a44afd9f72f5b5c647e41083"
+    }
+  }
+}

--- a/packages/coturn/project.bri
+++ b/packages/coturn/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libevent from "libevent";
+import openssl from "openssl";
+
+export const project = {
+  name: "coturn",
+  version: "4.7.0",
+  repository: "https://github.com/coturn/coturn.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function coturn(): std.Recipe<std.Directory> {
+  return (
+    cmakeBuild({
+      source,
+      dependencies: [std.toolchain, libevent, openssl],
+    })
+      // Fix broken absolute-path symlink
+      .insert("bin/turnadmin", std.symlink({ target: "turnserver" }))
+      .pipe((recipe) =>
+        // Ensure all binaries are marked as executable
+        std.runBash`
+          find bin -type f -exec chmod +x {} +
+        `
+          .outputScaffold(recipe)
+          .currentDir(std.outputPath)
+          .toDirectory(),
+      )
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    turnserver --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(coturn)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
This PR adds a package for [coturn](https://github.com/coturn/coturn), a free open source implementation of TURN and STUN Server.

This includes basic support, with just `libevent` and `openssl` as dependencies. coturn also optionally supports Prometheus, SQLite, Postgres, and MySQL which aren't enabled in this PR (we have packages for SQLite and Postgres today, but the CMake build didn't pick them up automatically when added as dependencies). Personally, I mainly added this to be able to use the various TURN utils included by default, so I haven't really tried the main server very thoroughly.