### PR TITLE
chore(std): update the script used to make paths relative in pkgconfig files

### DIFF
--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -9,14 +9,7 @@ export const PKG_CONFIG_MAKE_PATHS_RELATIVE_SCRIPT = std.indoc`
     sed -i 's|^prefix[[:space:]]*=.*|prefix=\${pcfiledir}/../..|' "$file"
     sed -i 's|^exec_prefix[[:space:]]*=.*|exec_prefix=\${prefix}|' "$file"
     sed -i 's|^libdir[[:space:]]*=.*|libdir=\${prefix}/lib|' "$file"
-    # Check if there is an include subdirectory in includedir
-    includedir=$(sed -n 's/^includedir=//p' "$file")
-    if [[ "$includedir" =~ /include/.* ]]; then
-      subdir=$(echo "$includedir" | sed 's|.*/include/||')
-      sed -i "s|^includedir=.*|includedir=\\\${prefix}/include/\${subdir}|" "$file"
-    else
-      sed -i 's|^includedir=.*|includedir=\${prefix}/include|' "$file"
-    fi
+    sed -i 's|^includedir[[:space:]]*=.*/include\\([^"]*\\)"\\?|includedir=\${prefix}/include\\1|' "$file"
 
     # Find and replace common patterns in Libs and Cflags variables
     sed -i -e "/^Libs:/ s|-L/[^[:space:]]*/lib|-L\\\${libdir}|g" "$file"


### PR DESCRIPTION
Part of https://github.com/brioche-dev/brioche-packages/issues/1357.

This PR resolves most of the issues seen in the mentioned issue. Only the variable `Libs.private` will remain to be updated for `libarchive` and `postgresql` recipes. This variable is exposed only when we tried to use `libarchive` and `postgresql` as static libraries:

```bash
pkg-config --libs PACKAGE # 'Libs' is printed
pkg-config --libs --static PACKAGE # 'Libs' and ``Libs.private are printed
```

Note: both recipes exposed static and dynamic linking options:

```bash
> rm -rf /tmp/output; brioche build -o /tmp/output -p packages/libarchive
Build finished, completed 1 job in 3.13s
Result: 14f80a4ee9bb72e0bbd60e8647565bae870c2ab4ddba58add6c03c925707bb28
Writing output
Wrote output to /tmp/output
> ls /tmp/output/lib/
libarchive.a  libarchive.la  libarchive.so  libarchive.so.13  libarchive.so.13.8.0  pkgconfig


> rm -rf /tmp/output; brioche build -o /tmp/output -p packages/postgresql/
Build finished, completed 1 job in 22.17s
Result: 5a529b0026d03420ede02667ee29a945fefb1b2ca24afee6e99fd9011287e193
Writing output
Wrote output to /tmp/output
> ls /tmp/output/lib/
libecpg.a   libecpg.so.6     libecpg_compat.a   libecpg_compat.so.3     libpgcommon.a        libpgfeutils.a  libpgport_shlib.a  libpgtypes.so    libpgtypes.so.3.18  libpq.so    libpq.so.5.18  postgresql
libecpg.so  libecpg.so.6.18  libecpg_compat.so  libecpg_compat.so.3.18  libpgcommon_shlib.a  libpgport.a     libpgtypes.a       libpgtypes.so.3  libpq.a             libpq.so.5  pkgconfig
```