### PR TITLE
feat(tenv): add package

### DIFF
--- a/packages/tenv/brioche.lock
+++ b/packages/tenv/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/tofuutils/tenv.git": {
+      "v4.7.21": "75176f712496d3f6ddd21f87604e504354c9531d"
+    }
+  }
+}

--- a/packages/tenv/project.bri
+++ b/packages/tenv/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "tenv",
+  version: "4.7.21",
+  repository: "https://github.com/tofuutils/tenv.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function tenv(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    path: "./cmd/tenv",
+    runnable: "bin/tenv",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    tenv --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(tenv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `tenv version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`tenv`](https://github.com/tofuutils/tenv): OpenTofu / Terraform / Terragrunt / Terramate and Atmos version manager

```bash
Build finished, completed 1 job in 9.28s
Running brioche-run
{
  "name": "tenv",
  "version": "4.7.21",
  "repository": "https://github.com/tofuutils/tenv.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 0.92s
Result: 82296a3bdba262f21965cdfb9b823702c2331ba52c96401ce3a2b3763fbcf5f8

⏵ Task `Run package test` finished successfully
```