### PR TITLE
chore(terraform): remove a workaround for Go 1.24

### DIFF
--- a/packages/terraform/project.bri
+++ b/packages/terraform/project.bri
@@ -10,15 +10,7 @@ export const project = {
 const source = Brioche.gitCheckout({
   repository: project.repository,
   ref: `v${project.version}`,
-}).pipe((recipe) =>
-  std.runBash`
-    # Workaround for Go 1.24, see: https://github.com/NixOS/nixpkgs/blob/2631b0b7abcea6e640ce31cd78ea58910d31e650/pkgs/applications/networking/cluster/terraform/default.nix#L48
-    cd "$BRIOCHE_OUTPUT"
-    sed -i 's/godebug tlskyber=0/godebug tlsmlkem=0/g' go.mod
-  `
-    .outputScaffold(recipe)
-    .toDirectory(),
-);
+});
 
 export default function terraform(): std.Recipe<std.Directory> {
   return goBuild({


### PR DESCRIPTION
I removed the workaround we had for Terraform recipe, and after testing on my terraform projects the following commands, I didn't see any issues, did I miss something or can we safely remove this workaround now ?

```bash
terraform init
terraform plan
terraform apply
```

