### PR TITLE
feat(lcms2): add package

### DIFF
--- a/packages/lcms2/brioche.lock
+++ b/packages/lcms2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/mm2/Little-CMS/releases/download/lcms2.17/lcms2-2.17.tar.gz": {
+      "type": "sha256",
+      "value": "d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"
+    }
+  }
+}

--- a/packages/lcms2/project.bri
+++ b/packages/lcms2/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import lerc from "lerc";
+import libdeflate from "libdeflate";
+import libjpegTurbo from "libjpeg_turbo";
+import libtiff from "libtiff";
+
+export const project = {
+  name: "lcms2",
+  version: "2.17",
+  repository: "https://github.com/mm2/Little-CMS",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/lcms${project.version}/lcms2-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lcms2(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, lerc, libdeflate, libjpegTurbo, libtiff)
+    .toDirectory()
+    .pipe(
+      std.libtoolSanitizeDependencies,
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/tificc"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lcms2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lcms2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^lcms(?<version>.+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lcms2`
- **Website / repository:** https://github.com/mm2/Little-CMS
- **Short description:** A free, open source, CMM engine. It provides fast transforms between ICC profiles.

# Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```bash
1382249│ 2.17
 0.01s ✓ Process 1382249
 0.04s ✓ Process 1382237
 0.04s ✓ Process 1382229
22.99s ✓ Process 1376579
Build finished, completed 6 jobs in 33.50s
Result: 47f5e3f9afb7c0d53d7bf40f5494f28fa4c42f421b1a53b7e17e3aeb5fd22c23
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```bash
 0.01s ✓ Process 1382559
Build finished, completed 1 job in 9.45s
Running brioche-run
{
  "name": "lcms2",
  "version": "2.17",
  "repository": "https://github.com/mm2/Little-CMS"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
