### PR TITLE
feat(libxrandr): add package

### DIFF
--- a/packages/libxrandr/brioche.lock
+++ b/packages/libxrandr/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXrandr-1.5.4.tar.xz": {
+      "type": "sha256",
+      "value": "1ad5b065375f4a85915aa60611cc6407c060492a214d7f9daf214be752c3b4d3"
+    }
+  }
+}

--- a/packages/libxrandr/project.bri
+++ b/packages/libxrandr/project.bri
@@ -1,0 +1,81 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import libxrender from "libxrender";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxrandr",
+  version: "1.5.4",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXrandr-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxrandr(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(
+      std.toolchain,
+      xorgproto,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      libxrender,
+    )
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xrandr | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxrandr)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXrandr") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXrandr-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxrandr`](https://x.org/releases/X11R7.5/doc/man/man1/xrandr.1.html): Xrandr is used to set the size, orientation and/or reflection of the outputs for a screen. It can also set the screen size.

```bash
Build finished, completed (no new jobs) in 2.45s
Result: f15abcc4d150214c697ed89fc601febe272cdbcd1ac20abf87c818249aebe994

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 13.61s
Running brioche-run
{
  "name": "libxrandr",
  "version": "1.5.4"
}

⏵ Task `Run package live-update` finished successfully
```