### PR TITLE
feat(cargo_expand): add package

### DIFF
--- a/packages/cargo_expand/brioche.lock
+++ b/packages/cargo_expand/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-expand/1.0.117/download": {
+      "type": "sha256",
+      "value": "603ddec49eb4fd6a2da1eda15a36ca280a3838b61937d04934fd9dc30caaab75"
+    }
+  }
+}

--- a/packages/cargo_expand/project.bri
+++ b/packages/cargo_expand/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_expand",
+  version: "1.0.117",
+  extra: {
+    crateName: "cargo-expand",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoExpand(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-expand",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo expand --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoExpand)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-expand ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_expand`](https://github.com/dtolnay/cargo-expand): a subcommand to show result of macro expansion.

```bash
Build finished, completed (no new jobs) in 13.02s
Running brioche-run
{
  "name": "cargo_expand",
  "version": "1.0.117",
  "extra": {
    "crateName": "cargo-expand"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 4.43s
Result: 385e2cd6bf034610a96f27d6a5b31868adb306bc31d4ef51ddab6efa41e9c5e9

⏵ Task `Run package test` finished successfully
```