### PR TITLE
chore(nushell): update the references from `std.NushellRunnable` / `std.runNushell` to `NushellRunnable` / `runNushell`

### DIFF
--- a/packages/nushell/nushell_runnable.bri
+++ b/packages/nushell/nushell_runnable.bri
@@ -38,7 +38,7 @@ interface NushellRunnableUtils {
  * import { nushellRunnable } from "nushell";
  *
  * // Running `brioche run` will print "Hello, world!"
- * export default function (): std.NushellRunnable {
+ * export default function (): NushellRunnable {
  *   return nushellRunnable`
  *     echo "Hello, world!"
  *   `;
@@ -70,7 +70,7 @@ export function nushellRunnable(
  * import { nushellRunnable } from "nushell";
  *
  * // Running `brioche run` will print "Hello, world!"
- * export default function (): std.NushellRunnable {
+ * export default function (): NushellRunnable {
  *   return nushellRunnable`
  *     echo "Hello, world!"
  *   `;

--- a/packages/nushell/run_nushell.bri
+++ b/packages/nushell/run_nushell.bri
@@ -31,7 +31,7 @@ import nushell from "/";
  *
  *   // Return a recipe that will call the script, with `$file` set to
  *   // the absolute path of the file above
- *   return std.runNushell`
+ *   return runNushell`
  *     mkdir $env.BRIOCHE_OUTPUT
  *     open $env.file | save $'($env.BRIOCHE_OUTPUT)/hello.txt'
  *   `


### PR DESCRIPTION
The types do not come from the `std` package, and are from the `nushell` package. Only TSDoc were updated here, there is no need to update other things.