### PR TITLE
feat(promptfoo): add package

### DIFF
--- a/packages/promptfoo/brioche.lock
+++ b/packages/promptfoo/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/promptfoo/project.bri
+++ b/packages/promptfoo/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "promptfoo",
+  version: "0.118.14",
+  extra: {
+    packageName: "promptfoo",
+  },
+};
+
+export default function promptfoo(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/promptfoo"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    promptfoo --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(promptfoo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
Add a new package [`promptfoo`](https://github.com/promptfoo/promptfoo): Test your prompts, agents, and RAGs. AI Red teaming, pentesting, and vulnerability scanning for LLMs. Compare performance of GPT, Claude, Gemini, Llama, and more. Simple declarative configs with command line and CI/CD integration.

```bash
Build finished, completed 1 job in 10.35s
Running brioche-run
{
  "name": "promptfoo",
  "version": "0.118.14",
  "extra": {
    "packageName": "promptfoo"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 10.96s
Result: 989a5745bac7c50b0d5f35bf25099f4ae3c1850df3bfa19682260406052c49a0

⏵ Task `Run package test` finished successfully
```