### PR TITLE
feat(ck_search): add package

### DIFF
--- a/packages/ck_search/brioche.lock
+++ b/packages/ck_search/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/ck-search/0.5.3/download": {
+      "type": "sha256",
+      "value": "cfe1c301c7ff642eebd543442db9eda814e24a9d898e0ddbe9436307ff58baa0"
+    }
+  }
+}

--- a/packages/ck_search/project.bri
+++ b/packages/ck_search/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import openssl from "openssl";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "ck_search",
+  version: "0.5.3",
+  extra: {
+    crateName: "ck-search",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function ckSearch(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [openssl],
+    unsafe: {
+      // Needed to run custom build command for 'ort-sys'
+      networking: true,
+    },
+    runnable: "bin/ck",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ck --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ckSearch)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ck ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`ck_search`](https://github.com/BeaconBay/ck): Local first semantic and hybrid BM25 grep / search tool for use by AI and humans

```bash
Build finished, completed (no new jobs) in 13.60s
Running brioche-run
{
  "name": "ck_search",
  "version": "0.5.3",
  "extra": {
    "crateName": "ck-search"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 5.15s
Result: 0310594206ad25a37108f14d822026eebb7ced99c8f4f3461f53ecc9a018d861

⏵ Task `Run package test` finished successfully
```