### PR TITLE
refactor(nasm): update recipe to use download instead of git checkout

### DIFF
--- a/packages/nasm/brioche.lock
+++ b/packages/nasm/brioche.lock
@@ -1,8 +1,9 @@
 {
   "dependencies": {},
-  "git_refs": {
-    "https://github.com/netwide-assembler/nasm": {
-      "nasm-2.16.03": "cd37b81b320ead83ca5a6bbce5da0a6456663bc6"
+  "downloads": {
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.xz": {
+      "type": "sha256",
+      "value": "1412a1c760bbd05db026b6c0d1657affd6631cd0a63cddb6f73cc6d4aa616148"
     }
   }
 }

--- a/packages/nasm/project.bri
+++ b/packages/nasm/project.bri
@@ -6,24 +6,22 @@ export const project = {
   repository: "https://github.com/netwide-assembler/nasm",
 };
 
-const source = Brioche.gitCheckout({
-  repository: project.repository,
-  ref: `nasm-${project.version}`,
-});
+const source = Brioche.download(
+  `https://www.nasm.us/pub/nasm/releasebuilds/${project.version}/nasm-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
 
 export default function nasm(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./autogen.sh
-    ./configure
+    ./configure --prefix=/
     make -j "$(nproc)"
-    make strip
-    mkdir -p "$BRIOCHE_OUTPUT/bin"
-    cp nasm "$BRIOCHE_OUTPUT/bin/nasm"
-    ln -s "bin/nasm" "$BRIOCHE_OUTPUT/brioche-run"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
   `
     .dependencies(std.toolchain)
     .workDir(source)
-    .toDirectory();
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/nasm"));
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {


### PR DESCRIPTION
By using directly the archive from the repository, it simplifies the build process of nasm. 

Bonus point: with the usage of `make install`, we now have two binaries available when installing this recipe:

```bash
> ls /tmp/output/bin/
nasm  ndisasm
```