### PR TITLE
ci: update publish workflow to skip check verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
             label="$package ($n / ${#packages[@]})"
             ((n++))
             echo "::group::$label"
-            brioche publish --no-verify --allow-dirty -p "$package"
+            brioche publish --no-verify -p "$package"
             echo "::endgroup::"
           done
         env:


### PR DESCRIPTION
Companion PR of https://github.com/brioche-dev/brioche/pull/326

It should reduce the time spent when publishing a package to the registry by avoiding steps already done earlier during the CI.