### PR TITLE
feat(gitea_mcp_server): add package

### DIFF
--- a/packages/gitea_mcp_server/brioche.lock
+++ b/packages/gitea_mcp_server/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://gitea.com/gitea/gitea-mcp": {
+      "v0.4.0": "de311344cd414bbbacda8393e616d1c00e1c55fc"
+    }
+  }
+}

--- a/packages/gitea_mcp_server/project.bri
+++ b/packages/gitea_mcp_server/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "gitea_mcp_server",
+  version: "0.4.0",
+  repository: "https://gitea.com/gitea/gitea-mcp",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function giteaMcpServer(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/gitea-mcp",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    gitea-mcp --help 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(giteaMcpServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGiteaReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`gitea_mcp_server`](https://gitea.com/gitea/gitea-mcp) that is using the new live update capability from https://github.com/brioche-dev/brioche-packages/pull/1468: interactive with Gitea instances with MCP

```bash
Build finished, completed (no new jobs) in 12.62s
Running brioche-run
{
  "name": "gitea_mcp_server",
  "version": "0.4.0",
  "repository": "https://gitea.com/gitea/gitea-mcp"
}

⏵ Task `Run package live-update` finished successfully
```

```bash
Build finished, completed 4 jobs in 19.65s
Result: eb0891ea3899ea1d83ab5588c0bd9ebf291f207cfbf01438eee4375bc2ddbe20

⏵ Task `Run package test` finished successfully
```