### PR TITLE
feat(libxau): add package

### DIFF
--- a/packages/libxau/brioche.lock
+++ b/packages/libxau/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXau-1.0.12.tar.xz": {
+      "type": "sha256",
+      "value": "74d0e4dfa3d39ad8939e99bda37f5967aba528211076828464d2777d477fc0fb"
+    }
+  }
+}

--- a/packages/libxau/project.bri
+++ b/packages/libxau/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxau",
+  version: "1.0.12",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXau-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxau(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xau | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxau)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXau") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXau-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package `libxau`: a library implementing the X11 Authorization Protocol. This is useful for restricting client access to the display.

```bash
Build finished, completed (no new jobs) in 0.77s
Result: 66e88717a4e5bb00549b21f35c2264ac2ccee5509b70a8ae3660a9f41857cc32

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "libxau",
  "version": "1.0.12"
}

⏵ Task `Run package live-update` finished successfully
```