### PR TITLE
chore: update staticSite function to remove LD_LIBRARY_PATH environment variable

### DIFF
--- a/examples/nodejs_frontend/project.bri
+++ b/examples/nodejs_frontend/project.bri
@@ -25,11 +25,6 @@ export function staticSite(): std.Recipe<std.Directory> {
   `
     .dependencies(nodejs)
     .workDir(npmPackage)
-    .env({
-      // NOTE: Rollup needs a dynamic library provided by the toolchain.
-      // Setting `$LD_LIBRARY_PATH` allows Node.js to find this library.
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
-    })
     .toDirectory();
 }
 


### PR DESCRIPTION
Building this example locally without the environment variable seems to work, now, as shown below:

```bash
> brioche run -p examples/nodejs_frontend/
Build finished, completed (no new jobs) in 2.79s
Running brioche-run
miniserve v0.32.0
Bound to [::]:8080, 0.0.0.0:8080
Serving path /home/jaudiger.linux/.local/share/brioche/locals/b3166cb0c5b31f54da5b50058cdbe4dfeba3c3059506b38e7f08a3d2f3d37a30
Available at (non-exhaustive list):
    http://127.0.0.1:8080
    http://192.168.5.15:8080
    http://192.168.64.6:8080
    http://[::1]:8080
    http://[fd04:e5ce:7b57:362d:5055:55ff:fe00:2b8f]:8080

Quit by pressing CTRL-C
```