### PR TITLE
feat(skim): add package

### DIFF
--- a/packages/skim/brioche.lock
+++ b/packages/skim/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/skim/0.20.5/download": {
+      "type": "sha256",
+      "value": "60e10a7f70e8e532d8780d88210055e15e12d0df431bf5dab7bb1ed22b6fb4f2"
+    }
+  }
+}

--- a/packages/skim/project.bri
+++ b/packages/skim/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "skim",
+  version: "0.20.5",
+  extra: {
+    crateName: "skim",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function skim(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/sk",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    sk --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(skim)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sk ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `skim`
- **Website / repository:** https://github.com/skim-rs/skim
- **Short description:** Fuzzy Finder in rust!

# Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
       │    Installed package `skim v0.20.5 (/home/brioche-runner-ba17e7e7a8a17d0d613bb19ffa11d67a4520e43474b58f6e7f4a4d1802155e8d/work)` (executable `sk`)
1680340│ sk 0.20.5
 0.03s ✓ Process 1680340
20.12s ✓ Process 1678634
 4.89s ✓ Process 1678618
 0.02s ✓ Process 1678614
Build finished, completed 11 jobs in 1m41s
Result: d1953d8d7a8c16ec1ce01330a95ac974d09b7fcec4a83df446e4d0de510e30d4
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 11.05s
Running brioche-run
{
  "name": "skim",
  "version": "0.20.5",
  "extra": {
    "crateName": "skim"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
