### PR TITLE
ci: update Dependabot schedule to Sunday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "America/Los_Angeles"
+      day: "sunday"


### PR DESCRIPTION
This PR updates the schedule time for Dependabot update checking to be more aligned with https://github.com/brioche-dev/brioche-packages/pull/1416. The schedule time is now set on Sunday. Dependabot will run it at a random time during the day, and if a PR has to be opened, we'll have it before the beginning Monday. This way on Monday, we can merge it whenever we're ready !