### PR TITLE
Add a new std function to ensure libtool files do not contain absolute deps path

### DIFF
--- a/packages/std/extra/index.bri
+++ b/packages/std/extra/index.bri
@@ -7,6 +7,7 @@ export * from "./set_env.bri";
 export * from "./with_runnable_link.bri";
 export * from "./apply_patch.bri";
 export * from "./live_update";
+export * from "./libtool_sanitize_dependencies.bri";
 export * from "./pkg_config_make_paths_relative.bri";
 export * from "./project_version";
 

--- a/packages/std/extra/libtool_sanitize_dependencies.bri
+++ b/packages/std/extra/libtool_sanitize_dependencies.bri
@@ -1,0 +1,27 @@
+import * as std from "/core";
+import { runBash } from "./run_bash.bri";
+
+/**
+ * Create a recipe that replaces dependencies absolute paths in libtool files
+ * with the corresponding linker flag.
+ *
+ * This is useful for ensuring that libtool files can be used in different
+ * environments without needing to modify them manually.
+ *
+ * @param recipe - The recipe to apply the transformation to.
+ *
+ * @returns A new recipe with the transformed libtool files.
+ *
+ * @remarks This function looks for libtool files in the standard locations
+ *   `lib` relative to the `$BRIOCHE_OUTPUT` output directory, and updates
+ *   the variable `dependency_libs`.
+ */
+export function libtoolSanitizeDependencies(
+  recipe: std.RecipeLike<std.Directory>,
+): std.Recipe<std.Directory> {
+  return runBash`
+    sed -i -e "/^dependency_libs='/,/'/ s#//lib/lib\\([^\\s]*\\)\\.la#-l\\1#g" "$BRIOCHE_OUTPUT"/lib/*.la
+  `
+    .outputScaffold(recipe)
+    .toDirectory();
+}

--- a/packages/std/toolchain/native/acl.bri
+++ b/packages/std/toolchain/native/acl.bri
@@ -41,7 +41,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         "pipefail",
         "-c",
         std.indoc`
-          sed -i 's|//lib/lib\\([^\\s]*\\).la|-l\\1|g' "$BRIOCHE_OUTPUT"/lib/*.la
+          sed -i 's|//lib/lib\\([^\\s]*\\)\\.la|-l\\1|g' "$BRIOCHE_OUTPUT"/lib/*.la
         `,
       ],
       env: {

--- a/packages/std/toolchain/native/acl.bri
+++ b/packages/std/toolchain/native/acl.bri
@@ -41,8 +41,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
         "pipefail",
         "-c",
         std.indoc`
-          cd "$BRIOCHE_OUTPUT"
-          sed -i 's|//lib/lib\\([^\\s]*\\).la|-l\\1|g' lib/*.la
+          sed -i 's|//lib/lib\\([^\\s]*\\).la|-l\\1|g' "$BRIOCHE_OUTPUT"/lib/*.la
         `,
       ],
       env: {


### PR DESCRIPTION
Add a new std function (inspired from the post process of `acl` recipe of the std toolchain) to ensure libtool files do not contain absolute deps path inside the variable `dependency_libs`. I discovered all of that by working on packaging `libx11` locally (and it now work 🚀), but I first need to upstream a few updates around `libxau` and `libxcb` to make use of the new std method related to libtool files.

Before:

```bash
> cat /tmp/output/lib/libxcb-composite.la
# libxcb-composite.la - a libtool library file
# Generated by libtool (GNU libtool) 2.4.7
#
# Please DO NOT delete this file!
# It is necessary for linking the library.

# The name that we can dlopen(3).
dlname='libxcb-composite.so.0'

# Names of this library.
library_names='libxcb-composite.so.0.0.0 libxcb-composite.so.0 libxcb-composite.so'

# The name of the static archive.
old_library='libxcb-composite.a'

# Linker flags that cannot go in dependency_libs.
inherited_linker_flags=''

# Libraries that this one depends upon.
dependency_libs=' //lib/libxcb.la -L/home/brioche-runner-eaf315e60b9ee608cdcfe57271bb2c755cbe20586c1aebceafe6f992958ff40c/.local/share/brioche/locals/7030701dd55d14702c05c7382ff7ab39d84601640d2c4a06e5d15660083564b7/lib/pkgconfig/../../lib //lib/libXau.la'

# Names of additional weak libraries provided by this library
weak_library_names=''

# Version information for libxcb-composite.
current=0
age=0
revision=0

# Is this an already installed library?
installed=yes

# Should we warn about portability when linking against -modules?
shouldnotlink=no

# Files to dlopen/dlpreopen
dlopen=''
dlpreopen=''

# Directory that this library needs to be installed in:
libdir='//lib'
```

After:

```bash
> cat /tmp/output/lib/libxcb-composite.la
# libxcb-composite.la - a libtool library file
# Generated by libtool (GNU libtool) 2.4.7
#
# Please DO NOT delete this file!
# It is necessary for linking the library.

# The name that we can dlopen(3).
dlname='libxcb-composite.so.0'

# Names of this library.
library_names='libxcb-composite.so.0.0.0 libxcb-composite.so.0 libxcb-composite.so'

# The name of the static archive.
old_library='libxcb-composite.a'

# Linker flags that cannot go in dependency_libs.
inherited_linker_flags=''

# Libraries that this one depends upon.
dependency_libs=' -lxcb -L/home/brioche-runner-eaf315e60b9ee608cdcfe57271bb2c755cbe20586c1aebceafe6f992958ff40c/.local/share/brioche/locals/7030701dd55d14702c05c7382ff7ab39d84601640d2c4a06e5d15660083564b7/lib/pkgconfig/../../lib -lXau'

# Names of additional weak libraries provided by this library
weak_library_names=''

# Version information for libxcb-composite.
current=0
age=0
revision=0

# Is this an already installed library?
installed=yes

# Should we warn about portability when linking against -modules?
shouldnotlink=no

# Files to dlopen/dlpreopen
dlopen=''
dlpreopen=''

# Directory that this library needs to be installed in:
libdir='//lib'
```