### PR TITLE
add package keep-sorted

### DIFF
--- a/packages/keep_sorted/brioche.lock
+++ b/packages/keep_sorted/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/keep-sorted.git": {
+      "v0.7.1": "c71803fd297b5736f3bfab1cfd84424ca52e961a"
+    }
+  }
+}

--- a/packages/keep_sorted/project.bri
+++ b/packages/keep_sorted/project.bri
@@ -3,7 +3,7 @@ import git, { gitCheckout } from "git";
 import { goBuild } from "go";
 
 export const project = {
-  name: "keep-sorted",
+  name: "keep_sorted",
   version: "0.7.1",
   repository: "https://github.com/google/keep-sorted.git",
   extra: {

--- a/packages/keep_sorted/project.bri
+++ b/packages/keep_sorted/project.bri
@@ -17,6 +17,7 @@ const gitRef = await Brioche.gitRef({
 });
 
 const source = gitCheckout(gitRef).pipe((recipe) =>
+  // Create a git tag in the repo, which is used as the version number
   std.runBash`
     git tag "$revision"
   `

--- a/packages/keep_sorted/project.bri
+++ b/packages/keep_sorted/project.bri
@@ -6,9 +6,6 @@ export const project = {
   name: "keep_sorted",
   version: "0.7.1",
   repository: "https://github.com/google/keep-sorted.git",
-  extra: {
-    releaseDate: "2025-08-20T21:05:58Z",
-  },
 };
 
 const gitRef = await Brioche.gitRef({
@@ -49,7 +46,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `v${project.version} (${project.extra.releaseDate})`;
+  const expected = `v${project.version}`;
   std.assert(
     result.startsWith(expected),
     `expected '${expected}', got '${result}'`,

--- a/packages/keep_sorted/project.bri
+++ b/packages/keep_sorted/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import git, { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "keep-sorted",
+  version: "0.7.1",
+  repository: "https://github.com/google/keep-sorted.git",
+  extra: {
+    releaseDate: "2025-08-20T21:05:58Z",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+const source = gitCheckout(gitRef).pipe((recipe) =>
+  std.runBash`
+    git tag "$revision"
+  `
+    .dependencies(git)
+    .env({ revision: `v${project.version}` })
+    .outputScaffold(recipe)
+    .currentDir(std.outputPath)
+    .toDirectory(),
+);
+
+export default function keepSorted(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/keep-sorted",
+    dependencies: [git],
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    keep-sorted --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(keepSorted)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version} (${project.extra.releaseDate})`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
This PR adds [keep-sorted](https://github.com/google/keep-sorted) which has a need to use [git] as a dependency during go build to pull the commit information. Also it relies on knowing the current tag in order to create the version command accordingly.