### PR TITLE
feat(libxtst): add a new package

### DIFF
--- a/packages/libxtst/brioche.lock
+++ b/packages/libxtst/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.x.org/archive/individual/lib/libXtst-1.2.5.tar.xz": {
+      "type": "sha256",
+      "value": "b50d4c25b97009a744706c1039c598f4d8e64910c9fde381994e1cae235d9242"
+    }
+  }
+}

--- a/packages/libxtst/project.bri
+++ b/packages/libxtst/project.bri
@@ -1,0 +1,83 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import libxfixes from "libxfixes";
+import libxi from "libxi";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxtst",
+  version: "1.2.5",
+};
+
+const source = Brioche.download(
+  `https://www.x.org/archive/individual/lib/libXtst-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libxtst(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .dependencies(
+      std.toolchain,
+      xorgproto,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      libxfixes,
+      libxi,
+    )
+    .workDir(source)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xtst | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxtst)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.x.org/archive/individual/lib
+      | lines
+      | where {|it| ($it | str contains "libXtst") and (not ($it | str contains ".sig")) }
+      | parse --regex '<a href="libXtst-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
Add a new package [`libxtst`](https://www.x.org/releases/X11R7.7/doc/libXtst/xtestlib.html): this extension is a minimal set of client and server extensions required to completely test the X11 server with no user intervention.

```bash
Running brioche-run
{
  "name": "libxtst",
  "version": "1.2.5"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.59s
Result: f199e8bfbfd5186a08acb30143c3b61239754196f4d472fbab2dc9e2562a3912

⏵ Task `Run package test` finished successfully
```