### PR TITLE
feat(slang): add package

### DIFF
--- a/packages/slang/brioche.lock
+++ b/packages/slang/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.jedsoft.org/releases/slang/slang-2.3.3.tar.bz2": {
+      "type": "sha256",
+      "value": "f9145054ae131973c61208ea82486d5dd10e3c5cdad23b7c4a0617743c8f5a18"
+    }
+  }
+}

--- a/packages/slang/project.bri
+++ b/packages/slang/project.bri
@@ -1,0 +1,95 @@
+import * as std from "std";
+import libpng from "libpng";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import oniguruma from "oniguruma";
+import pcre from "pcre";
+
+export const project = {
+  name: "slang",
+  version: "2.3.3",
+};
+
+const source = Brioche.download(
+  `https://www.jedsoft.org/releases/slang/slang-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel()
+  .pipe((source) =>
+    // Patch the source to properly build the recipe
+    // Inspired from: https://github.com/NixOS/nixpkgs/blob/d2ed99647a4b195f0bcc440f76edfa10aeb3b743/pkgs/by-name/sl/slang/package.nix#L29
+    std.runBash`
+      sed -i -e "s|/usr/lib/terminfo|$ncurses_path/lib/terminfo|" "$BRIOCHE_OUTPUT/configure"
+      sed -i -e "s|/usr/lib/terminfo|$ncurses_path/lib/terminfo|" "$BRIOCHE_OUTPUT/src/sltermin.c"
+      sed -i -e "s|/bin/ln|ln|" "$BRIOCHE_OUTPUT/src/Makefile.in"
+      sed -i -e "s|-ltermcap|-lncurses|" "$BRIOCHE_OUTPUT/configure"
+    `
+      .env({
+        ncurses_path: std.tpl`${std.toolchain}`,
+      })
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function slang(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --with-png=$libpng_path \
+      --with-onig=$oniguruma_path \
+      --with-pcre=$pcre_path \
+      --with-z=$zlib_path
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libpng, oniguruma, pcre)
+    .env({
+      libpng_path: std.tpl`${libpng}`,
+      oniguruma_path: std.tpl`${oniguruma}`,
+      pcre_path: std.tpl`${pcre}`,
+      zlib_path: std.tpl`${std.toolchain}`,
+    })
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/slsh"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion slang | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, slang)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.jedsoft.org/releases/slang
+      | lines
+      | where {|it| ($it | str contains '<a href="slang-') and (not ($it | str contains ".asc")) }
+      | parse --regex '<a href="slang-(?<version>.+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `slang`
- **Website / repository:** https://www.jedsoft.org/slang/
- **Short description:** S-Lang is a multi-platform programmer's library designed to allow a developer to create robust multi-platform software

# Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```bash
1555148│ 2.3.3
 0.01s ✓ Process 1555148
 0.04s ✓ Process 1555135
 1m17s ✓ Process 1550808
 0.02s ✓ Process 1550783
Build finished, completed 9 jobs in 1m37s
Result: c5d263355b5b6455a13d03daea7faed0b6302f80a7d8ba4e2be836c0a7607d6e
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```bash
Build finished, completed 1 job in 11.01s
Running brioche-run
{
  "name": "slang",
  "version": "2.3.3"
}
``

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
