### PR TITLE
Update cmakeBuild method to use workDir

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -188,7 +188,7 @@ export function cmakeBuild(
       fi
     done
 
-    cmake "$source/$path" "\${cmake_args[@]}"
+    cmake "$path" "\${cmake_args[@]}"
     cmake --build . --config "$config"
     cmake --install . --prefix="$BRIOCHE_OUTPUT"
 
@@ -201,9 +201,9 @@ export function cmakeBuild(
     fi
   `
     .dependencies(...dependencies, cmake)
+    .workDir(source)
     .env({
       ...options.env,
-      source,
       path: options.path ?? ".",
       config,
       cmake_num_set_entries: setEntriesWithIndices.length.toString(),

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -188,9 +188,11 @@ export function cmakeBuild(
       fi
     done
 
-    cmake "$path" "\${cmake_args[@]}"
-    cmake --build . --config "$config"
-    cmake --install . --prefix="$BRIOCHE_OUTPUT"
+    BUILD_DIR=$(mktemp -p . -d build.XXXXXX)
+
+    cmake -S "$path" -B "$BUILD_DIR" "\${cmake_args[@]}"
+    cmake --build "$BUILD_DIR" --config "$config"
+    cmake --install "$BUILD_DIR" --prefix="$BRIOCHE_OUTPUT"
 
     if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
       # Ensure the lib folder exists

--- a/packages/wabt/project.bri
+++ b/packages/wabt/project.bri
@@ -1,5 +1,5 @@
 import * as std from "std";
-import cmake from "cmake";
+import { cmakeBuild } from "cmake";
 import python from "python";
 
 export const project = {
@@ -17,32 +17,16 @@ const source = Brioche.gitCheckout({
 });
 
 export default function wabt(): std.Recipe<std.Directory> {
-  return std.runBash`
-    mkdir build
-    cd build
-    cmake ..
-    cmake --build .
-    cmake --install . --prefix="$BRIOCHE_OUTPUT"
-
-    if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
-      # Ensure the lib folder exists
-      mkdir -p "$BRIOCHE_OUTPUT/lib"
-
-      # Create relative symlinks for lib64 contents to lib folder
-      ln --symbolic --relative "$BRIOCHE_OUTPUT"/lib64/* "$BRIOCHE_OUTPUT/lib/"
-    fi
-  `
-    .workDir(source)
-    .dependencies(std.toolchain, python, cmake)
-    .toDirectory()
-    .pipe(std.pkgConfigMakePathsRelative)
-    .pipe((recipe) =>
-      std.setEnv(recipe, {
-        CPATH: { append: [{ path: "include" }] },
-        LIBRARY_PATH: { append: [{ path: "lib" }] },
-        CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
-      }),
-    );
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, python],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {


### PR DESCRIPTION
In order to resolve the recently issue with `llvm` recipe (#1124), due to building in a not writable directory:

```bash
[3h 0m35s] [100%] Linking CXX shared library ../../../../lib/liblldb.so
[3h 0m37s] Traceback (most recent call last):
[3h 0m37s]   File "/home/brioche-runner-c9b0b24f22bf3645600bd6801f4dbe9fb01c175235bd99be6a7c76af4346d78c/.local/share/brioche/locals/01cef55de38da0d1b29aaac3f1dbd80d07922094f29de52b3b1512f54b119b8e/lldb/scripts/version-header-fix.py", line 62, in <module>
[3h 0m37s]     main()
[3h 0m37s]     ~~~~^^
[3h 0m37s]   File "/home/brioche-runner-c9b0b24f22bf3645600bd6801f4dbe9fb01c175235bd99be6a7c76af4346d78c/.local/share/brioche/locals/01cef55de38da0d1b29aaac3f1dbd80d07922094f29de52b3b1512f54b119b8e/lldb/scripts/version-header-fix.py", line 36, in main
[3h 0m37s]     with open(output_path, "w") as output_file:
[3h 0m37s]          ~~~~^^^^^^^^^^^^^^^^^^
[3h 0m37s] PermissionError: [Errno 13] Permission denied: '/home/brioche-runner-c9b0b24f22bf3645600bd6801f4dbe9fb01c175235bd99be6a7c76af4346d78c/work/include/lldb/lldb-defines.h'
[3h 0m37s] make[2]: *** [tools/lldb/source/API/CMakeFiles/liblldb.dir/build.make:1808: lib/liblldb.so.21.1.0] Error 1
[3h 0m37s] make[2]: *** Deleting file 'lib/liblldb.so.21.1.0'
[3h 0m37s] make[1]: *** [CMakeFiles/Makefile2:206945: tools/lldb/source/API/CMakeFiles/liblldb.dir/all] Error 2
[3h 0m37s] make: *** [Makefile:156: all] Error 2
[3h 0m37s] [process exited with code 2]
```

Which is the same issue with `wabt` recipe (after tweaking it to use `cmakeBuild()`):

```bash
> brioche build -o /tmp/output -p packages/wabt/
 INFO build:bake:bake_process: brioche_core::bake::process: keeping temporary bake dir /home/jaudiger.linux/.local/share/brioche/process-temp/01K424RP45MYJPV4BWHMVEKN3D meta=Meta { source: Some([StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/core/recipes/process.bri"), line_number: Some(257), column_number: Some(14) }, StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/cmake/project.bri"), line_number: Some(212), column_number: Some(6) }, StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/wabt/project.bri"), line_number: Some(20), column_number: Some(10) }]) }
588525 │ -- Looking for __i386__ - not found
       │ -- Looking for __SSE2_MATH__
       │ -- Looking for __SSE2_MATH__ - not found
       │ -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
       │ -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
       │ -- Found Threads: TRUE
       │ -- Found Python3: /home/brioche-runner-a111fee76738a51294f0f56438aaa79c623b631adfe6db57ca23baa43a55282a/.local/share/brioche/locals/911cab99f3a3762da1bf94b5a6c137a007ee887fe7f5e77264909fd76d0eb5c4/bin/python3.13 (found suitable version "3.13.7", minimum required is "3.5") found components: Interpreter
       │ -- Configuring done (1.5s)
       │ -- Generating done (0.1s)
       │ -- Build files have been written to: /home/brioche-runner-a111fee76738a51294f0f56438aaa79c623b631adfe6db57ca23baa43a55282a/work
       │ [  0%] Generating gen-wasm2c-prebuilt
       │ CMake Error at /home/brioche-runner-a111fee76738a51294f0f56438aaa79c623b631adfe6db57ca23baa43a55282a/.local/share/brioche/locals/f8dfb36705b7e76a60266232937d5015a001a5d20199b7a1a2ce7048908ee2b8/scripts/gen-wasm2c-templates.cmake:5 (file):
       │   file failed to open for writing (Read-only file system):
       │     /home/brioche-runner-a111fee76738a51294f0f56438aaa79c623b631adfe6db57ca23baa43a55282a/.local/share/brioche/locals/f8dfb36705b7e76a60266232937d5015a001a5d20199b7a1a2ce7048908ee2b8/src/prebuilt/wasm2c_header_top.cc
       │ make[2]: *** [CMakeFiles/gen-wasm2c-prebuilt-target.dir/build.make:78: gen-wasm2c-prebuilt] Error 1
       │ make[1]: *** [CMakeFiles/Makefile2:261: CMakeFiles/gen-wasm2c-prebuilt-target.dir/all] Error 2
       │ make: *** [Makefile:136: all] Error 2
```

This PR tweaks the `cmakeBuild()` to use a working directory (which is writable, as it's done for `cargoBuild()`, `goBuild()`, ...) for all the CMake builds. With a difference with the main branche, the build is not done in the root directory, it is now done in a random build directory to resolve issue like:

```bash
> brioche build -o /tmp/output -p packages/wabt/
 INFO build:bake:bake_process: brioche_core::bake::process: keeping temporary bake dir /home/jaudiger.linux/.local/share/brioche/process-temp/01K4272SGY4YP05HGMYHWDJTV4 meta=Meta { source: Some([StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/std/core/recipes/process.bri"), line_number: Some(257), column_number: Some(14) }, StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/cmake/project.bri"), line_number: Some(212), column_number: Some(6) }, StackFrame { file_name: Some("file:///Users/jaudiger/Development/git-repositories/jaudiger/brioche-packages/packages/wabt/project.bri"), line_number: Some(20), column_number: Some(10) }]) }
589694 │ [ 61%] Built target wasm
       │ [ 62%] Building CXX object CMakeFiles/wat2wasm.dir/src/tools/wat2wasm.cc.o
       │ [ 63%] Linking CXX executable wat2wasm
       │ [ 63%] Built target wat2wasm
       │ [ 63%] Built target wat2wasm-copy-to-bin
       │ [ 64%] Building CXX object CMakeFiles/wast2json.dir/src/tools/wast2json.cc.o
       │ [ 64%] Linking CXX executable wast2json
       │ [ 64%] Built target wast2json
       │ [ 64%] Built target wast2json-copy-to-bin
       │ [ 64%] Building CXX object CMakeFiles/wasm2wat.dir/src/tools/wasm2wat.cc.o
       │ [ 65%] Linking CXX executable wasm2wat
       │ [ 65%] Built target wasm2wat
       │ [ 65%] Built target wasm2wat-copy-to-bin
       │ [ 65%] Building CXX object CMakeFiles/wasm2c.dir/src/tools/wasm2c.cc.o
       │ [ 66%] Linking CXX executable wasm2c
       │ /home/brioche-runner-34d89d83f8e818bb16be6d04a655d7ddde83f9d28abeb8c385af6af9d1bf48ed/.local/share/brioche/locals/ac72c24ec53721f2b9012665360657d3996993f9405f05cbdf05ede7ecf28526/libexec/brioche-ld/ld.gold: fatal error: wasm2c: open: Is a directory
       │ collect2: error: ld returned 1 exit status
       │ make[2]: *** [CMakeFiles/wasm2c.dir/build.make:101: wasm2c] Error 1
       │ make[1]: *** [CMakeFiles/Makefile2:639: CMakeFiles/wasm2c.dir/all] Error 2
       │ make: *** [Makefile:136: all] Error 2
```