### PR TITLE
Add the ability to update multiple versions for a recipe

### DIFF
--- a/packages/std/extra/live_update/from_github_releases.bri
+++ b/packages/std/extra/live_update/from_github_releases.bri
@@ -15,11 +15,13 @@ import type {} from "nushell";
  * @param versionDash - The version of the project (converted in dash format).
  * @param versionUnderscore - The version of the project (converted in underscore format).
  * @param releaseDate - The release date of the project in the format `YYYY-MM-DD`
+ * @param otherVersions - The other versions of the project.
  */
 interface LiveUpdateFromGithubReleasesProjectExtraOptions {
   versionDash?: string;
   versionUnderscore?: string;
   releaseDate?: string;
+  otherVersions?: { [key: string]: string };
 }
 
 /**

--- a/packages/std/extra/live_update/from_github_tags.bri
+++ b/packages/std/extra/live_update/from_github_tags.bri
@@ -14,10 +14,12 @@ import type {} from "nushell";
  *
  * @param versionDash - The version of the project (converted in dash format).
  * @param versionUnderscore - The version of the project (converted in underscore format).
+ * @param otherVersions - The other versions of the project.
  */
 interface LiveUpdateFromGithubTagsProjectExtraOptions {
   versionDash?: string;
   versionUnderscore?: string;
+  otherVersions?: { [key: string]: string };
 }
 
 /**


### PR DESCRIPTION
This PR updates `std.liveUpdateFromGithubTags()` and `std.liveUpdateFromGithubReleases()` to handle multiple versions for a single recipe. It'll be as simple as just updating the `project` variable to include the other possible versions as it's done in the `python` recipe:

```ts
export const project = {
  name: "python",
  version: "3.13.1",
  repository: "https://github.com/python/cpython",
  extra: {
    otherVersions: {
      "3.13": "3.13.1",
      "3.12": "3.12.8",
    },
  },
};
```

Everything will be handled behind the scene when calling `std.liveUpdateFromGithubTags()` and `std.liveUpdateFromGithubReleases()`. The versions will be scraped from the Github API and only the most recent versions will be kept per supported version.