### PR TITLE
feat(libsrtp): add package

### DIFF
--- a/packages/libsrtp/brioche.lock
+++ b/packages/libsrtp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/cisco/libsrtp/archive/refs/tags/v2.7.0.tar.gz": {
+      "type": "sha256",
+      "value": "54facb1727a557c2a76b91194dcb2d0a453aaf8e2d0cbbf1e3c2848c323e28ad"
+    }
+  }
+}

--- a/packages/libsrtp/project.bri
+++ b/packages/libsrtp/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import openssl from "openssl";
+
+export const project = {
+  name: "libsrtp",
+  version: "2.7.0",
+  repository: "https://github.com/cisco/libsrtp",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libsrtp(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-openssl
+    make -j "$(nproc)"
+    make -j "$(nproc)" shared_library
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, openssl)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative, (recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libsrtp2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libsrtp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libsrtp`
- **Website / repository:** https://github.com/cisco/libsrtp
- **Short description:** Library for SRTP (Secure Realtime Transport Protocol)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
1582667│ 2.7.0
 0.12s ✓ Process 1582667
Build finished, completed 1 job in 2.54s
Result: 54c5834916171d3c40ff1791f22442a4f4a01a328f790e759c9b8798b534be08
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 23.93s
Running brioche-run
{
  "name": "libsrtp",
  "version": "2.7.0",
  "repository": "https://github.com/cisco/libsrtp"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
