### PR TITLE
feat(terraform_ls): add package

### DIFF
--- a/packages/terraform_ls/brioche.lock
+++ b/packages/terraform_ls/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/hashicorp/terraform-ls.git": {
+      "v0.37.0": "71d65413d495b0f868f404d2750479fa3dc62d27"
+    }
+  }
+}

--- a/packages/terraform_ls/project.bri
+++ b/packages/terraform_ls/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "terraform_ls",
+  version: "0.37.0",
+  repository: "https://github.com/hashicorp/terraform-ls.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function terraformLs(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    path: ".",
+    runnable: "bin/terraform-ls",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    terraform-ls --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(terraformLs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`terraform_ls`](https://github.com/hashicorp/terraform-ls): a Terraform Language Server.

```bash
Running brioche-run
{
  "name": "terraform_ls",
  "version": "0.37.0",
  "repository": "https://github.com/hashicorp/terraform-ls.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.05s
Result: d20c22146a1bffd56d88487cc85e76dd3e3068303e4e2991b114056af59c930c

⏵ Task `Run package test` finished successfully
```