### PR TITLE
feat(github_copilot_cli): add package

### DIFF
--- a/packages/github_copilot_cli/brioche.lock
+++ b/packages/github_copilot_cli/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/github_copilot_cli/project.bri
+++ b/packages/github_copilot_cli/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "github_copilot_cli",
+  version: "0.0.336",
+  extra: {
+    packageName: "@github/copilot",
+  },
+};
+
+export default function githubCopilotCli(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/copilot"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    copilot --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(githubCopilotCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`github_copilot_cli`](https://github.com/github/copilot-cli): GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal.

```bash
Running brioche-run
{
  "name": "github_copilot_cli",
  "version": "0.0.336",
  "extra": {
    "packageName": "@github/copilot"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 9.01s
Result: d20c0d6dc222ed012c5d9275cad2555bd6fdfd10ccb52ca553980e80663e7eeb

⏵ Task `Run package test` finished successfully
```