### PR TITLE
refactor(recipe): remove redundant source property in cargoBuild calls

### DIFF
--- a/packages/asciinema/project.bri
+++ b/packages/asciinema/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 
 export default function asciinema(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/asciinema",
   });
 }

--- a/packages/biome/project.bri
+++ b/packages/biome/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function biome(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/biome",
     path: "crates/biome_cli",
     env: {

--- a/packages/cargo_about/project.bri
+++ b/packages/cargo_about/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoAbout(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-about",
   });
 }

--- a/packages/cargo_audit/project.bri
+++ b/packages/cargo_audit/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoAudit(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-audit",
     path: "cargo-audit",
   });

--- a/packages/cargo_binstall/project.bri
+++ b/packages/cargo_binstall/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 
 export default function cargoBinstall(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-binstall",
   });
 }

--- a/packages/cargo_bloat/project.bri
+++ b/packages/cargo_bloat/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoBloat(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-bloat",
   });
 }

--- a/packages/cargo_c/project.bri
+++ b/packages/cargo_c/project.bri
@@ -18,7 +18,7 @@ const source = Brioche.download(
 
 export default function cargoC(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     dependencies: [openssl],
     runnable: "bin/cargo-cinstall",
   });

--- a/packages/cargo_dist/project.bri
+++ b/packages/cargo_dist/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoDist(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     path: "cargo-dist",
     runnable: "bin/dist",
   });

--- a/packages/cargo_expand/project.bri
+++ b/packages/cargo_expand/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 
 export default function cargoExpand(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-expand",
   });
 }

--- a/packages/cargo_llvm_lines/project.bri
+++ b/packages/cargo_llvm_lines/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 
 export default function cargoLlvmLines(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-llvm-lines",
   });
 }

--- a/packages/cargo_msrv/project.bri
+++ b/packages/cargo_msrv/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoMsrv(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-mrsv",
   });
 }

--- a/packages/cargo_mutants/project.bri
+++ b/packages/cargo_mutants/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoMutants(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-mutants",
   });
 }

--- a/packages/cargo_quickinstall/project.bri
+++ b/packages/cargo_quickinstall/project.bri
@@ -17,7 +17,7 @@ const source = Brioche.download(
 
 export default function cargoQuickinstall(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-quickinstall",
   });
 }

--- a/packages/cargo_sort/project.bri
+++ b/packages/cargo_sort/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoSort(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-sort",
   });
 }

--- a/packages/cargo_spellcheck/project.bri
+++ b/packages/cargo_spellcheck/project.bri
@@ -18,7 +18,7 @@ const source = Brioche.download(
 
 export default function cargoSpellcheck(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     dependencies: [llvm],
     runnable: "bin/cargo-spellcheck",
   });

--- a/packages/cargo_tarpaulin/project.bri
+++ b/packages/cargo_tarpaulin/project.bri
@@ -18,7 +18,7 @@ const source = Brioche.download(
 
 export default function cargoTarpaulin(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     dependencies: [openssl],
     runnable: "bin/cargo-tarpaulin",
   });

--- a/packages/cargo_udeps/project.bri
+++ b/packages/cargo_udeps/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.gitCheckout({
 
 export default function cargoUdeps(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/cargo-udeps",
     dependencies: [openssl],
   });

--- a/packages/grcov/project.bri
+++ b/packages/grcov/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function grcov(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/grcov",
   });
 }

--- a/packages/kubectl_view_allocations/project.bri
+++ b/packages/kubectl_view_allocations/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function kubectlViewAllocations(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/kubectl-view-allocations",
   });
 }

--- a/packages/miniserve/project.bri
+++ b/packages/miniserve/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function miniserve(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/miniserve",
   });
 }

--- a/packages/sccache/project.bri
+++ b/packages/sccache/project.bri
@@ -15,7 +15,7 @@ const source = Brioche.gitCheckout({
 
 export default function sccache(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/sccache",
     dependencies: [openssl],
   });

--- a/packages/starship/project.bri
+++ b/packages/starship/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function starship(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/starship",
   });
 }

--- a/packages/tailspin/project.bri
+++ b/packages/tailspin/project.bri
@@ -14,7 +14,7 @@ const source = Brioche.gitCheckout({
 
 export default function tailspin(): std.Recipe<std.Directory> {
   return cargoBuild({
-    source: source,
+    source,
     runnable: "bin/tspin",
   });
 }


### PR DESCRIPTION
Part of https://github.com/brioche-dev/brioche/issues/325. This PR resolves all the outstanding issues we currently have with the current formatting/linting in Cargo build recipes.