### PR TITLE
fix(std): resolve a typo in comment for dependencies method

### DIFF
--- a/packages/std/extra/runnable.bri
+++ b/packages/std/extra/runnable.bri
@@ -16,7 +16,7 @@ export interface WithRunnableUtils {
   env(values: Record<string, RunnableTemplateEnvValue>): WithRunnable;
 
   /**
-   * Include additonal dependencies when the command is run. This
+   * Include additional dependencies when the command is run. This
    * will set the `$PATH` environment variable.
    */
   dependencies(...dependencies: std.RecipeLike<std.Directory>[]): WithRunnable;


### PR DESCRIPTION
Resolved a typo I saw, nothing more, just a really quick PR. Sorry for the noise