### PR TITLE
chore(re2c): update recipe to remove uneeded post build env var

### DIFF
--- a/packages/re2c/project.bri
+++ b/packages/re2c/project.bri
@@ -23,16 +23,7 @@ export default function re2c(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain, python)
     .workDir(source)
     .toDirectory()
-    .pipe(
-      std.pkgConfigMakePathsRelative,
-      (recipe) =>
-        std.setEnv(recipe, {
-          CPATH: { append: [{ path: "include" }] },
-          LIBRARY_PATH: { append: [{ path: "lib" }] },
-          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
-        }),
-      (recipe) => std.withRunnableLink(recipe, "bin/re2c"),
-    );
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/re2c"));
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {


### PR DESCRIPTION
We were setting `CPATH`, `LIBRARY_PATH` and `PKG_CONFIG_PATH`, but there is no `include` folder nor `lib` folder:

```bash
> rm -rf /tmp/output; brioche build -o /tmp/output -p packages/eigen/
Build finished, completed (no new jobs) in 0.93s
Result: f7d39cea0f711bf3dfe397965572e91485471f053d86544836f8ada9eb140a0f
Writing output
Wrote output to /tmp/output
> ls /tmp/output
brioche-env.d  include  share
```

Don't ask me how I discovered it... You won't like 🤣 I'll open another PR for that