### PR TITLE
[rust] Upgrade to v1.90.0

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://static.rust-lang.org/dist/channel-rust-1.89.0.toml": {
+    "https://static.rust-lang.org/dist/channel-rust-1.90.0.toml": {
       "type": "sha256",
-      "value": "fbd1662e100e7b305908ece23b441cb7534eadfa6336c5f173ff08d1cec174a1"
+      "value": "489c19f20d331765ab2835661eb546de90f6446a107a8db83045e7371e45cae2"
     }
   }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -110,6 +110,20 @@ export default async function rust(): Promise<std.Recipe<std.Directory>> {
           extraRuntimeLibraryPaths: ["lib"],
         },
       }),
+    )
+    .pipe((recipe) =>
+      useBriocheLd(recipe, {
+        ldPaths: [`lib/rustlib/${targetTriple()}/bin/rust-lld`],
+        interpreterPaths: {
+          [dynamicLinkerPath()]: `lib/rustlib/${targetTriple()}/libexec/brioche-ld/ld-linux.so`,
+        },
+      }),
+    )
+    .pipe((recipe) =>
+      recipe.insert(
+        `lib/rustlib/${targetTriple()}/libexec/brioche-ld/ld-linux.so`,
+        dynamicLinker,
+      ),
     );
 }
 
@@ -541,4 +555,89 @@ function targetTriple(): string {
         `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the rust package`,
       );
   }
+}
+
+function dynamicLinkerPath(): string {
+  switch (std.CURRENT_PLATFORM) {
+    case "x86_64-linux":
+      return "lib64/ld-linux-x86-64.so.2";
+    case "aarch64-linux":
+      return "lib/ld-linux-aarch64.so.1";
+    default:
+      throw new Error(
+        `The platform '${std.CURRENT_PLATFORM}' is currently not supported by this version of the rust package`,
+      );
+  }
+}
+
+function dynamicLinker(): std.Recipe<std.File> {
+  return std
+    .process({
+      command: "cp",
+      args: [std.tpl`${std.toolchain}/${dynamicLinkerPath()}`, std.outputPath],
+      dependencies: [std.tools],
+    })
+    .toFile();
+}
+
+interface UseBriocheLdOptions {
+  ldPaths: string[];
+  interpreterPaths: Record<string, string>;
+}
+
+// TODO: This was copy/pasted from `std/toolchain/utils.bri`, we should figure
+// out a good place to put this
+export function useBriocheLd(
+  dir: std.Recipe<std.Directory>,
+  options: UseBriocheLdOptions,
+): std.Recipe<std.Directory> {
+  const briocheLd = std.runtimeUtils().get("bin/brioche-ld");
+  const briochePacked = std.runtimeUtils().get("bin/brioche-packed-exec");
+
+  for (const ldPath of options.ldPaths) {
+    const systemLd = dir.get(ldPath);
+
+    const ldDir = ldPath.split("/").slice(0, -1).join("/");
+    const ldParentDirComponents = ldDir.split("/").slice(0, -1);
+    const ldName = ldPath.split("/").at(-1);
+    const ldParentDirName = ldDir.split("/").at(-1);
+    std.assert(ldName != null && ldParentDirName != null);
+
+    const libexecBriocheLdDir = [
+      ...ldParentDirComponents,
+      "libexec",
+      "brioche-ld",
+    ].join("/");
+
+    for (const [interpreterPath, interpreterTargetPath] of Object.entries(
+      options.interpreterPaths,
+    )) {
+      const interpreterDir = interpreterPath.split("/").slice(0, -1).join("/");
+      const pathToBriocheLd = interpreterDir
+        .split("/")
+        .map(() => "..")
+        .join("/");
+      const pathToRoot = libexecBriocheLdDir
+        .split("/")
+        .map(() => "..")
+        .join("/");
+      const interpreterTarget = `${pathToBriocheLd}/${pathToRoot}/${interpreterTargetPath}`;
+      dir = dir.insert(
+        `${libexecBriocheLdDir}/${interpreterPath}`,
+        std.symlink({ target: interpreterTarget }),
+      );
+    }
+
+    dir = dir.insert(
+      `${libexecBriocheLdDir}/${ldName}`,
+      std.symlink({
+        target: `../../${ldParentDirName}/.brioche-ld-orig-${ldName}`,
+      }),
+    );
+    dir = dir.insert(`${libexecBriocheLdDir}/brioche-packed`, briochePacked);
+    dir = dir.insert(`${ldDir}/.brioche-ld-orig-${ldName}`, systemLd);
+    dir = dir.insert(ldPath, briocheLd);
+  }
+
+  return dir;
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -5,7 +5,7 @@ import * as t from "typer";
 
 export const project = {
   name: "rust",
-  version: "1.89.0",
+  version: "1.90.0",
   repository: "https://github.com/rust-lang/rust",
 };
 

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -98,7 +98,12 @@ export default async function rust(): Promise<std.Recipe<std.Directory>> {
     })
     .pipe((recipe) =>
       std.autopack(recipe, {
-        globs: ["bin/**", "libexec/**", "lib/librustc_driver-*.so"],
+        globs: [
+          "bin/**",
+          "libexec/**",
+          "lib/librustc_driver-*.so",
+          "lib/rustlib/*/bin/**",
+        ],
         selfDependency: true,
         dynamicBinaryConfig: {
           skipLibraries: localLibNames,


### PR DESCRIPTION
[Rust v1.90.0](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/) was released ~today.

One of the big new features was switching to `ld.lld` by default. Since we use wrappers for linker shenanigans, our Rust package needed some tweaks to wrap the included `ld.lld` executable appropriately.

For now, I just ended up copy/pasting the `useBriocheLd` function from [`std/toolchain/utils.bri`](https://github.com/brioche-dev/brioche-packages/blob/c5956d746351635dd0a2e6596dc3d92ccb8d0a89/packages/std/toolchain/utils.bri#L33). It's a pretty specialized function, so I opted to copy/paste rather than including it in the public interface of the `std` package, at least for the time being (...although I'm not really opposed to just making `useBriocheLd` public from `std`, even if the interface isn't perfect now-- I might do a follow-up).

Locally, I tested with `brioche build -p packages/ripgrep -e test` and `brioche build -p packages/nushell -e test`, both seemed to work without any problems, so it seems like this is in a good place to try and get in.