### PR TITLE
feat(cargo_llvm_lines): add package

### DIFF
--- a/packages/cargo_llvm_lines/brioche.lock
+++ b/packages/cargo_llvm_lines/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-llvm-lines/0.4.45/download": {
+      "type": "sha256",
+      "value": "3e27ed7287519b160d7fd055175c11f74d14dff3795f5dcf92582111986a234c"
+    }
+  }
+}

--- a/packages/cargo_llvm_lines/project.bri
+++ b/packages/cargo_llvm_lines/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_llvm_lines",
+  version: "0.4.45",
+  extra: {
+    crateName: "cargo-llvm-lines",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoLlvmLines(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-llvm-lines",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo llvm-lines --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoLlvmLines)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-llvm-lines ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_llvm_lines`](https://github.com/dtolnay/cargo-llvm-lines): count lines of LLVM IR per generic function.

```bash
Running brioche-run
{
  "name": "cargo_llvm_lines",
  "version": "0.4.45",
  "extra": {
    "crateName": "cargo-llvm-lines"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 2 jobs in 5.56s
Result: 7e321787a894d9780c32412d49005619e2cc9a5cf53898f7fe10275d63ef3f58

⏵ Task `Run package test` finished successfully
```