### PR TITLE
chore(std): improve unreachable function error message

### DIFF
--- a/packages/std/core/utils.bri
+++ b/packages/std/core/utils.bri
@@ -38,7 +38,15 @@ export function assert(
  */
 export function unreachable(never: never): never {
   const value: any = never;
-  throw new Error(`reached unreachable code with value: ${value}`);
+
+  // If this is an object, stringify it. Otherwise, print it as a string
+  if (typeof value === "object") {
+    throw new Error(
+      `reached unreachable code with object value: ${JSON.stringify(value)}`,
+    );
+  } else {
+    throw new Error(`reached unreachable code with value: ${value}`);
+  }
 }
 
 export type Awaitable<T> = T | Promise<T>;


### PR DESCRIPTION
It improves the error message for the unreachable function.

Before this modification, the message printed when an object was injected in this function was: `reached unreachable code with value: [Object object]`. Now this function will stringily the object before to print it.