### PR TITLE
feat(eslint): add package

### DIFF
--- a/packages/eslint/brioche.lock
+++ b/packages/eslint/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/eslint/project.bri
+++ b/packages/eslint/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "eslint",
+  version: "9.34.0",
+  extra: {
+    packageName: "eslint",
+  },
+};
+
+export default function eslint(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/eslint"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    eslint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(eslint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`eslint`](https://eslint.org): The pluggable linting utility for JavaScript and JSX

```bash
Build finished, completed (no new jobs) in 11.71s
Result: 64a1be47d14ecafe112ce55d6bb086c08f0d09464cc31640217d6cc077fa4431

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "eslint",
  "version": "9.34.0",
  "extra": {
    "packageName": "eslint"
  }
}

⏵ Task `Run package live-update` finished successfully
```