### PR TITLE
build(python): enable optimizations and LTO

### DIFF
--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -72,6 +72,8 @@ export default async function python(options: PythonOptions = {}) {
     ./configure \\
       --prefix=/ \\
       --enable-shared \\
+      --enable-optimizations \\
+      --with-lto \\
       --without-ensurepip
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"


### PR DESCRIPTION
# Update an existing Brioche recipe

## Summary

This PR enables optimizations when building `python`. It was emitted as a warning at build time:

```
1670709│ configure: creating ./config.status
       │ config.status: creating Makefile.pre
       │ config.status: creating Misc/python.pc
       │ config.status: creating Misc/python-embed.pc
       │ config.status: creating Misc/python-config.sh
       │ config.status: creating Modules/Setup.bootstrap
       │ config.status: creating Modules/Setup.stdlib
       │ config.status: creating Modules/ld_so_aix
       │ config.status: creating pyconfig.h
       │ configure: creating Modules/Setup.local
       │ configure: creating Makefile
       │ configure:
       │ If you want a release build with all stable optimizations active (PGO, etc),
       │ please run ./configure --enable-optimizations
34.90s ◜ Process 1670709
```

And it seems to be the default way to build non debug version of Python, as I saw it in a recent blog from [Hugo van Kemenade](https://hugovk.dev/), [here](https://hugovk.dev/blog/2025/lazy-imports/#setup). The only downside is: it'll take more time to build the recipes, but I think it's worth it, since we should always install release builds (binary that are stripped, built with flag optimisations, ...). 

# Related issue(s) or discussion(s)

None.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
       │ $ensurepip --root=/home/brioche-runner-d0f9d8b278a39c03640dac0f08289696380b43ea28c3c0fba2bf02c9be3e3c92/.local/share/brioche/outputs/output-d0f9d8b278a39c03640dac0f08289696380b43ea28c3c0fba2bf02
       │ c9be3e3c92/ ; \
       │ fi
       │ Looking in links: /tmp/tmpaw71nf11
       │ Processing /tmp/tmpaw71nf11/pip-25.2-py3-none-any.whl
       │ Installing collected packages: pip
       │ Successfully installed pip-25.2
1647842│ autopacked /home/brioche-runner-deafedfbd265a5190faabe3d6237097832d31ef2f1dff94c492d2d74f3329948/.local/share/brioche/outputs/output-deafedfbd265a5190faabe3d6237097832d31ef2f1dff94c492d2d74f332994
       │ 8/bin/python3.13
1647900│ Python 3.13.7
 0.02s ✓ Process 1647900
 0.07s ✓ Process 1647879
 0.00s ✓ Cache     100% Fetch artifact: 0 B
 0.03s ✓ Cache     100% Fetch artifact: 0 B
Build finished, completed 27 jobs in 53m55s
Result: 2ee79c3e0f4850ecd13a401d9e89dbc5d533acaff850253b35baa383e27bfae1
```

</p>
</details>

2. Run the **live-update** scenario (only if the `liveUpdate` has been updated):

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

TODO: paste the relevant output here

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
