### PR TITLE
feat(libxext): add package

### DIFF
--- a/packages/libxext/brioche.lock
+++ b/packages/libxext/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXext-1.3.6.tar.xz": {
+      "type": "sha256",
+      "value": "edb59fa23994e405fdc5b400afdf5820ae6160b94f35e3dc3da4457a16e89753"
+    }
+  }
+}

--- a/packages/libxext/project.bri
+++ b/packages/libxext/project.bri
@@ -1,0 +1,71 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxext",
+  version: "1.3.6",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXext-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxext(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, libx11, libxau, libxcb)
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xext | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxext)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXext") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXext-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package `libxext`:  X11 miscellaneous extensions library. libXext provides an X Window System client interface to several extensions to the X protocol, iincluding DOUBLE-BUFFER (DBE), DPMS, Extended-Visual-Information (EVI), LBX, MIT-SHM, MIT-SUNDRY-NONSTANDARD, Multi-Buffering, SECURITY, SHAPE, SHAPE, SYNC, TOG-CUP, XC-APPGROUP, XC-MISC, XTEST and possibly others.

```bash
Running brioche-run
{
  "name": "libxext",
  "version": "1.3.6"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 1 job in 2.49s
Result: 649015f1207cbf63f38810b1dc94819132640440bae6911c6c698314b34770de

⏵ Task `Run package test` finished successfully
```