### PR TITLE
feat(cargo_edit): add package

### DIFF
--- a/packages/cargo_edit/brioche.lock
+++ b/packages/cargo_edit/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-edit/0.13.7/download": {
+      "type": "sha256",
+      "value": "6d933a243ca3e02ee943845b89f0bf0d3e2ca6e9d91e8391c7b2a2a751451a94"
+    }
+  }
+}

--- a/packages/cargo_edit/project.bri
+++ b/packages/cargo_edit/project.bri
@@ -1,0 +1,42 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_edit",
+  version: "0.13.7",
+  extra: {
+    crateName: "cargo-edit",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoEdit(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo set-version --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoEdit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-edit-set-version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_edit`](https://github.com/killercup/cargo-edit): a utility for managing cargo dependencies from the command line.

```bash
Build finished, completed 7 jobs in 50.08s
Running brioche-run
{
  "name": "cargo_edit",
  "version": "0.13.7",
  "extra": {
    "crateName": "cargo-edit"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 8 jobs in 1m45s
Result: 934b1b4b9468069c673c5125cacaf1db3b2a20843455046d2acb2e3be2a92071

⏵ Task `Run package test` finished successfully
```