### PR TITLE
feat: add pull request templates for adding and updating recipes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_recipe.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_recipe.md
@@ -1,0 +1,54 @@
+# Add a new Brioche recipe
+
+## Summary
+
+This Pull Request adds a new recipe to the registry.
+
+- **Recipe name:** `TODO: replace with name`
+- **Website / repository:** `TODO: link`
+- **Short description:** `TODO: one-line description`
+
+# Related issue(s) or discussion(s)
+
+`TODO: Link to the issue or discussion if relevant.`
+
+## Checklist (required)
+
+- [ ] `liveUpdate()` method added.
+- [ ] `test()` method added.
+
+## How I tested this locally (required)
+
+**When applicable, the commands below must succeed and their output must be pasted into this PR.**
+
+1. Run the **test** scenario:
+
+```bash
+   brioche build -e test -p RECIPE_PATH
+```
+
+<details><summary>Test output (click to expand)</summary>
+<p>
+
+TODO: paste the relevant output here
+
+</p>
+</details>
+
+2. Run the **live-update** scenario:
+
+```bash
+brioche run -e liveUpdate -p RECIPE_PATH
+```
+
+<details><summary>Live-update output (click to expand)</summary>
+<p>
+
+TODO: paste the relevant output here
+
+</p>
+</details>
+
+## Implementation notes / special instructions
+
+- If this introduces breaking changes, list them and any required follow-ups.

--- a/.github/PULL_REQUEST_TEMPLATE/update_recipe.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update_recipe.md
@@ -1,0 +1,45 @@
+# Update an existing Brioche recipe
+
+## Summary
+
+`TODO: Explain the changes made to the recipe, and why they are necessary.`
+
+# Related issue(s) or discussion(s)
+
+`TODO: Link to the issue or discussion if relevant.`
+
+## How I tested this locally (required)
+
+**When applicable, the commands below must succeed and their output must be pasted into this PR.**
+
+1. Run the **test** scenario:
+
+```bash
+   brioche build -e test -p RECIPE_PATH
+```
+
+<details><summary>Test output (click to expand)</summary>
+<p>
+
+TODO: paste the relevant output here
+
+</p>
+</details>
+
+2. Run the **live-update** scenario (only if the `liveUpdate` has been updated):
+
+```bash
+brioche run -e liveUpdate -p RECIPE_PATH
+```
+
+<details><summary>Live-update output (click to expand)</summary>
+<p>
+
+TODO: paste the relevant output here
+
+</p>
+</details>
+
+## Implementation notes / special instructions
+
+- If this introduces breaking changes, list them and any required follow-ups.


### PR DESCRIPTION
I think only me will use it at the beginning since there is no interface for this "feature" from GitHub. We can define multiple templates for the PR, but these templates can only be accessed through URI query, and cannot be used directly from the interface (which is a bit weird...), see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository.

So, here is an example of both templates:

- Add a new recipe: https://github.com/jaudiger/test-brioche-repo/compare/main...new-branch?quick_pull=1&template=add_recipe.md
- Update a recipe: https://github.com/jaudiger/test-brioche-repo/compare/main...new-branch?quick_pull=1&template=update_recipe.md