### PR TITLE
feat(duktape): add package

### DIFF
--- a/packages/duktape/brioche.lock
+++ b/packages/duktape/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz": {
+      "type": "sha256",
+      "value": "90f8d2fa8b5567c6899830ddef2c03f3c27960b11aca222fa17aa7ac613c2890"
+    }
+  }
+}

--- a/packages/duktape/project.bri
+++ b/packages/duktape/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+
+export const project = {
+  name: "duktape",
+  version: "2.7.0",
+  repository: "https://github.com/svaarala/duktape",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/duktape-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function duktape(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -f Makefile.cmdline -j "$(nproc)"
+    mkdir -p "$BRIOCHE_OUTPUT/bin"
+    mv duk "$BRIOCHE_OUTPUT/bin"
+
+    make -f Makefile.sharedlibrary -j "$(nproc)"
+    make INSTALL_PREFIX="$BRIOCHE_OUTPUT" -f Makefile.sharedlibrary install
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(
+      std.pkgConfigMakePathsRelative,
+      (recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      (recipe) => std.withRunnableLink(recipe, "bin/duk"),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion duktape | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, duktape)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `duktape`
- **Website / repository:** https://github.com/svaarala/duktape
- **Short description:** embeddable Javascript engine with a focus on portability and compact footprint

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
1694208│ 2.7.0
 0.06s ✓ Process 1694208
Build finished, completed 1 job in 2.26s
Result: 54c5834916171d3c40ff1791f22442a4f4a01a328f790e759c9b8798b534be08
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 6 jobs in 47.95s
Running brioche-run
{
  "name": "duktape",
  "version": "2.7.0",
  "repository": "https://github.com/svaarala/duktape"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
