### PR TITLE
feat(libxi): add package

### DIFF
--- a/packages/libxi/brioche.lock
+++ b/packages/libxi/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXi-1.8.2.tar.xz": {
+      "type": "sha256",
+      "value": "d0e0555e53d6e2114eabfa44226ba162d2708501a25e18d99cfb35c094c6c104"
+    }
+  }
+}

--- a/packages/libxi/project.bri
+++ b/packages/libxi/project.bri
@@ -1,0 +1,81 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import libxfixes from "libxfixes";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxi",
+  version: "1.8.2",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXi-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxi(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(
+      std.toolchain,
+      xorgproto,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      libxfixes,
+    )
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xi | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxi)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXi") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXi-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxi`](https://x.org/releases/X11R7.7/doc/libXi/inputlib.html): a library for the X Input Extension.

```bash
Build finished, completed 11 jobs in 45.88s
Result: 3f122b72902789273f2439b9928bad9992270e91ebeb790ad04788af9258807a

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 6 jobs in 49.47s
Running brioche-run
{
  "name": "libxi",
  "version": "1.8.2"
}

⏵ Task `Run package live-update` finished successfully
```