### PR TITLE
build(linux): remove unnecessary HOSTLDFLAGS and LD_LIBRARY_PATH env var

### DIFF
--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -122,15 +122,6 @@ export default function linux(
 
       INSTALL_MOD_PATH: std.outputPath,
 
-      // Needed since we're using `ld.bfd`, which tries to resolve transitive
-      // dependencies for libraries, so it needs to know where to look
-      HOSTLDFLAGS: std.tpl`-Wl,-rpath-link,${std.toolchain}/lib`,
-
-      // Needed because tools from the kernel build use `pthread_exit`, which
-      // dynamically opens `libgcc_s.so.1`, which is not directly a dependency
-      // of glibc
-      LD_LIBRARY_PATH: std.tpl`${std.toolchain}/lib`,
-
       ...env,
     })
     .toDirectory();


### PR DESCRIPTION
Similar to #1474 but for `linux` recipe. I'm a bit sceptical here @kylewlacy, since I'm surprised that I can build and run successfully the test without any issues. But maybe that's not the same for `x86_64` environment, could you test locally ? 

Here are my outputs:

```bash
> rm -rf /tmp/output; brioche build -o /tmp/output -p packages/linux
1113566│   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/nfc/nci/nci.ko
       │   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/hsr/hsr.ko
       │   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/qrtr/qrtr.ko
       │   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/qrtr/qrtr-smd.ko
       │   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/qrtr/qrtr-tun.ko
       │   INSTALL /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2/kernel/net/qrtr/qrtr-mhi.ko
       │   DEPMOD  /home/brioche-runner-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857/.local/share/brioche/outputs/output-051bb5bd013e25be0699b5c781cb7299b41efcd8045b2c72cd5d7dbfc9b90857
       │ /lib/modules/6.17.2
38m45s ✓ Process 1113566
Build finished, completed 1 job in 40m 5s
Result: aad72031fdd5cb31236e1c4ea39d20e634a3ac46b282c614922d425690c1a99d
Writing output
Wrote output to /tmp/output
```

```bash
> 1211908│ alias:          nf-logger-2-0
       │ alias:          nf-logger-7-0
       │ alias:          nf_log_netdev
       │ alias:          nf_log_ipv6
       │ alias:          nf_log_ipv4
       │ alias:          nf_log_bridge
       │ alias:          nf_log_arp
       │ license:        GPL
       │ description:    Netfilter syslog packet logging
       │ author:         Netfilter Core Team <coreteam@netfilter.org>
       │ depends:
       │ intree:         Y
       │ name:           nf_log_syslog
       │ vermagic:       6.17.2 SMP preempt mod_unload aarch64
 0.02s ✓ Process 1211908
Build finished, completed 1 job in 3.76s
Result: 617213e6eb7acbc68534c783da43796e9de750315438ead612f553ab8e456a99

⏵ Task `Run package test` finished successfully
```