### PR TITLE
feat(go_task): add package

### DIFF
--- a/packages/go_task/brioche.lock
+++ b/packages/go_task/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/go-task/task.git": {
+      "v3.45.3": "17db402e4bf1d816d4b3d0770b0d97ae962b41a4"
+    }
+  }
+}

--- a/packages/go_task/project.bri
+++ b/packages/go_task/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "go_task",
+  version: "3.45.3",
+  repository: "https://github.com/go-task/task.git",
+  extra: {
+    majorVersion: "3",
+  },
+};
+
+// Ensure the major version number matches the version
+std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function goTask(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/go-task/task/v${project.extra.majorVersion}/internal/version.version=${project.version}`,
+      ],
+    },
+    path: "./cmd/task",
+    runnable: "bin/task",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    task --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(goTask)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package `go_task`:

```bash
brioche run -e liveUpdate -p packages/go_task/

 0.02s ✓ Process 92108
Build finished, completed 1 job in 9.49s
Running brioche-run
{
  "name": "go_task",
  "version": "3.45.4",
  "repository": "https://github.com/go-task/task.git",
  "extra": {
    "majorVersion": "3"
  }
}
```

```bash
brioche build -e test -p packages/go_task/

Build finished, completed (no new jobs) in 0.90s
Result: 7521377fdaaf5d7200ec6ec9da1ed41b2614fce95cd1434d05fadf93b2b6c548
```