### PR TITLE
feat(tree_sitter): add package

### DIFF
--- a/packages/tree_sitter/brioche.lock
+++ b/packages/tree_sitter/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/tree-sitter/tree-sitter": {
+      "v0.25.8": "f2f197b6b27ce75c280c20f131d4f71e906b86f7"
+    }
+  }
+}

--- a/packages/tree_sitter/project.bri
+++ b/packages/tree_sitter/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "tree_sitter",
+  version: "0.25.8",
+  repository: "https://github.com/tree-sitter/tree-sitter",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function treeSitter(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "cli",
+    runnable: "bin/tree-sitter",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    tree-sitter --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(treeSitter)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `tree-sitter ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`tree_sitter`](https://github.com/tree-sitter/tree-sitter): an incremental parsing system for programming tools

```bash
Build finished, completed 1 job in 10.44s
Running brioche-run
{
  "name": "tree_sitter",
  "version": "0.25.8",
  "repository": "https://github.com/tree-sitter/tree-sitter"
}

⏵ Task `Run package live-update` finished successfully
``` 

```bash
Build finished, completed (no new jobs) in 2.43s
Result: 515dc7e953be68b2c6a5c681fc6978d1a0c19e51ef9a8828c353842f423460a0

⏵ Task `Run package test` finished successfully
```