### PR TITLE
feat(libxpm): add package

### DIFF
--- a/packages/libxpm/brioche.lock
+++ b/packages/libxpm/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXpm-3.5.17.tar.xz": {
+      "type": "sha256",
+      "value": "64b31f81019e7d388c822b0b28af8d51c4622b83f1f0cb6fa3fc95e271226e43"
+    }
+  }
+}

--- a/packages/libxpm/project.bri
+++ b/packages/libxpm/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxpm",
+  version: "3.5.17",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXpm-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxpm(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, libx11, libxau, libxcb)
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/cxpm"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xpm | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxpm)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXpm") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXpm-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package `libxpm`: this package contains the X PixMap library. XPM (X PixMap) is a format for storing and retrieving X pixmaps to and from files.

```bash
Build finished, completed 1 job in 10.56s
Running brioche-run
{
  "name": "libxpm",
  "version": "3.5.17"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 6 jobs in 19.68s
Result: 63fd1f03f2613170dc1213c4b61ca2fcb0a4aa099dc333875c8676f8126a93cb

⏵ Task `Run package test` finished successfully
```