### PR TITLE
feat(cargo_fuzz): add package

### DIFF
--- a/packages/cargo_fuzz/brioche.lock
+++ b/packages/cargo_fuzz/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-fuzz/0.13.1/download": {
+      "type": "sha256",
+      "value": "990e4e600e695b730ae23c2f4e6336ee63e9efe6527273f557f86d37eac724e7"
+    }
+  }
+}

--- a/packages/cargo_fuzz/project.bri
+++ b/packages/cargo_fuzz/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_fuzz",
+  version: "0.13.1",
+  extra: {
+    crateName: "cargo-fuzz",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoFuzz(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-fuzz",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo fuzz --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoFuzz)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-fuzz ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
Add a new package [`cargo_fuzz`](https://github.com/rust-fuzz/cargo-fuzz): Command line helpers for fuzzing

```bash
Running brioche-run
{
  "name": "cargo_fuzz",
  "version": "0.13.1",
  "extra": {
    "crateName": "cargo-fuzz"
  }
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 4 jobs in 21.43s
Result: 4b0958b77736b96fc7d0603c244e9673ed8dc0cb3fd2c504c4a961ebecd55803

⏵ Task `Run package test` finished successfully
```