### PR TITLE
feat(terraform_docs): add package

### DIFF
--- a/packages/terraform_docs/brioche.lock
+++ b/packages/terraform_docs/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/terraform-docs/terraform-docs.git": {
+      "v0.20.0": "cf462c5da36feb66051cf0a6f1124594ed9adc7c"
+    }
+  }
+}

--- a/packages/terraform_docs/project.bri
+++ b/packages/terraform_docs/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "terraform_docs",
+  version: "0.20.0",
+  repository: "https://github.com/terraform-docs/terraform-docs.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function terraformDocs(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    path: ".",
+    runnable: "bin/terraform-docs",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    terraform-docs --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(terraformDocs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `terraform-docs version v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`terraform_docs`](https://github.com/terraform-docs/terraform-docs): Generate documentation from Terraform modules in various output formats

```bash
Build finished, completed (no new jobs) in 1.34s
Result: 7ef9f5b026da7a742b8792fb2efe8bf2cbdc3d4db09f7866451ac6936f45c2b1

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 10.88s
Running brioche-run
{
  "name": "terraform_docs",
  "version": "0.20.0",
  "repository": "https://github.com/terraform-docs/terraform-docs.git"
}

⏵ Task `Run package live-update` finished successfully
```