### PR TITLE
chore(ncurses): add --with-termlib to configure options

### DIFF
--- a/packages/ncurses/project.bri
+++ b/packages/ncurses/project.bri
@@ -24,6 +24,7 @@ export default function ncurses(): std.Recipe<std.Directory> {
       --enable-symlinks \
       --enable-pc-files \
       --enable-widec \
+      --with-termlib \
       --with-pkg-config-libdir=/lib/pkgconfig
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"


### PR DESCRIPTION
Without:

```bash
> ls /tmp/output/lib/
libformw.a   libformw.so.6    libmenuw.a   libmenuw.so.6    libncurses++w.a   libncurses++w.so.6    libncursesw.a   libncursesw.so.6    libpanelw.a   libpanelw.so.6    pkgconfig
libformw.so  libformw.so.6.5  libmenuw.so  libmenuw.so.6.5  libncurses++w.so  libncurses++w.so.6.5  libncursesw.so  libncursesw.so.6.5  libpanelw.so  libpanelw.so.6.5  terminfo
```

With:

```bash
> ls /tmp/output/lib/
libformw.a   libformw.so.6    libmenuw.a   libmenuw.so.6    libncurses++w.a   libncurses++w.so.6    libncursesw.a   libncursesw.so.6    libpanelw.a   libpanelw.so.6    libtinfow.a   libtinfow.so.6    pkgconfig
libformw.so  libformw.so.6.5  libmenuw.so  libmenuw.so.6.5  libncurses++w.so  libncurses++w.so.6.5  libncursesw.so  libncursesw.so.6.5  libpanelw.so  libpanelw.so.6.5  libtinfow.so  libtinfow.so.6.5  terminfo
```

An additional library is built `libtinfow` with the flag `--with-termlib`. As for now, we don't need it. But I added it since we could maybe need it in the future. I wasn't aware of this option until I saw it in the [nix recipe](https://github.com/NixOS/nixpkgs/blob/e9b7f2ff62b35f711568b1f0866243c7c302028d/pkgs/development/libraries/ncurses/default.nix#L59). It's a quick win without the need to include additional dependencies for this recipe.

Extract from the documentation:

```bash
--with-termlib

Provide ncurses's lower-level terminal interface functions (those that do not depend on the SCREEN and WINDOW abstractions) in a library named tinfo. This arrangement reduces an application's linking and/or loading times when it does not require curses's higher-level features.
The following pages document curses functions provided by tinfo.
extensions(3NCURSES) - miscellaneous ncurses extensions
inopts(3NCURSES) - curses input options
kernel(3NCURSES) - low-level curses routines
termattrs(3NCURSES) - curses environment query routines
termcap(3NCURSES) - curses emulation of termcap
terminfo(3NCURSES) - curses interface to terminfo database
util(3NCURSES) - miscellaneous curses utility routines
```