### PR TITLE
feat(python): add live update capability

### DIFF
--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -6,6 +6,7 @@ import sqlite from "sqlite";
 export const project = {
   name: "python",
   version: "3.13.1",
+  repository: "https://github.com/python/cpython",
   extra: {
     otherVersions: {
       "3.13": "3.13.1",
@@ -174,6 +175,10 @@ export function test(): std.Recipe<std.Directory> {
   });
 
   return std.merge(...tests);
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
 }
 
 async function fixShebangs(


### PR DESCRIPTION
Part of https://github.com/brioche-dev/brioche-packages/issues/883. This finally adds the live update capability for `python` recipe by relying on the [recently updated](https://github.com/brioche-dev/brioche-packages/pull/1103) `std.liveUpdateFromGithubTags` method:

```bash
Build finished, completed (no new jobs) in 9.88s
Running brioche-run
{
  "name": "python",
  "version": "3.13.7",
  "repository": "https://github.com/python/cpython",
  "extra": {
    "otherVersions": {
      "3.13": "3.13.7",
      "3.12": "3.12.11"
    }
  }
}

⏵ Task `Run package live-update` finished successfully
```