### PR TITLE
feat(libxmu): add package

### DIFF
--- a/packages/libxmu/brioche.lock
+++ b/packages/libxmu/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXmu-1.2.1.tar.xz": {
+      "type": "sha256",
+      "value": "fcb27793248a39e5fcc5b9c4aec40cc0734b3ca76aac3d7d1c264e7f7e14e8b2"
+    }
+  }
+}

--- a/packages/libxmu/project.bri
+++ b/packages/libxmu/project.bri
@@ -1,0 +1,85 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libice from "libice";
+import libsm from "libsm";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import libxt from "libxt";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxmu",
+  version: "1.2.1",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXmu-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxmu(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(
+      std.toolchain,
+      xorgproto,
+      libice,
+      libsm,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      libxt,
+    )
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xmu | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxmu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXmu") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXmu-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxmu`](https://www.x.org/releases/X11R7.7/doc/libXmu/Xmu.html): a collection of miscellaneous (some might say random) utility functions that have been useful in building various applications and widgets. This library is required by the Athena Widgets.

```bash
Running brioche-run
{
  "name": "libxmu",
  "version": "1.2.1"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.72s
Result: 533ab8419757ea9170f559b09f12537dde6c5a83e08b41bbdf9939779808757a

⏵ Task `Run package test` finished successfully
```