### PR TITLE
feat(cspell): add package

### DIFF
--- a/packages/cspell/brioche.lock
+++ b/packages/cspell/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/cspell/project.bri
+++ b/packages/cspell/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "cspell",
+  version: "9.2.0",
+  extra: {
+    packageName: "cspell",
+  },
+};
+
+export default function cspell(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/cspell"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cspell --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cspell)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`cspell`](https://cspell.org): a spell checker for code

```bash
Build finished, completed (no new jobs) in 15.86s
Running brioche-run
{
  "name": "cspell",
  "version": "9.2.0",
  "extra": {
    "packageName": "cspell"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 16.51s
Result: 960c5b058bb28a5067c9f34d21180b807ea2c165d12cce329c0dc84e124b362e

⏵ Task `Run package test` finished successfully
```