### PR TITLE
feat(cargo_c): add package

### DIFF
--- a/packages/cargo_c/brioche.lock
+++ b/packages/cargo_c/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-c/0.10.16+cargo-0.91.0/download": {
+      "type": "sha256",
+      "value": "17d431789b050b0fcf678455dfd5ceb7e5b45cd806140f8fe03b16b995d6cbff"
+    }
+  }
+}

--- a/packages/cargo_c/project.bri
+++ b/packages/cargo_c/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import openssl from "openssl";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_c",
+  version: "0.10.16+cargo-0.91.0",
+  extra: {
+    crateName: "cargo-c",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoC(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    dependencies: [openssl],
+    runnable: "bin/cargo-cinstall",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo cinstall --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoC)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-c ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_c`](https://github.com/lu-zero/cargo-c): to build and install C-compatible libraries.

```bash
Running brioche-run
{
  "name": "cargo_c",
  "version": "0.10.16+cargo-0.91.0",
  "extra": {
    "crateName": "cargo-c"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 1 job in 3.72s
Result: c8fc38deb0ab96cee6dd3b1292f09a587fcf2ed89cc3a78ae00b43aa8147d84d

⏵ Task `Run package test` finished successfully
```