### PR TITLE
Update live-update workflow to run on Monday at 5:37am UTC

### DIFF
--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -3,7 +3,7 @@ name: Live updates
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 12 * * FRI" # Every Friday at 12:17pm UTC
+    - cron: "37 5 * * MON" # Every Monday at 5:37am UTC
 
 jobs:
   live-update-packages:


### PR DESCRIPTION
This PR updates the live-update workflow to run on Mondays at 5:37am UTC (Sundays 9:37pm Pacific). I felt like this time would work better for me personally, when it comes to working on Bricohe nearer to the weekend (opening as a draft to get feedback first!)