### PR TITLE
Uniformize python building recipe

### DIFF
--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -80,7 +80,6 @@ export default function awsCli(): std.Recipe<std.Directory> {
     .env({
       PATH: std.tpl`${std.outputPath}/bin`,
       PIP_FIND_LINKS: dependencies,
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
       PIP_NO_INDEX: "1",
     })
     .outputScaffold(venv)


### PR DESCRIPTION
Just to keep things uniformized between recipes. The other recipes were already formatted this way.