### PR TITLE
feat(terraform_mcp_server): add package

### DIFF
--- a/packages/terraform_mcp_server/brioche.lock
+++ b/packages/terraform_mcp_server/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/hashicorp/terraform-mcp-server.git": {
+      "v0.3.1": "5d06867d2318a729906db1abbed51011beb076a9"
+    }
+  }
+}

--- a/packages/terraform_mcp_server/project.bri
+++ b/packages/terraform_mcp_server/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "terraform_mcp_server",
+  version: "0.3.1",
+  repository: "https://github.com/hashicorp/terraform-mcp-server.git",
+  extra: {
+    releaseDate: "2025-10-04",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function terraformMcpServer(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/hashicorp/terraform-mcp-server/version.GitCommit=${gitRef.commit}`,
+        "-X",
+        `github.com/hashicorp/terraform-mcp-server/version.BuildDate=${project.extra.releaseDate}`,
+      ],
+    },
+    path: "./cmd/terraform-mcp-server",
+    runnable: "bin/terraform-mcp-server",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    terraform-mcp-server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(terraformMcpServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`terraform_mcp_server`](https://github.com/hashicorp/terraform-mcp-server): The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development.

```bash
Build finished, completed 5 jobs in 59.45s
Result: e68280906bbc0c399c4758b0e82ce67ad09e3a2a23af23031598b1813a62ab04

⏵ Task `Run package test` finished successfully
```

```bash
Running brioche-run
{
  "name": "terraform_mcp_server",
  "version": "0.3.1",
  "repository": "https://github.com/hashicorp/terraform-mcp-server.git",
  "extra": {
    "releaseDate": "2025-10-04"
  }
}

⏵ Task `Run package live-update` finished successfully
```