### PR TITLE
[CI] Use GitHub Action to install Brioche nightly

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -23,10 +23,6 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 1440
     steps:
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
       - name: Checkout code
         uses: actions/checkout@v5
 

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -31,13 +31,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Brioche
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/$PLATFORM/brioche -o ~/.local/bin/brioche
-          chmod +x ~/.local/bin/brioche
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-        env:
-          PLATFORM: ${{ matrix.platform }}
+        uses: brioche-dev/setup-brioche@v1
+        with:
+          version: "nightly"
 
       - name: Build packages
         run: |

--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -12,11 +12,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Brioche
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/x86_64-linux/brioche -o ~/.local/bin/brioche
-          chmod +x ~/.local/bin/brioche
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: brioche-dev/setup-brioche@v1
+        with:
+          version: "nightly"
 
       - name: Check packages
         run: |

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -34,11 +34,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Install Brioche
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/x86_64-linux/brioche -o ~/.local/bin/brioche
-          chmod +x ~/.local/bin/brioche
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: brioche-dev/setup-brioche@v1
+        with:
+          version: "nightly"
 
       - name: Update packages
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,11 +27,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Brioche
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/x86_64-linux/brioche -o ~/.local/bin/brioche
-          chmod +x ~/.local/bin/brioche
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: brioche-dev/setup-brioche@v1
+        with:
+          version: "nightly"
 
       - name: Publish packages
         run: |


### PR DESCRIPTION
Based on top of #1393.

Similar to https://github.com/brioche-dev/brioche/pull/317.

Following the release of https://github.com/brioche-dev/setup-brioche/releases/tag/v1.4.0, we can now make use of the latest capability of the Brioche GitHub Action in the CI to streamline the installation of Brioche.