### PR TITLE
feat(wakatime_cli): add package

### DIFF
--- a/packages/wakatime_cli/brioche.lock
+++ b/packages/wakatime_cli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/wakatime/wakatime-cli.git": {
+      "v1.131.0": "71f75a0bc9521a950fde6d4b10dd378d1491c7be"
+    }
+  }
+}

--- a/packages/wakatime_cli/project.bri
+++ b/packages/wakatime_cli/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "wakatime_cli",
+  version: "1.131.0",
+  repository: "https://github.com/wakatime/wakatime-cli.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function wakatimeCli(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/wakatime/wakatime-cli/pkg/version.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/wakatime-cli",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wakatime-cli --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wakatimeCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`wakatime_cli`](https://github.com/wakatime/wakatime-cli): a command line interface used by all WakaTime text editor plugins

```bash
Build finished, completed 7 jobs in 47.02s
Running brioche-run
{
  "name": "wakatime_cli",
  "version": "1.131.0",
  "repository": "https://github.com/wakatime/wakatime-cli.git",
  "extra": {
    "releaseDate": "2025-08-23"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed (no new jobs) in 1.03s
Result: 209159106e83e3a253dbc743021cbcc2c22671a86557369c227ff0d3f0f9a74c

⏵ Task `Run package test` finished successfully
```