### PR TITLE
fix(freetype): update freetype-config to use relative paths

### DIFF
--- a/packages/freetype/project.bri
+++ b/packages/freetype/project.bri
@@ -12,7 +12,15 @@ const source = Brioche.download(
   `https://downloads.sourceforge.net/project/freetype/freetype2/${project.version}/freetype-${project.version}.tar.xz`,
 )
   .unarchive("tar", "xz")
-  .peel();
+  .peel()
+  .pipe((source) =>
+    // Avoid using an absolute path to pkg-config
+    std.runBash`
+      sed -i 's|%PKG_CONFIG%|pkg-config|g' "$BRIOCHE_OUTPUT/builds/unix/freetype-config.in"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
 
 export default function freetype(): std.Recipe<std.Directory> {
   return std.runBash`
@@ -26,6 +34,16 @@ export default function freetype(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain, brotli, libpng)
     .toDirectory()
     .pipe(
+      (source) =>
+        // Fix absolute paths in the script freetype-config
+        std.runBash`
+          sed -i 's|  prefix=".*"|  prefix=\`dirname "\$0"\`/..|' "$BRIOCHE_OUTPUT/bin/freetype-config"
+          sed -i 's|  exec_prefix=".*"|  exec_prefix=\${prefix}|' "$BRIOCHE_OUTPUT/bin/freetype-config"
+          sed -i 's|  libdir=".*"|  libdir=\${prefix}/lib|' "$BRIOCHE_OUTPUT/bin/freetype-config"
+          sed -i 's|  includedir=".*"|  includedir=\${prefix}/include|' "$BRIOCHE_OUTPUT/bin/freetype-config"
+        `
+          .outputScaffold(source)
+          .toDirectory(),
       std.libtoolSanitizeDependencies,
       std.pkgConfigMakePathsRelative,
       (recipe) =>
@@ -41,12 +59,9 @@ export default function freetype(): std.Recipe<std.Directory> {
 
 export async function test(): Promise<std.Recipe<std.File>> {
   const script = std.runBash`
-    freetype-config --prefix=$prefix --ftversion | tee "$BRIOCHE_OUTPUT"
+    freetype-config --ftversion | tee "$BRIOCHE_OUTPUT"
   `
     .dependencies(freetype)
-    .env({
-      prefix: std.tpl`${freetype}`,
-    })
     .toFile();
 
   const result = (await script.read()).trim();


### PR DESCRIPTION
This recipe had two issues with the 'script' binary produced: `freetype-config`:

- `pkg-config` was associated to an absolute path
- `prefix`, `exec_prefix`, `includedir` and `libdir` variables were not updated as in the pkg config file `freetype2.pc`

So, here is a before and after when calling `freetype-config` script:

### Before

```bash
> freetype-config --cflags --libs --ftversion --exec-prefix --prefix
/
/
grep: //include/freetype2/freetype/freetype.h: No such file or directory
grep: //include/freetype2/freetype/freetype.h: No such file or directory
grep: //include/freetype2/freetype/freetype.h: No such file or directory
..
-I//include/freetype2
-L//lib -lfreetype
```

### After

```bash
> freetype-config --cflags --libs --ftversion --exec-prefix --prefix
/tmp/output/bin/..
/tmp/output/bin/..
2.14.1
-I/tmp/output/bin/../include/freetype2
-L/tmp/output/bin/../lib -lfreetype
```

Bonus point: the testing of the recipe can now be simplified.