### PR TITLE
feat(libtiff): add package

### DIFF
--- a/packages/libtiff/brioche.lock
+++ b/packages/libtiff/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "http://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz": {
+      "type": "sha256",
+      "value": "b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba"
+    }
+  }
+}

--- a/packages/libtiff/project.bri
+++ b/packages/libtiff/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+import lerc from "lerc";
+import libdeflate from "libdeflate";
+import libjpegTurbo from "libjpeg_turbo";
+
+export const project = {
+  name: "libtiff",
+  version: "4.7.1",
+  repository: "https://gitlab.com/libtiff/libtiff",
+};
+
+const source = Brioche.download(
+  `http://download.osgeo.org/libtiff/tiff-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libtiff(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, lerc, libdeflate, libjpegTurbo)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/tiffinfo"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libtiff-4 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libtiff)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`libtiff`](https://libtiff.gitlab.io/libtiff/): the LibTIFF software provides support for the Tag Image File Format (TIFF), a widely used format for storing image data.

```bash
Build finished, completed 1 job in 14.51s
Running brioche-run
{
  "name": "libtiff",
  "version": "4.7.1",
  "repository": "https://gitlab.com/libtiff/libtiff"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 9 jobs in 1m58s
Result: 6f0e754af66fa8785539055ddc7cc78112ce9fc1943f55f20223c4e789f50e71

⏵ Task `Run package test` finished successfully
```