### PR TITLE
feat(libnet): add package

### DIFF
--- a/packages/libnet/brioche.lock
+++ b/packages/libnet/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libnet/libnet/releases/download/v1.3/libnet-1.3.tar.gz": {
+      "type": "sha256",
+      "value": "ad1e2dd9b500c58ee462acd839d0a0ea9a2b9248a1287840bc601e774fb6b28f"
+    }
+  }
+}

--- a/packages/libnet/project.bri
+++ b/packages/libnet/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+
+export const project = {
+  name: "libnet",
+  version: "1.3",
+  repository: "https://github.com/libnet/libnet",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libnet-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libnet(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/libnet-config"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnet | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnet)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libnet`](https://github.com/libnet/libnet): a portable framework for low-level network packet construction

```bash
Build finished, completed (no new jobs) in 1.10s
Result: 889948b3baaeaa8f6f320205aaac44568a862035635984aeda8af095e6ddb203

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 1 job in 15.36s
Running brioche-run
{
  "name": "libnet",
  "version": "1.3",
  "repository": "https://github.com/libnet/libnet"
}

⏵ Task `Run package live-update` finished successfully
```