### PR TITLE
feat(recipe): add ACLOCAL_PATH where it's relevant

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -29,6 +29,7 @@ export default function alsaLib(): std.Recipe<std.Directory> {
           CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+          ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
         }),
     );
 }

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -81,6 +81,7 @@ export default function cmake(): std.Recipe<std.Directory> {
           CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+          ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
         }),
       (recipe) => std.withRunnableLink(recipe, "bin/cmake"),
     );

--- a/packages/curl/project.bri
+++ b/packages/curl/project.bri
@@ -69,6 +69,7 @@ export default function curl(
           CPATH: { append: [{ path: "include" }] },
           LIBRARY_PATH: { append: [{ path: "lib" }] },
           PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+          ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
           CURL_ROOT: { fallback: { path: "." } },
         }),
       (recipe) => std.withRunnableLink(recipe, "bin/curl"),

--- a/packages/util_macros/project.bri
+++ b/packages/util_macros/project.bri
@@ -24,6 +24,7 @@ export default function utilMacros(): std.Recipe<std.Directory> {
     .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
       std.setEnv(recipe, {
         PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
       }),
     );
 }

--- a/packages/xtrans/project.bri
+++ b/packages/xtrans/project.bri
@@ -27,6 +27,7 @@ export default function xtrans(): std.Recipe<std.Directory> {
       std.setEnv(recipe, {
         CPATH: { append: [{ path: "include" }] },
         PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
       }),
     );
 }

--- a/packages/zziplib/project.bri
+++ b/packages/zziplib/project.bri
@@ -31,6 +31,7 @@ export default function zziplib(): std.Recipe<std.Directory> {
       CPATH: { append: [{ path: "include" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
       CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
     }),
   );


### PR DESCRIPTION
Part of the overall work on libtool, pkgconfig and automake (aclocal). For better libraries integration with Brioche.

This PR adds the `ACLOCAL_PATH` environment variable in recipes that contain at least a `*.m4` file. `ACLOCAL_PATH` is an environment variable used to specify additional directories where aclocal should look for macro files. This allows to include third-party macros in build process without needing to specify them each time with command-line options.

Thanks for @kylewlacy to have given all the current `*.m4` files in Brioche recipes:

```bash
./alsa_lib/share/aclocal/alsa.m4
./cmake/share/aclocal/cmake.m4
./curl/share/aclocal/libcurl.m4
./freetype/share/aclocal/freetype2.m4
./php/lib/php/build/ax_check_compile_flag.m4
./php/lib/php/build/ax_gcc_func_attribute.m4
./php/lib/php/build/libtool.m4
./php/lib/php/build/php.m4
./php/lib/php/build/php_cxx_compile_stdcxx.m4
./php/lib/php/build/phpize.m4
./php/lib/php/build/pkg.m4
./std/share/aclocal/bison-i18n.m4
./std/share/aclocal/build-to-host.m4
./std/share/aclocal/gettext.m4
./std/share/aclocal/host-cpu-c-abi.m4
./std/share/aclocal/iconv.m4
./std/share/aclocal/intlmacosx.m4
./std/share/aclocal/intltool.m4
./std/share/aclocal/lib-ld.m4
./std/share/aclocal/lib-link.m4
./std/share/aclocal/lib-prefix.m4
./std/share/aclocal/libtool.m4
./std/share/aclocal/ltargz.m4
./std/share/aclocal/ltdl.m4
./std/share/aclocal/ltoptions.m4
./std/share/aclocal/ltsugar.m4
./std/share/aclocal/ltversion.m4
./std/share/aclocal/lt~obsolete.m4
./std/share/aclocal/nls.m4
./std/share/aclocal/pkg.m4
./std/share/aclocal/po.m4
./std/share/aclocal/progtest.m4
./std/share/aclocal-1.16/amversion.m4
./std/share/aclocal-1.16/ar-lib.m4
./std/share/aclocal-1.16/as.m4
./std/share/aclocal-1.16/auxdir.m4
./std/share/aclocal-1.16/cond-if.m4
./std/share/aclocal-1.16/cond.m4
./std/share/aclocal-1.16/depend.m4
./std/share/aclocal-1.16/depout.m4
./std/share/aclocal-1.16/dmalloc.m4
./std/share/aclocal-1.16/extra-recurs.m4
./std/share/aclocal-1.16/gcj.m4
./std/share/aclocal-1.16/init.m4
./std/share/aclocal-1.16/install-sh.m4
./std/share/aclocal-1.16/internal/ac-config-macro-dirs.m4
./std/share/aclocal-1.16/lead-dot.m4
./std/share/aclocal-1.16/lex.m4
./std/share/aclocal-1.16/lispdir.m4
./std/share/aclocal-1.16/maintainer.m4
./std/share/aclocal-1.16/make.m4
./std/share/aclocal-1.16/missing.m4
./std/share/aclocal-1.16/mkdirp.m4
./std/share/aclocal-1.16/obsolete.m4
./std/share/aclocal-1.16/options.m4
./std/share/aclocal-1.16/prog-cc-c-o.m4
./std/share/aclocal-1.16/python.m4
./std/share/aclocal-1.16/runlog.m4
./std/share/aclocal-1.16/sanity.m4
./std/share/aclocal-1.16/silent.m4
./std/share/aclocal-1.16/strip.m4
./std/share/aclocal-1.16/substnot.m4
./std/share/aclocal-1.16/tar.m4
./std/share/aclocal-1.16/upc.m4
./std/share/aclocal-1.16/vala.m4
./std/share/autoconf/autoconf/autoconf.m4
./std/share/autoconf/autoconf/autoheader.m4
./std/share/autoconf/autoconf/autoscan.m4
./std/share/autoconf/autoconf/autotest.m4
./std/share/autoconf/autoconf/autoupdate.m4
./std/share/autoconf/autoconf/c.m4
./std/share/autoconf/autoconf/erlang.m4
./std/share/autoconf/autoconf/fortran.m4
./std/share/autoconf/autoconf/functions.m4
./std/share/autoconf/autoconf/general.m4
./std/share/autoconf/autoconf/go.m4
./std/share/autoconf/autoconf/headers.m4
./std/share/autoconf/autoconf/lang.m4
./std/share/autoconf/autoconf/libs.m4
./std/share/autoconf/autoconf/oldnames.m4
./std/share/autoconf/autoconf/programs.m4
./std/share/autoconf/autoconf/specific.m4
./std/share/autoconf/autoconf/status.m4
./std/share/autoconf/autoconf/trailer.m4
./std/share/autoconf/autoconf/types.m4
./std/share/autoconf/autotest/autotest.m4
./std/share/autoconf/autotest/general.m4
./std/share/autoconf/autotest/specific.m4
./std/share/autoconf/m4sugar/foreach.m4
./std/share/autoconf/m4sugar/m4sh.m4
./std/share/autoconf/m4sugar/m4sugar.m4
./std/share/autoconf/m4sugar/version.m4
./std/share/bison/m4sugar/foreach.m4
./std/share/bison/m4sugar/m4sugar.m4
./std/share/bison/skeletons/bison.m4
./std/share/bison/skeletons/c++-skel.m4
./std/share/bison/skeletons/c++.m4
./std/share/bison/skeletons/c-like.m4
./std/share/bison/skeletons/c-skel.m4
./std/share/bison/skeletons/c.m4
```