### PR TITLE
refactor: simplify calling python recipe in venv creation in asciinema and meson packages

### DIFF
--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -23,7 +23,7 @@ const pipDependencies = std.directory({
 
 export default function asciinema(): std.Recipe<std.Directory> {
   // Create a venv
-  let venv = std.recipe(python());
+  let venv = std.recipe(python);
 
   // Install setuptools from the archive we downloaded. Setuptools is the
   // only dependency we need installed in the venv, the rest will be installed

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -23,7 +23,7 @@ const pipDependencies = std.directory({
 
 export default function meson(): std.Recipe<std.Directory> {
   // Create a venv
-  let venv = std.recipe(python());
+  let venv = std.recipe(python);
 
   // Install setuptools from the archive we downloaded. Setuptools is the
   // only dependency we need installed in the venv, the rest will be installed


### PR DESCRIPTION
Nothing more than just removing two parenthesis when calling python recipe. I saw it when working on #1091 