### PR TITLE
Improve cmake building

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -133,11 +133,14 @@ export type CMakeVariableType =
  * Generate and build a CMake project.
  *
  * @description A project build system will be generated out-of-tree from the source project,
- * and will be built and installed automatically with the chosen build
+ * and will be built using parallel jobs and installed automatically with the chosen build
  * generator.
  *
  * If the result includes a `lib64/`, the symlink `lib/` will be added
  * automatically to follow the standard Brioche conventions.
+ *
+ * @remarks To override the number of parallel jobs, set the environment variable `CMAKE_BUILD_PARALLEL_LEVEL`
+ * to the desired number. Setting it to `1` will disable parallelism.
  *
  * @param options - The options for building the CMake project.
  *
@@ -187,6 +190,10 @@ export function cmakeBuild(
         cmake_args+=("-D\${!var_cmake_name}=\${!var_cmake_value}")
       fi
     done
+
+    if [ -z "\${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]; then
+      export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+    fi
 
     BUILD_DIR=$(mktemp -p . -d build.XXXXXX)
 

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -195,11 +195,11 @@ export function cmakeBuild(
       export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
     fi
 
-    BUILD_DIR=$(mktemp -p . -d build.XXXXXX)
+    build_dir=$(mktemp -p . -d build.XXXXXX)
 
-    cmake -S "$path" -B "$BUILD_DIR" "\${cmake_args[@]}"
-    cmake --build "$BUILD_DIR" --config "$config"
-    cmake --install "$BUILD_DIR" --prefix="$BRIOCHE_OUTPUT"
+    cmake -S "$path" -B "$build_dir" "\${cmake_args[@]}"
+    cmake --build "$build_dir" --config "$config"
+    cmake --install "$build_dir" --prefix="$BRIOCHE_OUTPUT"
 
     if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then
       # Ensure the lib folder exists

--- a/packages/pstack/project.bri
+++ b/packages/pstack/project.bri
@@ -23,9 +23,6 @@ export default function pstack(): std.Recipe<std.Directory> {
     set: {
       VERSION_TAG: gitRef.commit,
     },
-    env: {
-      CMAKE_BUILD_PARALLEL_LEVEL: "16",
-    },
     runnable: "bin/pstack",
   });
 }


### PR DESCRIPTION
As mentioned in #1194, this PR is the final work on parallel build in our recipe when using `make` or `cmake` tools. By default for `cmakeBuild()`, parallel build will be enabled, if for a recipe we need to disable it, I updated the TSDoc of this function to state that we only need to set `CMAKE_BUILD_PARALLEL_LEVEL` to `1`.

We can still customise (override) the number of jobs used by CMake by setting this env var as we continue to do in:

- binaryen
- libxc
- llvm

For `pstack`, I removed/unset the env var since the building is fast enough (less than 30s) with 8 threads (on my computer).