### PR TITLE
feat(sendme): add package

### DIFF
--- a/packages/sendme/brioche.lock
+++ b/packages/sendme/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/sendme/0.29.0/download": {
+      "type": "sha256",
+      "value": "526bb8e6e9454b2d38a428ffcbf2e42ecb440446487cf78a8f74156d9ac1f9dd"
+    }
+  }
+}

--- a/packages/sendme/project.bri
+++ b/packages/sendme/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "sendme",
+  version: "0.29.0",
+  extra: {
+    crateName: "sendme",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sendme(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: source,
+    runnable: "bin/sendme",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    sendme --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(sendme)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sendme ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`sendme`](https://github.com/n0-computer/sendme): A cli tool to send directories over the network, with NAT hole punching

```bash
Build finished, completed 2 jobs in 11.20s
Running brioche-run
{
  "name": "sendme",
  "version": "0.29.0",
  "extra": {
    "crateName": "sendme"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 7 jobs in 3m26s
Result: 0e75eb74b32b65e5b1d3bc0bb9d0631a823d74f1e5d8ad3d17f8926bf43ce115

⏵ Task `Run package test` finished successfully
```