### PR TITLE
Update "Live updates" workflow to refresh GitHub app token

### DIFF
--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -10,7 +10,7 @@ jobs:
     name: Live-update packages
     runs-on: ubuntu-24.04
     steps:
-      - name: Create GitHub App Token
+      - name: Create GitHub app token
         uses: actions/create-github-app-token@v2
         id: app-token
         with:
@@ -88,10 +88,20 @@ jobs:
           git checkout "$git_head"
           printf "%s\n" "${failed_packages[@]}" > failed-packages.txt
 
+      # Create a fresh GitHub app token to authenticate PR pushes, in case
+      # the previous token expired already (at the time of writing, tokens
+      # are valid for 1 hour)
+      - name: Create GitHub app token
+        uses: actions/create-github-app-token@v2
+        id: app-token-2
+        with:
+          app-id: ${{ vars.LIVE_UPDATE_APP_ID }}
+          private-key: ${{ secrets.LIVE_UPDATE_PRIVATE_KEY }}
+
       - name: Configure git credentials
         run: git remote set-url origin "$auth_url"
         env:
-          auth_url: https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
+          auth_url: https://x-access-token:${{ steps.app-token-2.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Push branches
         run: |
@@ -112,7 +122,7 @@ jobs:
         env:
           run_label: "${{ github.workflow }} #${{ github.run_number}}"
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-2.outputs.token }}
 
       - name: Check for failed packages
         run: |


### PR DESCRIPTION
The [last "Live updates" workflow run](https://github.com/brioche-dev/brioche-packages/actions/runs/18038375041) failed to create PRs for live-updates. The "Push branches" step failed with a bunch of errors like this:

```
Creating PR for live-update/aws_cdk
remote: {"auth_status":"auth_error","body":"Invalid username or token. Password authentication is not supported for Git operations."}
fatal: Authentication failed for 'https://github.com/brioche-dev/brioche-packages.git/'
Error: Failed to push live-update/aws_cdk
Creating PR for live-update/aws_cli
remote: {"auth_status":"auth_error","body":"Invalid username or token. Password authentication is not supported for Git operations."}
fatal: Authentication failed for 'https://github.com/brioche-dev/brioche-packages.git/'
Error: Failed to push live-update/aws_cli
Creating PR for live-update/broot
remote: {"auth_status":"auth_error","body":"Invalid username or token. Password authentication is not supported for Git operations."}
fatal: Authentication failed for 'https://github.com/brioche-dev/brioche-packages.git/'
Error: Failed to push live-update/broot
...
```

When pushing branches and creating PRs, the workflow uses a [GitHub app installation access token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#about-installation-access-tokens) created by the [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) action. The job was creating a token at the start and re-using it at the end. But since [these tokens expire after 1 hour](https://github.com/actions/create-github-app-token/tree/b96fde71c0080358ed6e2d162f11c612c92a97d1?tab=readme-ov-file#usage) and the "Live updates" workflow failed after 1 hour and 7 minutes, I believe the error was from the token expiring.

This PR adjusts the workflow to create a fresh app installation access token just before pushing the PRs, which should prevent the same issue from occurring. (Okay, we _could_ hit the same problem if it takes more than an hour just to open all the PRs, but we've still got time before that happens!)