### PR TITLE
feat(cargo_machete): add package

### DIFF
--- a/packages/cargo_machete/brioche.lock
+++ b/packages/cargo_machete/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-machete/0.9.1/download": {
+      "type": "sha256",
+      "value": "58666d6421d1fc50f0e635a88c1286a6ab73bf3978839e5ac35762cdecf84073"
+    }
+  }
+}

--- a/packages/cargo_machete/project.bri
+++ b/packages/cargo_machete/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_machete",
+  version: "0.9.1",
+  extra: {
+    crateName: "cargo-machete",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoMachete(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/cargo-machete",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo machete --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoMachete)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_machete`](https://github.com/bnjbvr/cargo-machete): Remove unused Rust dependencies with this one weird trick!

```bash
Running brioche-run
{
  "name": "cargo_machete",
  "version": "0.9.1",
  "extra": {
    "crateName": "cargo-machete"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 2.39s
Result: 4d352bd65e6cf1711b8b6b8ed2531130c8b252e752ee15653a269561392e725c

⏵ Task `Run package test` finished successfully
```