### PR TITLE
refactor(recipes): add missing make commands when building packages

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function alsaLib(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/cyrus_sasl/project.bri
+++ b/packages/cyrus_sasl/project.bri
@@ -17,6 +17,7 @@ const source = Brioche.download(
 export default function cyrusSasl(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/fribidi/project.bri
+++ b/packages/fribidi/project.bri
@@ -17,6 +17,7 @@ export default function fribidi(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-static
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/gengetopt/project.bri
+++ b/packages/gengetopt/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function gengetopt(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/gperf/project.bri
+++ b/packages/gperf/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function gperf(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/isl/project.bri
+++ b/packages/isl/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function isl(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/libfaketime/project.bri
+++ b/packages/libfaketime/project.bri
@@ -20,6 +20,7 @@ const source = Brioche.gitCheckout({
 
 export default function libfaketime(): std.Recipe<std.Directory> {
   return std.runBash`
+    make -j "$(nproc)"
     make install \
       PREFIX=/ \
       DESTDIR="$BRIOCHE_OUTPUT"

--- a/packages/libice/project.bri
+++ b/packages/libice/project.bri
@@ -17,6 +17,7 @@ const source = Brioche.download(
 export default function libice(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, xorgproto, xtrans)

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function libpcap(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -16,6 +16,7 @@ export default function libpng(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure \\
       --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libpsl/project.bri
+++ b/packages/libpsl/project.bri
@@ -16,6 +16,7 @@ const source = Brioche.download(
 export default function libPsl(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libsm/project.bri
+++ b/packages/libsm/project.bri
@@ -20,6 +20,7 @@ export default function libsm(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-docs=no
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, xorgproto, xtrans, libice)

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function libsodium(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -18,6 +18,7 @@ export default function libssh2(): std.Recipe<std.Directory> {
     ./configure \\
       --prefix=/ \\
       --disable-examples-build
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libxau/project.bri
+++ b/packages/libxau/project.bri
@@ -16,6 +16,7 @@ const source = Brioche.download(
 export default function libxau(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, xorgproto)

--- a/packages/libxdmcp/project.bri
+++ b/packages/libxdmcp/project.bri
@@ -18,6 +18,7 @@ export default function libxdmcp(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-docs=no
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, xorgproto)

--- a/packages/libyaml/project.bri
+++ b/packages/libyaml/project.bri
@@ -15,6 +15,7 @@ export default function libyaml(): std.Recipe<std.Directory> {
   return std.runBash`
     ./bootstrap
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/lzop/project.bri
+++ b/packages/lzop/project.bri
@@ -16,6 +16,7 @@ const source = Brioche.download(
 export default function lzop(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/ncurses/project.bri
+++ b/packages/ncurses/project.bri
@@ -25,6 +25,7 @@ export default function ncurses(): std.Recipe<std.Directory> {
       --enable-pc-files \
       --enable-widec \
       --with-pkg-config-libdir=/lib/pkgconfig
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/patch/project.bri
+++ b/packages/patch/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function patch(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/readline/project.bri
+++ b/packages/readline/project.bri
@@ -16,6 +16,7 @@ export default function readline(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/ \
       --with-curses
+    make -j "$(nproc)"
     make install SHLIB_LIBS="-lncursesw" DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -16,6 +16,7 @@ const source = Brioche.download(
 export default function tcpdump(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/util_macros/project.bri
+++ b/packages/util_macros/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function utilMacros(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/xorgproto/project.bri
+++ b/packages/xorgproto/project.bri
@@ -15,6 +15,7 @@ const source = Brioche.download(
 export default function xorgproto(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/xtrans/project.bri
+++ b/packages/xtrans/project.bri
@@ -17,6 +17,7 @@ export default function xtrans(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-docs=no
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)


### PR DESCRIPTION
For reference: https://github.com/brioche-dev/brioche-packages/discussions/230

I tested each recipe one by one by running `brioche build -e test -p packages/RECIPE` to ensure no regression happened. On my machine (MacBook Pro with M1 CPU), `nproc` returns 8. I can definitively see the build improvement here in the updated recipes, the build time is most of the time significantly reduced.