### PR TITLE
fix: resolve a typo in TSDoc comments

### DIFF
--- a/packages/nushell/run_nushell.bri
+++ b/packages/nushell/run_nushell.bri
@@ -10,7 +10,7 @@ import nushell from "/";
  * extra dependencies or environment variables using `.dependencies()`
  * or `.env()`, respectively, along with other process options.
  *
- * @description See also `nushellRunnable,` which will return a recipe that
+ * @description See also `nushellRunnable` which will return a recipe that
  * packages up a Nushell script that can be run outside of Brioche.
  *
  * @param strings - The template string parts for the Nushell script.

--- a/packages/std/extra/run_bash.bri
+++ b/packages/std/extra/run_bash.bri
@@ -10,7 +10,7 @@ import { tools } from "/toolchain";
  * extra dependencies or environment variables using `.dependencies()`
  * or `.env()`, respectively, along with other process options.
  *
- * @description See also `std.bashRunnable,` which will return a recipe that packages
+ * @description See also `std.bashRunnable` which will return a recipe that packages
  * up a Bash script that can be run outside of Brioche.
  *
  * @param strings - The template string parts for the Bash script.


### PR DESCRIPTION
Resolve a typo seen in TSDoc comments of `nushellRunnable` and `bashRunnable`