### PR TITLE
Update CI to install `xz-utils` on self-hosted runners

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl gettext
+          sudo apt-get install -y curl gettext xz-utils
 
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
This PR updates our GitHub Actions CI workflow to install `xz-utils` as a system package for our self-hosted runners. This was prompted by the release of [`setup-brioche` v1.4.1](https://github.com/brioche-dev/setup-brioche/releases/tag/v1.4.1), which now requires `xz-utils` to install nightly Brioche releases.

For more context, see these PRs:

- https://github.com/brioche-dev/setup-brioche/pull/13
- https://github.com/brioche-dev/brioche/pull/281
- https://github.com/brioche-dev/brioche/pull/324