### PR TITLE
feat(cargo_tarpaulin): add package

### DIFF
--- a/packages/cargo_tarpaulin/brioche.lock
+++ b/packages/cargo_tarpaulin/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-tarpaulin/0.32.8/download": {
+      "type": "sha256",
+      "value": "ada964af4d3e366851d5e75950b0bd167eacbbcf5493c6f1fdc8694428db7558"
+    }
+  }
+}

--- a/packages/cargo_tarpaulin/project.bri
+++ b/packages/cargo_tarpaulin/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import openssl from "openssl";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_tarpaulin",
+  version: "0.32.8",
+  extra: {
+    crateName: "cargo-tarpaulin",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoTarpaulin(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    dependencies: [openssl],
+    runnable: "bin/cargo-tarpaulin",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo tarpaulin --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoTarpaulin)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-tarpaulin-tarpaulin ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_tarpaulin`](https://github.com/xd009642/tarpaulin): a code coverage tool for Rust projects

```bash
Build finished, completed 1 job in 10.35s
Running brioche-run
{
  "name": "cargo_tarpaulin",
  "version": "0.32.8",
  "extra": {
    "crateName": "cargo-tarpaulin"
  }
}

⏵ Task `Run package live-update` finished successfully
```

I wasn't able to generate the output for testing, but it was working yesterday. I'm having network issues right now (since I'm on my mobile network, and for some reasons I can't access the crates.io API through my mobile network...):

```bash
63018  │     Updating crates.io index
       │ warning: spurious network error (3 tries remaining): [28] Timeout was reached (Connection timed out after 30014 milliseconds)
       │ warning: spurious network error (2 tries remaining): [28] Timeout was reached (Connection timed out after 30018 milliseconds)
       │ warning: spurious network error (1 try remaining): [28] Timeout was reached (Connection timed out after 30021 milliseconds)
       │ error: failed to sync
       │ Caused by:
       │   failed to load lockfile for /home/brioche-runner-b99e339fb53a6e3702a933acd54872b4dfb341733e438e6d8067c0d3d7cc9fce/.local/share/brioche/outputs/output-b99e339fb53a6e3702a933acd54872b4dfb341733e438e6d8067c0d3d7cc9fce
       │ Caused by:
       │   failed to get `cargo_metadata` as a dependency of package `cargo-tarpaulin v0.0.1 (/home/brioche-runner-b99e339fb53a6e3702a933acd54872b4dfb341733e438e6d8067c0d3d7cc9fce/.local/share/brioche/outputs/output-b99e339fb53a6e3702a933acd54872b4dfb341733e438e6d8067c0d3d7cc9fce)`
       │ Caused by:
       │   download of config.json failed
       │ Caused by:
       │   failed to download from `https://index.crates.io/config.json`
       │ Caused by:
       │   [28] Timeout was reached (Connection timed out after 30022 milliseconds)
```

