### PR TITLE
feat(unixodbc): add package

### DIFF
--- a/packages/unixodbc/brioche.lock
+++ b/packages/unixodbc/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.unixodbc.org/unixODBC-2.3.12.tar.gz": {
+      "type": "sha256",
+      "value": "f210501445ce21bf607ba51ef8c125e10e22dffdffec377646462df5f01915ec"
+    }
+  }
+}

--- a/packages/unixodbc/project.bri
+++ b/packages/unixodbc/project.bri
@@ -1,0 +1,69 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "unixodbc",
+  version: "2.3.12",
+};
+
+const source = Brioche.download(
+  `https://www.unixodbc.org/unixODBC-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function unixodbc(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-static \
+      --disable-gui
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain)
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/odbc_config"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion odbc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, unixodbc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.unixodbc.org/download.html
+      | lines
+      | where {|it| $it | str contains "unixODBC" }
+      | parse --regex '<a  HREF="unixODBC-(?<version>.+)\.tar\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`unixodbc`](https://www.unixodbc.org): ODBC is an open specification for providing application developers with a predictable API with which to access Data Sources. Data Sources include SQL Servers and any Data Source with an ODBC Driver. 

```bash
Build finished, completed (no new jobs) in 10.88s
Running brioche-run
{
  "name": "unixodbc",
  "version": "2.3.12"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.92s
Result: 5d21592654d108fd0dabb0a8778bd2b3b04b28b3425a6c8aa21bd8df66a5fa06

⏵ Task `Run package test` finished successfully
```