### PR TITLE
feat(cargo_deny): add package

### DIFF
--- a/packages/cargo_deny/brioche.lock
+++ b/packages/cargo_deny/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-deny/0.18.5/download": {
+      "type": "sha256",
+      "value": "d590834db3356c6089a5fd5509c8ac652f8fb7941f2bff7ba69bf377c2a7d92e"
+    }
+  }
+}

--- a/packages/cargo_deny/project.bri
+++ b/packages/cargo_deny/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_deny",
+  version: "0.18.5",
+  extra: {
+    crateName: "cargo-deny",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoDeny(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-deny",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo deny --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoDeny)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-deny ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_deny`](https://github.com/EmbarkStudios/cargo-deny): a Cargo plugin for linting your dependencies.

```bash
Build finished, completed (no new jobs) in 4.80s
Result: 2311a8c161ad4eee9e53f923f4ceffed4e4a8f5fa3de8818a0d0183d096d766f

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 11.97s
Running brioche-run
{
  "name": "cargo_deny",
  "version": "0.18.5",
  "extra": {
    "crateName": "cargo-deny"
  }
}

⏵ Task `Run package live-update` finished successfully
```