### PR TITLE
feat(igrep): add package

### DIFF
--- a/packages/igrep/brioche.lock
+++ b/packages/igrep/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/konradsz/igrep.git": {
+      "v1.3.0": "00b309dd164f5a00371cd77c76cc5181ddf427db"
+    }
+  }
+}

--- a/packages/igrep/project.bri
+++ b/packages/igrep/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "igrep",
+  version: "1.3.0",
+  repository: "https://github.com/konradsz/igrep.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function igrep(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/ig",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ig --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(igrep)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ig ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/igrep/project.bri
+++ b/packages/igrep/project.bri
@@ -29,7 +29,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `ig ${project.version}`;
+  const expected = `igrep ${project.version}`;
   std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;


### PR DESCRIPTION
Add a new package [`igrep`](https://github.com/konradsz/igrep): an interactive grep

```bash
Build finished, completed (no new jobs) in 2.21s
Result: cd690538180ca2b6e1f23be1c3d32a7a15fb3193d42fd0dad9644f9739b29d6f

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "igrep",
  "version": "1.3.0",
  "repository": "https://github.com/konradsz/igrep.git"
}

⏵ Task `Run package live-update` finished successfully
```