### PR TITLE
feat(velero): add package

### DIFF
--- a/packages/velero/brioche.lock
+++ b/packages/velero/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/vmware-tanzu/velero.git": {
+      "v1.17.0": "3172d9f99c3d501aad9ddfac8176d783f7692dce"
+    }
+  }
+}

--- a/packages/velero/project.bri
+++ b/packages/velero/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "velero",
+  version: "1.17.0",
+  repository: "https://github.com/vmware-tanzu/velero.git",
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function velero(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${project.version}`,
+        "-X",
+        `github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${gitRef.commit}`,
+        "-X",
+        "github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean",
+      ],
+    },
+    path: "./cmd/velero",
+    runnable: "bin/velero",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    velero version --client-only | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(velero)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`velero`](https://github.com/vmware-tanzu/velero): Backup and migrate Kubernetes applications and their persistent volumes.

```bash
Build finished, completed 1 job in 18.69s
Running brioche-run
{
  "name": "velero",
  "version": "1.17.0",
  "repository": "https://github.com/vmware-tanzu/velero.git"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 1 job in 9.26s
Result: acc2c78b97f6683ff9e160512904949d9f0b002641507e0020d67fc58b1a9f57

⏵ Task `Run package test` finished successfully
```