### PR TITLE
Update awscli recipe

### DIFF
--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -106,7 +106,7 @@ export default function awsCli(): std.Recipe<std.Directory> {
 
 export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
-    aws --version | tr -d '\n' | tee "$BRIOCHE_OUTPUT"
+    aws --version | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(awsCli)
     .toFile();

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -22,7 +22,7 @@ const source = Brioche.gitCheckout({
 
 export default function awsCli(): std.Recipe<std.Directory> {
   // Create a venv
-  let venv = std.recipe(python({ version: "3.12" }));
+  let venv = std.recipe(python);
 
   // Download dependencies from PyPI
   // SAFETY: the `requirements-*-lock.txt` files have hashes, and the


### PR DESCRIPTION
New output when testing the recipe:

```bash
129786 │ aws-cli/2.28.15 Python/3.13.1 Linux/6.8.0-71-generic source/aarch64
 0.95s ✓ Process 129786
Build finished, completed 1 job in 2.85s
Result: 4908d009e49e34b7b6feaec82f5729d9c108123522db5c89a3af43b4193fdf3c

⏵ Task `Run package test` finished successfully
```