### PR TITLE
Add `mutagen` package

### DIFF
--- a/packages/mutagen/brioche.lock
+++ b/packages/mutagen/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mutagen-io/mutagen.git": {
+      "v0.18.1": "a225ae50aee3d7ebb59139203cb84e8a6a3ff4bf"
+    }
+  }
+}

--- a/packages/mutagen/project.bri
+++ b/packages/mutagen/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import go from "go";
+
+export const project = {
+  name: "mutagen",
+  version: "0.18.1",
+  repository: "https://github.com/mutagen-io/mutagen.git",
+};
+
+export const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function mutagen(): std.Recipe<std.Directory> {
+  // Run Mutagen's custom build script, which builds the main CLI and
+  // cross-compiles the agent for many different architectures
+  return std.runBash`
+    go run scripts/build.go
+
+    mkdir -p "$BRIOCHE_OUTPUT/bin"
+    mv build/mutagen build/mutagen-agents.tar.gz "$BRIOCHE_OUTPUT/bin"
+  `
+    .dependencies(go)
+    .unsafe({ networking: true })
+    .workDir(source)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/mutagen"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    mutagen --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(mutagen)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const version = result.split("\n").at(0);
+
+  // Check that the result contains the expected version
+  const expected = `Mutagen version ${project.version}`;
+  std.assert(version === expected, `expected '${expected}', got '${version}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
This PR adds a package for [Mutagen](https://github.com/mutagen-io/mutagen), a tool for fast file synchronization and network forwarding for remote development.

I considered building it using `goBuild`, but it seemed like a pretty tall order to also build the agent bundle, considering the set of platforms they support out-of-the-box:

- `darwin_amd64`
- `darwin_arm64`
- `freebsd_amd64`
- `linux_amd64`
- `linux_arm64`
- `windows_amd64`

(It's not hard to compile all of these in Go, but we don't have very many options for cross-compilation yet)

They provide a simple build script under `scripts/build.go`, which is [the recommended way to build Mutagen](https://github.com/mutagen-io/mutagen/blob/03c982a3a34e1dfe496f4bcd4ee7ced34307db68/BUILDING.md), so I decided to just use that for the build. This meant enabling `unsafe({ networking: true })`, but it seemed simpler as a first pass for now.