### PR TITLE
feat(libx11): add package

### DIFF
--- a/packages/libx11/brioche.lock
+++ b/packages/libx11/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libX11-1.8.12.tar.xz": {
+      "type": "sha256",
+      "value": "fa026f9bb0124f4d6c808f9aef4057aad65e7b35d8ff43951cef0abe06bb9a9a"
+    }
+  }
+}

--- a/packages/libx11/project.bri
+++ b/packages/libx11/project.bri
@@ -1,0 +1,78 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import utilMacros from "util_macros";
+import xorgproto from "xorgproto";
+import xtrans from "xtrans";
+
+export const project = {
+  name: "libx11",
+  version: "1.8.12",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libX11-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libx11(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-unix-transport \
+      --enable-tcp-transport \
+      --enable-ipv6 \
+      --enable-loadable-i18n \
+      --enable-xthreads
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, utilMacros, xorgproto, xtrans, libxau, libxcb)
+    .workDir(source)
+    .env({})
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion x11 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libx11)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libX11") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libX11-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libx11`](https://x.org/releases/current/doc/libX11/libX11/libX11.html): an X Window System protocol client library written in the C programming language. It contains functions for interacting with an X server. These functions allow programmers to write programs without knowing the details of the X protocol.

```bash
Result: 2b3c907b94aaea906d85b2ec6ff6f642cf36b78fc0a0010bc1f26187853392e6

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "libx11",
  "version": "1.8.12"
}

⏵ Task `Run package live-update` finished successfully
```