### PR TITLE
feat(libxfixes): add package

### DIFF
--- a/packages/libxfixes/brioche.lock
+++ b/packages/libxfixes/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXfixes-6.0.2.tar.xz": {
+      "type": "sha256",
+      "value": "39f115d72d9c5f8111e4684164d3d68cc1fd21f9b27ff2401b08fddfc0f409ba"
+    }
+  }
+}

--- a/packages/libxfixes/project.bri
+++ b/packages/libxfixes/project.bri
@@ -1,0 +1,71 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxfixes",
+  version: "6.0.2",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXfixes-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxfixes(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xorgproto, libx11, libxau, libxcb)
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xfixes | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxfixes)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXfixes") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXfixes-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxfixes`](https://www.x.org/releases/X11R7.6/doc/man/man3/Xfixes.3.xhtml): a simple library designed to interface the X Fixes Extension. This extension provides application with work arounds for various limitations in the core protocol.

```bash
Build finished, completed (no new jobs) in 12.61s
Running brioche-run
{
  "name": "libxfixes",
  "version": "6.0.2"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.19s
Result: 89022b7044c460b13ae51956b88cdc4345a2db3a0edfde1f76d38f7b116b9077

⏵ Task `Run package test` finished successfully
```