### PR TITLE
feat(opus): add package

### DIFF
--- a/packages/opus/brioche.lock
+++ b/packages/opus/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz": {
+      "type": "sha256",
+      "value": "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
+    }
+  }
+}

--- a/packages/opus/project.bri
+++ b/packages/opus/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+
+export const project = {
+  name: "opus",
+  version: "1.5.2",
+  repository: "https://github.com/xiph/opus",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/opus-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function opus(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --disable-doc
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+          ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+        }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion opus | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, opus)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`opus`](https://github.com/xiph/opus): Modern audio compression for the internet.

```bash
Build finished, completed 1 job in 1.71s
Result: 92576f8ef62f29825147a587cdb7c70a10a101e220438d19e3c8301a44574a43

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "opus",
  "version": "1.5.2",
  "repository": "https://github.com/xiph/opus"
}

⏵ Task `Run package live-update` finished successfully
```