### PR TITLE
feat: update make commands to use $(nproc) for parallel builds

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -56,12 +56,16 @@ export default function cmake(): std.Recipe<std.Directory> {
     ./bootstrap \\
       --prefix=/ \\
       --system-curl \\
-      --parallel=16
+      --parallel="$(nproc)"
     make
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
     .dependencies(std.toolchain, openssl, curl({ minimal: true }))
+    .env({
+      // Set the number of threads to use during compilation
+      OMP_NUM_THREADS: "16",
+    })
     .toDirectory()
     .pipe(
       (recipe) =>

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -52,7 +52,7 @@ export default function curl(
       --without-ca-path \\
       --with-ca-fallback \\
       $buildFlags
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/editline/project.bri
+++ b/packages/editline/project.bri
@@ -15,7 +15,7 @@ export default function editline(): std.Recipe<std.Directory> {
   return std.runBash`
     ./autogen.sh
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/expat/project.bri
+++ b/packages/expat/project.bri
@@ -24,7 +24,7 @@ const source = Brioche.download(
 export default function expat(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/freetype/project.bri
+++ b/packages/freetype/project.bri
@@ -19,7 +19,7 @@ export default function freetype(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-freetype-config
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -16,8 +16,14 @@ const source = Brioche.download(
 
 export default function git(): std.Recipe<std.Directory> {
   return std.runBash`
-    make prefix=/ all
-    make prefix=/ install DESTDIR="$BRIOCHE_OUTPUT"
+    make \
+      -j "$(nproc)" \
+      prefix=/ \
+      all
+    make \
+      prefix=/ \
+      install \
+      DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
     .dependencies(std.toolchain, openssl, curl({ minimal: true }))

--- a/packages/gmp/project.bri
+++ b/packages/gmp/project.bri
@@ -18,7 +18,7 @@ export default function gmp(): std.Recipe<std.Directory> {
       --prefix=/ \
       --with-pic \
       --enable-cxx
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/htop/project.bri
+++ b/packages/htop/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function htop(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/hunspell/project.bri
+++ b/packages/hunspell/project.bri
@@ -17,7 +17,7 @@ export default function hunspell(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --with-readline
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/icu/project.bri
+++ b/packages/icu/project.bri
@@ -29,7 +29,7 @@ export default function icu(): std.Recipe<std.Directory> {
     cd icu/source
     ./runConfigureICU Linux \\
       --prefix=/
-    make -j16
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/iperf3/project.bri
+++ b/packages/iperf3/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 export default function iperf3(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -17,7 +17,7 @@ export default function jq(): std.Recipe<std.Directory> {
     ./configure \\
       --prefix=/ \\
       --with-oniguruma=builtin
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/krb5/project.bri
+++ b/packages/krb5/project.bri
@@ -24,7 +24,7 @@ const source = Brioche.download(
 export default function krb5(): std.Recipe<std.Directory> {
   return std.runBash`
     ./src/configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function libarchive(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix="$BRIOCHE_OUTPUT"
-    make
+    make -j "$(nproc)"
     make install
   `
     .workDir(source)

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -23,6 +23,7 @@ const source = std.recipe(() => {
 export default function libcap(): std.Recipe<std.Directory> {
   return std.runBash`
     make \\
+      -j "$(nproc)" \\
       prefix=/ \\
       lib=lib \\
       sbin=bin \\

--- a/packages/libevent/project.bri
+++ b/packages/libevent/project.bri
@@ -16,7 +16,7 @@ export default function libevent(): std.Recipe<std.Directory> {
   return std.runBash`
     ./autogen.sh
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libffi/project.bri
+++ b/packages/libffi/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function libffi(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -16,7 +16,7 @@ export default function libjpeg(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure \\
       --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -18,7 +18,7 @@ export default function libtirpc(): std.Recipe<std.Directory> {
     ./configure \\
       --prefix=/ \\
       --disable-gssapi
-    make -j16
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libunistring/project.bri
+++ b/packages/libunistring/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function libunistring(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libunwind/project.bri
+++ b/packages/libunwind/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function libunwind(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libxcrypt/project.bri
+++ b/packages/libxcrypt/project.bri
@@ -17,7 +17,7 @@ export default function libxcrypt(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --disable-failure-tokens
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -25,7 +25,7 @@ const source = Brioche.download(
 export default function libxml2(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -26,7 +26,7 @@ const source = Brioche.download(
 export default function libxslt(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -93,7 +93,7 @@ export default function linux(
   // and `System.map` because not all architectures have a `make install`
   // target
   return std.runBash`
-    make -j16
+    make -j "$(nproc)"
 
     image_path="$(make image_name)"
     image_name="$(basename "$image_path")"
@@ -117,6 +117,9 @@ export default function linux(
       std.toolchain,
     )
     .env({
+      // Set the number of threads to use during compilation
+      OMP_NUM_THREADS: "16",
+
       INSTALL_MOD_PATH: std.outputPath,
 
       // Needed since we're using `ld.bfd`, which tries to resolve transitive

--- a/packages/lzo/project.bri
+++ b/packages/lzo/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function lzo(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.gitCheckout({
 
 export default function moreutils(): std.Recipe<std.Directory> {
   return std.runBash`
-    make
+    make -j "$(nproc)"
     make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, libxml2, libxslt)
@@ -137,7 +137,7 @@ function perlEnv(): std.Recipe<std.Directory> {
 
   perlEnv = std.runBash`
     perl Makefile.PL
-    make
+    make -j "$(nproc)"
     make install
   `
     .workDir(ipcRun)

--- a/packages/mpfr/project.bri
+++ b/packages/mpfr/project.bri
@@ -17,7 +17,7 @@ export default function mpfr(): std.Recipe<std.Directory> {
     ./configure \
       --prefix=/ \
       --enable-thread-safe
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -15,7 +15,7 @@ export default function nasm(): std.Recipe<std.Directory> {
   return std.runBash`
     ./autogen.sh
     ./configure
-    make
+    make -j "$(nproc)"
     make strip
     mkdir -p "$BRIOCHE_OUTPUT/bin"
     cp nasm "$BRIOCHE_OUTPUT/bin/nasm"

--- a/packages/nginx/project.bri
+++ b/packages/nginx/project.bri
@@ -18,7 +18,7 @@ export default function nginx(): std.Recipe<std.Directory> {
     ./configure \\
       --prefix=/etc/nginx \\
       --sbin-path=/bin/nginx
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/oniguruma/project.bri
+++ b/packages/oniguruma/project.bri
@@ -17,7 +17,7 @@ export default function oniguruma(): std.Recipe<std.Directory> {
     ./configure \\
       --prefix=/ \\
       --enable-posix-api=yes
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -18,7 +18,7 @@ export default function openssl(): std.Recipe<std.Directory> {
       --prefix=/ \\
       --openssldir=/etc/ssl \\
       --libdir=lib
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -22,7 +22,7 @@ export default function pcre(): std.Recipe<std.Directory> {
       --enable-pcre16 \\
       --enable-pcre32 \\
       --enable-unicode-properties
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/pcre2/project.bri
+++ b/packages/pcre2/project.bri
@@ -23,7 +23,7 @@ export default function pcre2(): std.Recipe<std.Directory> {
       --enable-pcre2-8 \\
       --enable-pcre2-16 \\
       --enable-pcre2-32
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -30,7 +30,7 @@ export default function perl(): std.Recipe<std.Directory> {
       -Dprefix=/ \\
       -Duserelocatableinc \\
       -Dusethreads
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/php/project.bri
+++ b/packages/php/project.bri
@@ -17,11 +17,15 @@ const source = Brioche.download(
 export default function php(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix="$BRIOCHE_OUTPUT"
-    make -j16
+    make -j "$(nproc)"
     make install
   `
-    .dependencies(std.toolchain, libxml2, sqlite)
     .workDir(source)
+    .dependencies(std.toolchain, libxml2, sqlite)
+    .env({
+      // Set the number of threads to use during compilation
+      OMP_NUM_THREADS: "16",
+    })
     .toDirectory()
     .pipe(
       (recipe) =>

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -27,11 +27,15 @@ export default function postgresql(): std.Recipe<std.Directory> {
       --with-uuid=e2fs \\
       --with-libxml \\
       --with-libxslt
-    make world-bin -j16
+    make -j "$(nproc)" world-bin
     make install-world-bin DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)
     .dependencies(std.toolchain, icu, openssl, libxml, libxslt)
+    .env({
+      // Set the number of threads to use during compilation
+      OMP_NUM_THREADS: "16",
+    })
     .toDirectory()
     .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {

--- a/packages/proot/project.bri
+++ b/packages/proot/project.bri
@@ -40,7 +40,7 @@ export default function proot(): std.Recipe<std.Directory> {
         ;;
     esac
 
-    make -C src proot care
+    make -j "$(nproc)" -C src proot care
     make -C src install PREFIX="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function pv(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -72,7 +72,7 @@ export default async function python(options: PythonOptions = {}) {
       --prefix=/ \\
       --enable-shared \\
       --without-ensurepip
-    make -j8
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
 
     python3 -m ensurepip --default-pip

--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -17,7 +17,7 @@ export default function re2c(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure \\
       --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain, python)

--- a/packages/rpcsvc_proto/project.bri
+++ b/packages/rpcsvc_proto/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function rpcsvcProto(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make -j16
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.download(
 
 export default function scdoc(): std.Recipe<std.Directory> {
   return std.runBash`
-    make PREFIX=/
+    make -j "$(nproc)" PREFIX=/
     make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -32,7 +32,7 @@ export default function sqlite(): std.Recipe<std.Directory> {
       --enable-readline \\
       --enable-fts3 \\
       --enable-session
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/strace/project.bri
+++ b/packages/strace/project.bri
@@ -26,7 +26,7 @@ export default function strace(): std.Recipe<std.Directory> {
         ;;
     esac
 
-    make -j16
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -16,7 +16,7 @@ const source = Brioche.download(
 export default function talloc(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix="$BRIOCHE_OUTPUT"
-    make
+    make -j "$(nproc)"
     make install
   `
     .workDir(source)

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -16,7 +16,7 @@ export default function tcsh(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure \\
       --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)

--- a/packages/tinycbor/project.bri
+++ b/packages/tinycbor/project.bri
@@ -13,7 +13,7 @@ const source = Brioche.gitCheckout({
 
 export default function tinycbor(): std.Recipe<std.Directory> {
   return std.runBash`
-    make
+    make -j "$(nproc)"
     make install "prefix=/" DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/unzip/project.bri
+++ b/packages/unzip/project.bri
@@ -20,7 +20,7 @@ export default function unzip(): std.Recipe<std.Directory> {
     patch -Np1 -i "$patches"/unzip-6.0-consolidated_fixes-1.patch
     patch -Np1 -i "$patches"/unzip-6.0-gcc14-1.patch
 
-    make -f unix/Makefile generic
+    make -j "$(nproc)" -f unix/Makefile generic
     make -f unix/Makefile install prefix="$BRIOCHE_OUTPUT"
   `
     .env({ patches })

--- a/packages/xz/project.bri
+++ b/packages/xz/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function xz(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.download(
 export default function zlib(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)

--- a/packages/zlib_ng/project.bri
+++ b/packages/zlib_ng/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 export default function zlibNg(): std.Recipe<std.Directory> {
   return std.runBash`
     ./configure --prefix=/
-    make
+    make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .workDir(source)


### PR DESCRIPTION
Here is the second part of https://github.com/brioche-dev/brioche-packages/pull/1149, this time targeting the existing `make` commands.

I didn't test all of them, but I did test the most important recipes (cmake, git, linux, etc).