### PR TITLE
feat(rust_analyzer): add package

### DIFF
--- a/packages/rust_analyzer/brioche.lock
+++ b/packages/rust_analyzer/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rust-lang/rust-analyzer.git": {
+      "2025-08-25": "6b2e677795722dc95b9b5dbd2f38ab4e0cfaafc0"
+    }
+  }
+}

--- a/packages/rust_analyzer/project.bri
+++ b/packages/rust_analyzer/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "rust_analyzer",
+  version: "2025-08-25",
+  repository: "https://github.com/rust-lang/rust-analyzer.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function rustAnalyzer(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    path: "crates/rust-analyzer",
+    env: {
+      CFG_RELEASE: project.version,
+    },
+    runnable: "bin/rust-analyzer",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    rust-analyzer --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rustAnalyzer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `rust-analyzer ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^(?<version>.+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `rust_analyzer`
- **Website / repository:** https://github.com/rust-lang/rust-analyzer.git
- **Short description:** A Rust compiler front-end for IDEs.

# Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```bash
1401129│ rust-analyzer 2025-08-25
 0.05s ✓ Process 1401129
 1m51s ✓ Process 1397031
Build finished, completed 2 jobs in 2m 4s
Result: bf9d32729b8cad4cb2c23acc5c6348f8a9b6a459eb791297af3ffc848625e35e
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```bash
Build finished, completed 1 job in 27.45s
Running brioche-run
{
  "name": "rust_analyzer",
  "version": "2025-08-25",
  "repository": "https://github.com/rust-lang/rust-analyzer.git"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
