### PR TITLE
Rework live update scripts

### DIFF
--- a/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
@@ -4,9 +4,7 @@ mut project = $env.project
 
 # Retrieve the most recent releases from Gitea
 let releases = http get $'https://gitea.com/api/v1/repos/($env.repoOwner)/($env.repoName)/releases'
-
-# Extract the version(s)
-let releasesInfo = $releases
+  # Extract the version(s)
   | each {|release|
     let parsedTag = $release.tag_name
       | parse --regex $env.matchTag
@@ -19,14 +17,15 @@ let releasesInfo = $releases
   }
   | sort-by --natural version
 
-if ($releasesInfo | length) == 0 {
+if ($releases | length) == 0 {
   error make { msg: $'No tag did match regex ($env.matchTag)' }
 }
 
-# Extract the latest version
-let latestReleaseInfo = $releasesInfo
+# Get the latest release
+let latestReleaseInfo = $releases
   | last
 
+# Get the version
 mut version = $latestReleaseInfo.version
 
 if $env.normalizeVersion == "true" {

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -4,9 +4,7 @@ mut project = $env.project
 
 # Retrieve the most recent releases from GitLab
 let releases = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases'
-
-# Extract the version(s)
-let releasesInfo = $releases
+  # Extract the version(s)
   | each {|release|
     let parsedTag = $release.tag_name
       | parse --regex $env.matchTag
@@ -19,14 +17,15 @@ let releasesInfo = $releases
   }
   | sort-by --natural version
 
-if ($releasesInfo | length) == 0 {
+if ($releases | length) == 0 {
   error make { msg: $'No tag did match regex ($env.matchTag)' }
 }
 
-# Extract the latest version
-let latestReleaseInfo = $releasesInfo
+# Get the latest release
+let latestReleaseInfo = $releases
   | last
 
+# Get the version
 mut version = $latestReleaseInfo.version
 
 if $env.normalizeVersion == "true" {

--- a/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
@@ -3,10 +3,10 @@ mut project = $env.project
   | from json
 
 # Retrieve the latest release from npm registry
-let releaseInfo = http get $'https://registry.npmjs.org/($env.packageName)/latest'
+let latestReleaseInfo = http get $'https://registry.npmjs.org/($env.packageName)/latest'
 
-# Extract the version
-let version = $releaseInfo
+# Get the version
+let version = $latestReleaseInfo
   | get version
 
 let parsedVersion = $version

--- a/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
@@ -2,11 +2,11 @@
 mut project = $env.project
   | from json
 
-# Retrieve the most recent releases from crates.io registry
-let releaseInfo = http get $'https://crates.io/api/v1/crates/($env.crateName)'
+# Retrieve the crate information from crates.io registry
+let crateInfo = http get $'https://crates.io/api/v1/crates/($env.crateName)'
 
-# Extract the latest version
-let version = $releaseInfo
+# Get the version
+let version = $crateInfo
   | get crate.max_version
 
 let parsedVersion = $version


### PR DESCRIPTION
The work in this PR was unlocked by the latest version of Nushell `0.108.0` with the introduction of [`[HTTP Response Metadata](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#http-response-metadata-16821-toc)`](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#http-response-metadata-16821-toc). It let us refactor our Nushell scripts by only using pipes to extract releases or tags. 

Plus, I took this opportunity to enhance the consistency with the naming of the variables and with some comments.