### PR TITLE
feat(github_mcp_server): add package

### DIFF
--- a/packages/github_mcp_server/brioche.lock
+++ b/packages/github_mcp_server/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/github/github-mcp-server.git": {
+      "v0.18.0": "f9343e62fd825d77ff741c7909016c461402783b"
+    }
+  }
+}

--- a/packages/github_mcp_server/project.bri
+++ b/packages/github_mcp_server/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "github_mcp_server",
+  version: "0.18.0",
+  repository: "https://github.com/github/github-mcp-server.git",
+  extra: {
+    releaseDate: "2025-10-10",
+  },
+};
+
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function githubMcpServer(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.version=${project.version}`,
+        "-X",
+        `main.commit=${gitRef.commit}`,
+        "-X",
+        `main.date=${project.extra.releaseDate}`,
+      ],
+    },
+    path: "./cmd/github-mcp-server",
+    runnable: "bin/github-mcp-server",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    github-mcp-server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(githubMcpServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `github_mcp_server`
- **Website / repository:** https://github.com/github/github-mcp-server
- **Short description:** GitHub's official MCP Server

# Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```bash
1557403│ GitHub MCP Server
       │ Version: 0.18.0
       │ Commit: f9343e62fd825d77ff741c7909016c461402783b
       │ Build Date: 2025-10-10
 0.03s ✓ Process 1557403
10.28s ✓ Process 1555191
 2.85s ✓ Process 1555154
 0.88s ✓ Process 1554671
Build finished, completed 7 jobs in 2m 2s
Result: a97d671b9a620a009f267e4ba621cdc3b123ba09db4df1bef1bdb9e57fbb8469
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```bash
Build finished, completed 1 job in 9.74s
Running brioche-run
{
  "name": "github_mcp_server",
  "version": "0.18.0",
  "repository": "https://github.com/github/github-mcp-server.git",
  "extra": {
    "releaseDate": "2025-10-10"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
