### PR TITLE
feat(yasm): add package

### DIFF
--- a/packages/yasm/brioche.lock
+++ b/packages/yasm/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz": {
+      "type": "sha256",
+      "value": "3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"
+    }
+  }
+}

--- a/packages/yasm/project.bri
+++ b/packages/yasm/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import python from "python";
+
+export const project = {
+  name: "yasm",
+  version: "1.3.0",
+  repository: "https://github.com/yasm/yasm",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/yasm-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function yasm(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, python)
+    .toDirectory()
+    .pipe(
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/yasm"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    yasm --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(yasm)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `yasm ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
Add a new package [`yasm`](https://github.com/yasm/yasm): yasm Assembler mainline development tree

```bash
Build finished, completed 1 job in 1.84s
Result: deb8d199a4e1d96eca552e45203683dc42039d8124ca3dfb52db2d66e332cb7e

⏵ Task `Run package test` finished successfully
```

```bash
Build finished, completed 1 job in 12.84s
Running brioche-run
{
  "name": "yasm",
  "version": "1.3.0",
  "repository": "https://github.com/yasm/yasm"
}

⏵ Task `Run package live-update` finished successfully
```