### PR TITLE
Tweak pkgconfig files

### DIFF
--- a/packages/jq/project.bri
+++ b/packages/jq/project.bri
@@ -23,7 +23,16 @@ export default function jq(): std.Recipe<std.Directory> {
     .workDir(source)
     .dependencies(std.toolchain)
     .toDirectory()
-    .pipe((recipe) => std.withRunnableLink(recipe, "bin/jq"));
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/jq"),
+    );
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -24,7 +24,19 @@ export default function kmod(): std.Recipe<std.Directory> {
   `
     .workDir(source)
     .dependencies(std.toolchain, meson, ninja, scdoc, openssl)
-    .toDirectory();
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: {
+            append: [{ path: "lib/pkgconfig" }, { path: "share/pkgconfig" }],
+          },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/kmod"),
+    );
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {

--- a/packages/postgresql/project.bri
+++ b/packages/postgresql/project.bri
@@ -37,12 +37,15 @@ export default function postgresql(): std.Recipe<std.Directory> {
       OMP_NUM_THREADS: "16",
     })
     .toDirectory()
-    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
-      std.setEnv(recipe, {
-        LIBRARY_PATH: { append: [{ path: "lib" }] },
-        CPATH: { append: [{ path: "include" }] },
-        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
-      }),
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          CPATH: { append: [{ path: "include" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/postgres"),
     );
 }
 

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -24,7 +24,15 @@ export default function scdoc(): std.Recipe<std.Directory> {
       // TODO: Remove this and make it so brioche-ld handles this properly
       BRIOCHE_LD_AUTOPACK: "false",
     })
-    .toDirectory();
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/scdoc"),
+    );
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {


### PR DESCRIPTION
See https://github.com/brioche-dev/brioche-packages/pull/1286 for context. This PR adds the missing calling to `std.pkgConfigMakePathsRelative` where the recipe contains a pkgconfig folder.

This PR is interesting for `scdoc`, since it's used by `kmod` which is in turn used by `linux` recipe.