### PR TITLE
feat(gitlab): improve the script to retrieve and process multiple releases from GitLab

### DIFF
--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -3,19 +3,30 @@ mut project = $env.project
   | from json
 
 # Retrieve the latest release information from GitLab
-let releaseInfo = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases/permalink/latest'
+let releases = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases'
 
-# Extract the version
-let tagName = $releaseInfo
-  | get tag_name
+# Extract the version(s)
+let releasesInfo = $releases
+  | each {|release|
+    let parsedTag = $release.tag_name
+      | parse --regex $env.matchTag
 
-let parsedTagName = $tagName
-  | parse --regex $env.matchTag
-if ($parsedTagName | length) == 0 {
-  error make { msg: $'Latest release tag ($tagName) did not match regex ($env.matchTag)' }
+    # If no tag is matched, a nil value will be returned
+    # and this value will be ignored by 'each'
+    if ($parsedTag | length) != 0 {
+      { version: $parsedTag.0.version }
+    }
+  }
+  | sort-by --natural version
+
+if ($releasesInfo | length) == 0 {
+  error make { msg: $'No tag did match regex ($env.matchTag)' }
 }
 
-mut version = $parsedTagName.0.version
+let latestReleaseInfo = $releasesInfo
+  | last
+
+mut version = $latestReleaseInfo.version
 
 if $env.normalizeVersion == "true" {
   $version = $version


### PR DESCRIPTION
This PR improves the Nushell script we are using to extract and sort GitLab releases based on a regex pattern. This ensures the latest matching release is used for updates.

Resolves https://github.com/brioche-dev/brioche-packages/issues/1390.

The issue was detected first with `eigen` recipe during the last live update checking:

Before the PR:

```bash
Running brioche-run
{
  "name": "eigen",
  "version": "3.4.1",
  "repository": "https://gitlab.com/libeigen/eigen.git"
}

⏵ Task `Run package live-update` finished successfully
```

After the PR:

```bash
Running brioche-run
{
  "name": "eigen",
  "version": "5.0.0",
  "repository": "https://gitlab.com/libeigen/eigen.git"
}

⏵ Task `Run package live-update` finished successfully
```