### PR TITLE
feat(xcb_proto): add package

### DIFF
--- a/packages/xcb_proto/brioche.lock
+++ b/packages/xcb_proto/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/proto/xcb-proto-1.17.0.tar.xz": {
+      "type": "sha256",
+      "value": "2c1bacd2110f4799f74de6ebb714b94cf6f80fb112316b1219480fd22562148c"
+    }
+  }
+}

--- a/packages/xcb_proto/project.bri
+++ b/packages/xcb_proto/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import python from "python";
+
+export const project = {
+  name: "xcb_proto",
+  version: "1.17.0",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/proto/xcb-proto-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function xcbProto(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, python)
+    .workDir(source)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xcb-proto | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xcbProto)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/proto
+      | lines
+      | where {|it| ($it | str contains "xcb-proto") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="xcb-proto-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`xcb_proto`](https://xcb.freedesktop.org): the X protocol C-language Binding (XCB) is a replacement for Xlib [featuring](https://xcb.freedesktop.org/Features/) a small footprint, latency hiding, direct access to the protocol, improved threading support, and extensibility.

```bash
Running brioche-run
{
  "name": "xcb_proto",
  "version": "1.17.0"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Result: a447d14fdcea861408dd77dc055814db266543d3e45fb6ecb9590fe66b98c26a

⏵ Task `Run package test` finished successfully
```