### PR TITLE
feat(libxrender): add package

### DIFF
--- a/packages/libxrender/brioche.lock
+++ b/packages/libxrender/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXrender-0.9.12.tar.xz": {
+      "type": "sha256",
+      "value": "b832128da48b39c8d608224481743403ad1691bf4e554e4be9c174df171d1b97"
+    }
+  }
+}

--- a/packages/libxrender/project.bri
+++ b/packages/libxrender/project.bri
@@ -1,0 +1,71 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxrender",
+  version: "0.9.12",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXrender-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxrender(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, libx11, libxau, libxcb)
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xrender | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxrender)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXrender") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXrender-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxrender`](https://www.x.org/releases/current/doc/renderproto/renderproto.txt): The X Rendering Extension (Render) introduces digital image composition as the foundation of a new rendering model within the X Window System.

```bash
Running brioche-run
{
  "name": "libxrender",
  "version": "0.9.12"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.16s
Result: 4b45d93833be69cc8f88054a1ef65115f82a0752c7eb8b117f6c825b9b561e21

⏵ Task `Run package test` finished successfully
```