### PR TITLE
feat(usage): add package

### DIFF
--- a/packages/usage/brioche.lock
+++ b/packages/usage/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/jdx/usage.git": {
+      "v2.2.2": "d5cdaf592f7e0266ad65db8f40c0bc6618f7beed"
+    }
+  }
+}

--- a/packages/usage/project.bri
+++ b/packages/usage/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "usage",
+  version: "2.2.2",
+  repository: "https://github.com/jdx/usage.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function usage(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "cli",
+    runnable: "bin/usage",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    usage --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(usage)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `usage-cli ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`usage`](https://github.com/jdx/usage): a spec and CLI for defining CLI tools

```bash
Running brioche-run
{
  "name": "usage",
  "version": "2.2.2",
  "repository": "https://github.com/jdx/usage.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.55s
Result: 04321ffcb04b537ecbe9412f28c5db6ce5649aba596c8b07dd0568fcb19bd9e3

⏵ Task `Run package test` finished successfully
```