### PR TITLE
feat(traefik): add package

### DIFF
--- a/packages/traefik/brioche.lock
+++ b/packages/traefik/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/traefik/traefik/releases/download/v3.5.2/traefik-v3.5.2.src.tar.gz": {
+      "type": "sha256",
+      "value": "77ea75c424d8419ccc5d3bf8af614a311b43dbbfe7a9871a14521a419c133327"
+    }
+  }
+}

--- a/packages/traefik/project.bri
+++ b/packages/traefik/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "traefik",
+  version: "3.5.2",
+  repository: "https://github.com/traefik/traefik",
+  extra: {
+    majorVersion: 3,
+  },
+};
+
+// Ensure the major version number matches the version
+std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+
+// Download the source code from the GitHub release, since it contains some additional files
+// than are not present in the git repository (ie: 'static' folder for webui)
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/traefik-v${project.version}.src.tar.gz`,
+).unarchive("tar", "gzip");
+
+export default function traefik(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/traefik/traefik/v${project.extra.majorVersion}/pkg/version.Version=${project.version}`,
+      ],
+    },
+    path: "./cmd/traefik",
+    runnable: "bin/traefik",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    traefik version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(traefik)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version:      ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`traefik`](https://traefik.io): Traefik is your all-in-one, self-hosted, cloud-native, GitOps-driven application proxy, API gateway, and API management platform.

```bash
Running brioche-run
{
  "name": "traefik",
  "version": "3.5.2",
  "repository": "https://github.com/traefik/traefik",
  "extra": {
    "majorVersion": 3
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.97s
Result: 5154604143aa1fa8a5db12a392f354fc8ab44e3c32dfd8b947f3007e3f71d1a8

⏵ Task `Run package test` finished successfully
```