### PR TITLE
Add `socat` package

### DIFF
--- a/packages/socat/brioche.lock
+++ b/packages/socat/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz": {
+      "type": "sha256",
+      "value": "a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4"
+    }
+  }
+}

--- a/packages/socat/project.bri
+++ b/packages/socat/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import openssl from "openssl";
+import { nushellRunnable } from "nushell";
+
+export const project = {
+  name: "socat",
+  version: "1.8.0.3",
+};
+
+const source = Brioche.download(
+  `http://www.dest-unreach.org/socat/download/socat-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function socat(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, openssl)
+    .workDir(source)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/socat"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    socat -V | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(socat)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `socat version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got: ${result}`,
+  );
+
+  // Check that the result includes OpenSSL support
+  std.assert(
+    result.includes("#define WITH_OPENSSL 1"),
+    "expected OpenSSL support",
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return nushellRunnable`
+    let version = http get http://www.dest-unreach.org/socat/
+      | lines
+      | where {|it| $it | str contains 'href="download/socat-' }
+      | parse --regex '<a href="download/socat-(?<version>(?<major>[\\d]+)\\.(?<minor>[\\d]+)(?:\\.(?<patch>[\\d]+)(?:\\.(?<extra>[\\d]+))?)?)\\.tar.gz"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
This PR adds a package for [socat](http://www.dest-unreach.org/socat/)[^1], a "multipurpose relay". Basically, it allows for piping between all sorts of different transports (TCP, UDP, Unix sockets, stdio, etc.).

[^1]: I had trouble accessing that site for a while because I have HTTPS-only mode enabled in my browser. The site is only accessible over HTTP, while trying to access it over HTTPS just returns an error page with a self-signed cert...