### PR TITLE
feat(cargo_flamegraph): add package

### DIFF
--- a/packages/cargo_flamegraph/brioche.lock
+++ b/packages/cargo_flamegraph/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/flamegraph/0.6.9/download": {
+      "type": "sha256",
+      "value": "33701a8ff419cd128d4834192ff7a216b09d46f5a8adace616a6a32dac64f018"
+    }
+  }
+}

--- a/packages/cargo_flamegraph/project.bri
+++ b/packages/cargo_flamegraph/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_flamegraph",
+  version: "0.6.9",
+  extra: {
+    crateName: "flamegraph",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoFlamegraph(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-flamegraph",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo flamegraph --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoFlamegraph)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `flamegraph-flamegraph ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_flamegraph`](https://github.com/flamegraph-rs/flamegraph): easy flamegraphs for Rust projects and everything else, without Perl or pipes

```bash
Build finished, completed 4 jobs in 1m 9s
Result: 8495bde6b2172ffb7fcf1e0106591bf271edd7580a514f4b285a30b1de9ff7e1

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed (no new jobs) in 15.79s
Running brioche-run
{
  "name": "cargo_flamegraph",
  "version": "0.6.9",
  "extra": {
    "crateName": "flamegraph"
  }
}

⏵ Task `Run package live-update` finished successfully
```