### PR TITLE
Update cmake build method

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -96,6 +96,7 @@ export default function cmake(): std.Recipe<std.Directory> {
  *   CMake projects that reference each other.
  * @param dependencies - Optionally add dependencies to the build. Most projects
  *   will want to include `std.toolchain()` or a similar toolchain.
+ * @param config - Optionally set the build type on single-configuration generators.
  * @param env - Optionally set environment variables for the build.
  * @param unsafe - Optional unsafe options to enable when building. For example,
  *   passing `{ networking: true }` will allow to download files during the build.
@@ -196,6 +197,12 @@ export function cmakeBuild(
       fi
     done
 
+    # If not set, set the build type to the config
+    if [ -z "\${CMAKE_BUILD_TYPE:-}" ]; then
+      cmake_args+=("-DCMAKE_BUILD_TYPE=$config")
+    fi
+
+    # If not set, set the parallel build level to the number of cores
     if [ -z "\${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]; then
       export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
     fi
@@ -203,7 +210,7 @@ export function cmakeBuild(
     build_dir=$(mktemp -p . -d build.XXXXXX)
 
     cmake -S "$path" -B "$build_dir" --install-prefix "$BRIOCHE_OUTPUT" "\${cmake_args[@]}"
-    cmake --build "$build_dir" --config "$config"
+    cmake --build "$build_dir"
     cmake --install "$build_dir"
 
     if [ -d "$BRIOCHE_OUTPUT/lib64" ]; then


### PR DESCRIPTION
This PR resolved two issues I saw recently when trying to build [`json-c`](https://github.com/json-c/json-c) locally:

- `Debug` configuration was used whereas it should have been `Release`
- Output files were trying to be installed into `/usr/local/...` instead of `$BRIOCHE_OUTPUT`

See below for the errors (only the end of the build output is relevant):

<details>

```
[0.00s] [spawned process with pid 1753486, preparation took 0.00s]
[0.06s] -- The C compiler identification is GNU 13.2.0
[0.06s] -- Detecting C compiler ABI info
[0.12s] -- Detecting C compiler ABI info - done
[0.13s] -- Check for working C compiler: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/locals/7dca703b5f8285de65d1913ebaa34aceffdc83e86537d55cc703b8b701fac6c9/bin/cc - skipped
[0.13s] -- Detecting C compile features
[0.13s] -- Detecting C compile features - done
[0.15s] -- Looking for fcntl.h
[0.20s] -- Looking for fcntl.h - found
[0.20s] -- Looking for inttypes.h
[0.26s] -- Looking for inttypes.h - found
[0.26s] -- Looking for stdarg.h
[0.30s] -- Looking for stdarg.h - found
[0.30s] -- Looking for strings.h
[0.36s] -- Looking for strings.h - found
[0.36s] -- Looking for string.h
[0.41s] -- Looking for string.h - found
[0.41s] -- Looking for syslog.h
[0.46s] -- Looking for syslog.h - found
[0.46s] -- Looking for 4 include files stdlib.h, ..., float.h
[0.52s] -- Looking for 4 include files stdlib.h, ..., float.h - found
[0.52s] -- Looking for unistd.h
[0.58s] -- Looking for unistd.h - found
[0.58s] -- Looking for sys/types.h
[0.63s] -- Looking for sys/types.h - found
[0.63s] -- Looking for sys/resource.h
[0.69s] -- Looking for sys/resource.h - found
[0.69s] -- Looking for dlfcn.h
[0.73s] -- Looking for dlfcn.h - found
[0.73s] -- Looking for endian.h
[0.79s] -- Looking for endian.h - found
[0.79s] -- Looking for limits.h
[0.84s] -- Looking for limits.h - found
[0.84s] -- Looking for locale.h
[0.89s] -- Looking for locale.h - found
[0.89s] -- Looking for memory.h
[0.94s] -- Looking for memory.h - found
[0.94s] -- Looking for stdint.h
[0.99s] -- Looking for stdint.h - found
[0.99s] -- Looking for stdlib.h
[1.05s] -- Looking for stdlib.h - found
[1.05s] -- Looking for sys/cdefs.h
[1.10s] -- Looking for sys/cdefs.h - found
[1.10s] -- Looking for sys/param.h
[1.17s] -- Looking for sys/param.h - found
[1.17s] -- Looking for sys/random.h
[1.22s] -- Looking for sys/random.h - found
[1.22s] -- Looking for sys/stat.h
[1.27s] -- Looking for sys/stat.h - found
[1.27s] -- Looking for xlocale.h
[1.30s] -- Looking for xlocale.h - not found
[1.30s] -- Looking for _isnan
[1.33s] -- Looking for _isnan - not found
[1.33s] -- Looking for _finite
[1.35s] -- Looking for _finite - not found
[1.35s] -- Looking for INFINITY
[1.44s] -- Looking for INFINITY - found
[1.44s] -- Looking for isinf
[1.51s] -- Looking for isinf - found
[1.51s] -- Looking for isnan
[1.59s] -- Looking for isnan - found
[1.59s] -- Looking for nan
[1.67s] -- Looking for nan - found
[1.67s] -- Looking for _doprnt
[1.71s] -- Looking for _doprnt - not found
[1.71s] -- Looking for snprintf
[1.76s] -- Looking for snprintf - found
[1.76s] -- Looking for vasprintf
[1.81s] -- Looking for vasprintf - found
[1.81s] -- Looking for vsnprintf
[1.87s] -- Looking for vsnprintf - found
[1.87s] -- Looking for vprintf
[1.92s] -- Looking for vprintf - found
[1.92s] -- Looking for arc4random
[1.98s] -- Looking for arc4random - found
[1.98s] -- Looking for open
[2.03s] -- Looking for open - found
[2.03s] -- Looking for realloc
[2.09s] -- Looking for realloc - found
[2.09s] -- Looking for setlocale
[2.14s] -- Looking for setlocale - found
[2.14s] -- Looking for uselocale
[2.19s] -- Looking for uselocale - found
[2.19s] -- Looking for strcasecmp
[2.24s] -- Looking for strcasecmp - found
[2.24s] -- Looking for strncasecmp
[2.29s] -- Looking for strncasecmp - found
[2.29s] -- Looking for strdup
[2.35s] -- Looking for strdup - found
[2.35s] -- Looking for strerror
[2.40s] -- Looking for strerror - found
[2.40s] -- Looking for vsyslog
[2.46s] -- Looking for vsyslog - found
[2.46s] -- Looking for getrandom
[2.51s] -- Looking for getrandom - found
[2.51s] -- Looking for getrusage
[2.56s] -- Looking for getrusage - found
[2.56s] -- Looking for strtoll
[2.61s] -- Looking for strtoll - found
[2.61s] -- Looking for strtoull
[2.67s] -- Looking for strtoull - found
[2.67s] -- Looking for stddef.h
[2.72s] -- Looking for stddef.h - found
[2.72s] -- Check size of int
[2.78s] -- Check size of int - done
[2.78s] -- Check size of int64_t
[2.83s] -- Check size of int64_t - done
[2.83s] -- Check size of long
[2.89s] -- Check size of long - done
[2.89s] -- Check size of long long
[2.95s] -- Check size of long long - done
[2.95s] -- Check size of size_t
[3.01s] -- Check size of size_t - done
[3.01s] -- Check size of ssize_t
[3.07s] -- Check size of ssize_t - done
[3.07s] -- Performing Test HAS_GNU_WARNING_LONG
[3.10s] -- Performing Test HAS_GNU_WARNING_LONG - Failed
[3.10s] -- Performing Test HAVE_ATOMIC_BUILTINS
[3.15s] -- Performing Test HAVE_ATOMIC_BUILTINS - Success
[3.15s] -- Performing Test HAVE___THREAD
[3.21s] -- Performing Test HAVE___THREAD - Success
[3.21s] -- Wrote /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/work/build.BVISvS/config.h
[3.21s] -- Wrote /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/work/build.BVISvS/json_config.h
[3.21s] -- Performing Test REENTRANT_WORKS
[3.26s] -- Performing Test REENTRANT_WORKS - Success
[3.26s] -- Performing Test BSYMBOLIC_WORKS
[3.31s] -- Performing Test BSYMBOLIC_WORKS - Success
[3.31s] -- Performing Test VERSION_SCRIPT_WORKS
[3.37s] -- Performing Test VERSION_SCRIPT_WORKS - Success
[3.37s] -- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
[3.37s] Warning: doxygen not found, the 'doc' target will not be included
[3.37s] CMake Deprecation Warning at tests/CMakeLists.txt:1 (cmake_minimum_required):
[3.37s]   Compatibility with CMake < 3.10 will be removed from a future version of
[3.37s]   CMake.
[3.37s]
[3.37s]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[3.37s]   to tell CMake that the project requires at least <min> but has been updated
[3.37s]   to work with policies introduced by <max> or earlier.
[3.37s]
[3.37s]
[3.37s] CMake Deprecation Warning at apps/CMakeLists.txt:2 (cmake_minimum_required):
[3.37s]   Compatibility with CMake < 3.10 will be removed from a future version of
[3.37s]   CMake.
[3.37s]
[3.37s]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[3.37s]   to tell CMake that the project requires at least <min> but has been updated
[3.37s]   to work with policies introduced by <max> or earlier.
[3.37s]
[3.37s]
[3.37s] -- Wrote /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/work/build.BVISvS/apps_config.h
[3.37s] -- Configuring done (3.4s)
[3.44s] -- Generating done (0.1s)
[3.44s] -- Build files have been written to: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/work/build.BVISvS
[3.47s] [  2%] Building C object CMakeFiles/json-c-static.dir/arraylist.c.o
[3.47s] [  3%] Building C object CMakeFiles/json-c.dir/arraylist.c.o
[3.47s] [  6%] Building C object CMakeFiles/json-c.dir/json_c_version.c.o
[3.47s] [  6%] Building C object CMakeFiles/json-c-static.dir/json_c_version.c.o
[3.47s] [  6%] Building C object CMakeFiles/json-c-static.dir/debug.c.o
[3.47s] [  2%] Building C object CMakeFiles/json-c.dir/debug.c.o
[3.47s] [  7%] Building C object CMakeFiles/json-c-static.dir/json_object.c.o
[3.47s] [  9%] Building C object CMakeFiles/json-c.dir/json_object.c.o
[3.50s] [ 10%] Building C object CMakeFiles/json-c.dir/json_object_iterator.c.o
[3.50s] [ 11%] Building C object CMakeFiles/json-c-static.dir/json_object_iterator.c.o
[3.55s] [ 12%] Building C object CMakeFiles/json-c-static.dir/json_tokener.c.o
[3.55s] [ 13%] Building C object CMakeFiles/json-c-static.dir/json_util.c.o
[3.56s] [ 14%] Building C object CMakeFiles/json-c.dir/json_tokener.c.o
[3.56s] [ 15%] Building C object CMakeFiles/json-c.dir/json_util.c.o
[3.56s] [ 17%] Building C object CMakeFiles/json-c-static.dir/json_visit.c.o
[3.57s] [ 18%] Building C object CMakeFiles/json-c.dir/json_visit.c.o
[3.62s] [ 19%] Building C object CMakeFiles/json-c.dir/linkhash.c.o
[3.65s] [ 20%] Building C object CMakeFiles/json-c-static.dir/linkhash.c.o
[3.66s] [ 21%] Building C object CMakeFiles/json-c.dir/printbuf.c.o
[3.66s] [ 22%] Building C object CMakeFiles/json-c-static.dir/printbuf.c.o
[3.73s] [ 23%] Building C object CMakeFiles/json-c-static.dir/random_seed.c.o
[3.74s] [ 25%] Building C object CMakeFiles/json-c-static.dir/strerror_override.c.o
[3.75s] [ 26%] Building C object CMakeFiles/json-c-static.dir/json_pointer.c.o
[3.78s] [ 27%] Building C object CMakeFiles/json-c.dir/random_seed.c.o
[3.78s] [ 28%] Building C object CMakeFiles/json-c.dir/strerror_override.c.o
[3.80s] [ 29%] Building C object CMakeFiles/json-c-static.dir/json_patch.c.o
[3.81s] [ 30%] Building C object CMakeFiles/json-c.dir/json_pointer.c.o
[3.83s] [ 31%] Building C object CMakeFiles/json-c.dir/json_patch.c.o
[3.88s] [ 32%] Linking C static library libjson-c.a
[3.90s] [ 32%] Built target json-c-static
[3.90s] [ 34%] Linking C shared library libjson-c.so
[3.95s] [ 34%] Built target json-c
[3.96s] [ 36%] Building C object tests/CMakeFiles/test1.dir/test1.c.o
[3.96s] [ 36%] Building C object tests/CMakeFiles/test1Formatted.dir/test1.c.o
[3.96s] [ 38%] Building C object tests/CMakeFiles/test2Formatted.dir/test2.c.o
[3.96s] [ 38%] Building C object tests/CMakeFiles/test2.dir/test2.c.o
[3.96s] [ 39%] Building C object tests/CMakeFiles/test4.dir/test4.c.o
[3.97s] [ 40%] Building C object tests/CMakeFiles/test_charcase.dir/test_charcase.c.o
[3.97s] [ 42%] Building C object tests/CMakeFiles/testReplaceExisting.dir/testReplaceExisting.c.o
[3.97s] [ 43%] Building C object tests/CMakeFiles/test_cast.dir/test_cast.c.o
[4.02s] [ 44%] Building C object tests/CMakeFiles/test2Formatted.dir/parse_flags.c.o
[4.04s] [ 46%] Linking C executable testReplaceExisting
[4.04s] [ 46%] Linking C executable test2
[4.04s] [ 47%] Linking C executable test4
[4.04s] [ 48%] Linking C executable test_charcase
[4.05s] [ 50%] Linking C executable test_cast
[4.07s] [ 51%] Linking C executable test1
[4.08s] [ 52%] Building C object tests/CMakeFiles/test1Formatted.dir/parse_flags.c.o
[4.12s] [ 53%] Linking C executable test2Formatted
[4.13s] [ 53%] Built target test_charcase
[4.13s] [ 53%] Built target test4
[4.14s] [ 53%] Built target testReplaceExisting
[4.14s] [ 53%] Built target test2
[4.14s] [ 54%] Building C object tests/CMakeFiles/test_deep_copy.dir/test_deep_copy.c.o
[4.15s] [ 55%] Building C object tests/CMakeFiles/test_compare.dir/test_compare.c.o
[4.15s] [ 55%] Built target test_cast
[4.16s] [ 56%] Building C object tests/CMakeFiles/test_double_serializer.dir/test_double_serializer.c.o
[4.16s] [ 57%] Linking C executable test1Formatted
[4.16s] [ 59%] Building C object tests/CMakeFiles/test_float.dir/test_float.c.o
[4.17s] [ 60%] Building C object tests/CMakeFiles/test_int_add.dir/test_int_add.c.o
[4.18s] [ 60%] Built target test1
[4.19s] [ 61%] Building C object tests/CMakeFiles/test_int_get.dir/test_int_get.c.o
[4.20s] [ 61%] Built target test2Formatted
[4.22s] [ 62%] Linking C executable test_float
[4.22s] [ 63%] Building C object tests/CMakeFiles/test_locale.dir/test_locale.c.o
[4.23s] [ 64%] Linking C executable test_compare
[4.23s] [ 64%] Built target test1Formatted
[4.24s] [ 65%] Building C object tests/CMakeFiles/test_null.dir/test_null.c.o
[4.24s] [ 67%] Linking C executable test_double_serializer
[4.26s] [ 68%] Linking C executable test_int_add
[4.29s] [ 69%] Linking C executable test_deep_copy
[4.31s] [ 70%] Linking C executable test_locale
[4.33s] [ 70%] Built target test_float
[4.34s] [ 70%] Built target test_compare
[4.34s] [ 71%] Building C object tests/CMakeFiles/test_parse.dir/test_parse.c.o
[4.35s] [ 72%] Linking C executable test_null
[4.36s] [ 73%] Linking C executable test_int_get
[4.36s] [ 73%] Built target test_int_add
[4.36s] [ 73%] Built target test_double_serializer
[4.37s] [ 75%] Building C object tests/CMakeFiles/test_parse_int64.dir/test_parse_int64.c.o
[4.38s] [ 75%] Built target test_deep_copy
[4.39s] [ 76%] Building C object tests/CMakeFiles/test_printbuf.dir/test_printbuf.c.o
[4.39s] [ 77%] Building C object tests/CMakeFiles/test_set_serializer.dir/test_set_serializer.c.o
[4.39s] [ 77%] Built target test_locale
[4.40s] [ 78%] Building C object tests/CMakeFiles/test_set_value.dir/test_set_value.c.o
[4.42s] [ 79%] Building C object tests/CMakeFiles/test_strerror.dir/test_strerror.c.o
[4.42s] [ 79%] Built target test_null
[4.44s] [ 80%] Building C object tests/CMakeFiles/test_util_file.dir/test_util_file.c.o
[4.44s] [ 80%] Built target test_int_get
[4.44s] [ 81%] Linking C executable test_parse_int64
[4.45s] [ 82%] Building C object tests/CMakeFiles/test_visit.dir/test_visit.c.o
[4.46s] [ 84%] Linking C executable test_strerror
[4.48s] [ 85%] Linking C executable test_printbuf
[4.49s] [ 86%] Linking C executable test_set_value
[4.49s] [ 87%] Linking C executable test_set_serializer
[4.51s] [ 88%] Linking C executable test_parse
[4.52s] [ 88%] Built target test_parse_int64
[4.54s] [ 89%] Linking C executable test_visit
[4.54s] [ 89%] Built target test_strerror
[4.54s] [ 90%] Building C object tests/CMakeFiles/test_object_iterator.dir/test_object_iterator.c.o
[4.56s] [ 92%] Building C object tests/CMakeFiles/test_json_pointer.dir/test_json_pointer.c.o
[4.57s] [ 92%] Built target test_set_value
[4.57s] [ 92%] Built target test_printbuf
[4.58s] [ 93%] Building C object apps/CMakeFiles/json_parse.dir/json_parse.c.o
[4.59s] [ 93%] Built target test_set_serializer
[4.59s] [ 94%] Building C object tests/CMakeFiles/test_json_patch.dir/test_json_patch.c.o
[4.59s] [ 95%] Linking C executable test_util_file
[4.60s] [ 95%] Built target test_parse
[4.61s] [ 95%] Built target test_visit
[4.62s] [ 96%] Linking C executable test_object_iterator
[4.64s] [ 96%] Built target test_util_file
[4.66s] [ 97%] Linking C executable test_json_patch
[4.67s] [ 97%] Built target test_object_iterator
[4.67s] [ 98%] Linking C executable json_parse
[4.69s] [100%] Linking C executable test_json_pointer
[4.71s] [100%] Built target test_json_patch
[4.72s] [100%] Built target json_parse
[4.74s] [100%] Built target test_json_pointer
[4.75s] -- Install configuration: "debug"
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/libjson-c.so.5.4.0
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/libjson-c.so.5
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/libjson-c.so
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/libjson-c.a
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/cmake/json-c/json-c-targets.cmake
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/cmake/json-c/json-c-targets-debug.cmake
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/cmake/json-c/json-c-config.cmake
[4.75s] -- Installing: /home/brioche-runner-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/.local/share/brioche/outputs/output-bfc5c33e7a1e9865f19c44230fd388d138a3e18ce92318d8db73b180d0ffca8d/lib64/pkgconfig/json-c.pc
[4.75s] CMake Error at build.BVISvS/cmake_install.cmake:127 (file):
[4.75s]   file cannot create directory: /usr/local/include/json-c.  Maybe need
[4.75s]   administrative privileges.
[4.75s]
[4.75s]
[4.75s] [process exited with code 1]
```

</details>

With this PR:

<details>

```
[0.00s] [spawned process with pid 1754921, preparation took 0.00s]
[0.08s] -- The C compiler identification is GNU 13.2.0
[0.09s] -- Detecting C compiler ABI info
[0.14s] -- Detecting C compiler ABI info - done
[0.16s] -- Check for working C compiler: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/locals/7dca703b5f8285de65d1913ebaa34aceffdc83e86537d55cc703b8b701fac6c9/bin/cc - skipped
[0.16s] -- Detecting C compile features
[0.16s] -- Detecting C compile features - done
[0.17s] -- Looking for fcntl.h
[0.23s] -- Looking for fcntl.h - found
[0.23s] -- Looking for inttypes.h
[0.28s] -- Looking for inttypes.h - found
[0.28s] -- Looking for stdarg.h
[0.33s] -- Looking for stdarg.h - found
[0.33s] -- Looking for strings.h
[0.39s] -- Looking for strings.h - found
[0.39s] -- Looking for string.h
[0.44s] -- Looking for string.h - found
[0.44s] -- Looking for syslog.h
[0.49s] -- Looking for syslog.h - found
[0.49s] -- Looking for 4 include files stdlib.h, ..., float.h
[0.56s] -- Looking for 4 include files stdlib.h, ..., float.h - found
[0.56s] -- Looking for unistd.h
[0.61s] -- Looking for unistd.h - found
[0.61s] -- Looking for sys/types.h
[0.67s] -- Looking for sys/types.h - found
[0.67s] -- Looking for sys/resource.h
[0.72s] -- Looking for sys/resource.h - found
[0.72s] -- Looking for dlfcn.h
[0.77s] -- Looking for dlfcn.h - found
[0.77s] -- Looking for endian.h
[0.82s] -- Looking for endian.h - found
[0.82s] -- Looking for limits.h
[0.88s] -- Looking for limits.h - found
[0.88s] -- Looking for locale.h
[0.93s] -- Looking for locale.h - found
[0.93s] -- Looking for memory.h
[0.98s] -- Looking for memory.h - found
[0.98s] -- Looking for stdint.h
[1.03s] -- Looking for stdint.h - found
[1.03s] -- Looking for stdlib.h
[1.10s] -- Looking for stdlib.h - found
[1.10s] -- Looking for sys/cdefs.h
[1.15s] -- Looking for sys/cdefs.h - found
[1.15s] -- Looking for sys/param.h
[1.21s] -- Looking for sys/param.h - found
[1.21s] -- Looking for sys/random.h
[1.27s] -- Looking for sys/random.h - found
[1.27s] -- Looking for sys/stat.h
[1.33s] -- Looking for sys/stat.h - found
[1.33s] -- Looking for xlocale.h
[1.36s] -- Looking for xlocale.h - not found
[1.36s] -- Looking for _isnan
[1.39s] -- Looking for _isnan - not found
[1.39s] -- Looking for _finite
[1.42s] -- Looking for _finite - not found
[1.42s] -- Looking for INFINITY
[1.50s] -- Looking for INFINITY - found
[1.50s] -- Looking for isinf
[1.59s] -- Looking for isinf - found
[1.59s] -- Looking for isnan
[1.67s] -- Looking for isnan - found
[1.67s] -- Looking for nan
[1.76s] -- Looking for nan - found
[1.76s] -- Looking for _doprnt
[1.79s] -- Looking for _doprnt - not found
[1.79s] -- Looking for snprintf
[1.85s] -- Looking for snprintf - found
[1.85s] -- Looking for vasprintf
[1.91s] -- Looking for vasprintf - found
[1.91s] -- Looking for vsnprintf
[1.96s] -- Looking for vsnprintf - found
[1.96s] -- Looking for vprintf
[2.02s] -- Looking for vprintf - found
[2.02s] -- Looking for arc4random
[2.08s] -- Looking for arc4random - found
[2.08s] -- Looking for open
[2.14s] -- Looking for open - found
[2.14s] -- Looking for realloc
[2.20s] -- Looking for realloc - found
[2.20s] -- Looking for setlocale
[2.26s] -- Looking for setlocale - found
[2.26s] -- Looking for uselocale
[2.31s] -- Looking for uselocale - found
[2.31s] -- Looking for strcasecmp
[2.37s] -- Looking for strcasecmp - found
[2.37s] -- Looking for strncasecmp
[2.42s] -- Looking for strncasecmp - found
[2.42s] -- Looking for strdup
[2.48s] -- Looking for strdup - found
[2.48s] -- Looking for strerror
[2.53s] -- Looking for strerror - found
[2.53s] -- Looking for vsyslog
[2.59s] -- Looking for vsyslog - found
[2.59s] -- Looking for getrandom
[2.64s] -- Looking for getrandom - found
[2.64s] -- Looking for getrusage
[2.69s] -- Looking for getrusage - found
[2.70s] -- Looking for strtoll
[2.76s] -- Looking for strtoll - found
[2.76s] -- Looking for strtoull
[2.82s] -- Looking for strtoull - found
[2.82s] -- Looking for stddef.h
[2.87s] -- Looking for stddef.h - found
[2.87s] -- Check size of int
[2.93s] -- Check size of int - done
[2.93s] -- Check size of int64_t
[2.99s] -- Check size of int64_t - done
[2.99s] -- Check size of long
[3.05s] -- Check size of long - done
[3.05s] -- Check size of long long
[3.11s] -- Check size of long long - done
[3.11s] -- Check size of size_t
[3.16s] -- Check size of size_t - done
[3.16s] -- Check size of ssize_t
[3.22s] -- Check size of ssize_t - done
[3.22s] -- Performing Test HAS_GNU_WARNING_LONG
[3.25s] -- Performing Test HAS_GNU_WARNING_LONG - Failed
[3.25s] -- Performing Test HAVE_ATOMIC_BUILTINS
[3.30s] -- Performing Test HAVE_ATOMIC_BUILTINS - Success
[3.30s] -- Performing Test HAVE___THREAD
[3.35s] -- Performing Test HAVE___THREAD - Success
[3.35s] -- Wrote /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/work/build.MYvBKQ/config.h
[3.35s] -- Wrote /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/work/build.MYvBKQ/json_config.h
[3.35s] -- Performing Test REENTRANT_WORKS
[3.41s] -- Performing Test REENTRANT_WORKS - Success
[3.41s] -- Performing Test BSYMBOLIC_WORKS
[3.46s] -- Performing Test BSYMBOLIC_WORKS - Success
[3.46s] -- Performing Test VERSION_SCRIPT_WORKS
[3.51s] -- Performing Test VERSION_SCRIPT_WORKS - Success
[3.52s] -- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
[3.52s] Warning: doxygen not found, the 'doc' target will not be included
[3.52s] CMake Deprecation Warning at tests/CMakeLists.txt:1 (cmake_minimum_required):
[3.52s]   Compatibility with CMake < 3.10 will be removed from a future version of
[3.52s]   CMake.
[3.52s]
[3.52s]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[3.52s]   to tell CMake that the project requires at least <min> but has been updated
[3.52s]   to work with policies introduced by <max> or earlier.
[3.52s]
[3.52s]
[3.52s] CMake Deprecation Warning at apps/CMakeLists.txt:2 (cmake_minimum_required):
[3.52s]   Compatibility with CMake < 3.10 will be removed from a future version of
[3.52s]   CMake.
[3.52s]
[3.52s]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[3.52s]   to tell CMake that the project requires at least <min> but has been updated
[3.52s]   to work with policies introduced by <max> or earlier.
[3.52s]
[3.52s]
[3.52s] -- Wrote /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/work/build.MYvBKQ/apps_config.h
[3.52s] -- Configuring done (3.5s)
[3.60s] -- Generating done (0.1s)
[3.60s] -- Build files have been written to: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/work/build.MYvBKQ
[3.63s] [  1%] Building C object CMakeFiles/json-c.dir/arraylist.c.o
[3.63s] [  2%] Building C object CMakeFiles/json-c-static.dir/debug.c.o
[3.63s] [  3%] Building C object CMakeFiles/json-c.dir/json_c_version.c.o
[3.63s] [  4%] Building C object CMakeFiles/json-c.dir/debug.c.o
[3.63s] [  5%] Building C object CMakeFiles/json-c-static.dir/arraylist.c.o
[3.63s] [  7%] Building C object CMakeFiles/json-c-static.dir/json_object.c.o
[3.63s] [  9%] Building C object CMakeFiles/json-c.dir/json_object.c.o
[3.63s] [  9%] Building C object CMakeFiles/json-c-static.dir/json_c_version.c.o
[3.67s] [ 10%] Building C object CMakeFiles/json-c.dir/json_object_iterator.c.o
[3.67s] [ 11%] Building C object CMakeFiles/json-c-static.dir/json_object_iterator.c.o
[3.74s] [ 12%] Building C object CMakeFiles/json-c.dir/json_tokener.c.o
[3.75s] [ 13%] Building C object CMakeFiles/json-c.dir/json_util.c.o
[3.75s] [ 14%] Building C object CMakeFiles/json-c.dir/json_visit.c.o
[3.78s] [ 15%] Building C object CMakeFiles/json-c.dir/linkhash.c.o
[3.86s] [ 17%] Building C object CMakeFiles/json-c-static.dir/json_tokener.c.o
[3.88s] [ 18%] Building C object CMakeFiles/json-c-static.dir/json_util.c.o
[3.90s] [ 19%] Building C object CMakeFiles/json-c-static.dir/json_visit.c.o
[4.01s] [ 20%] Building C object CMakeFiles/json-c-static.dir/linkhash.c.o
[4.03s] [ 21%] Building C object CMakeFiles/json-c-static.dir/printbuf.c.o
[4.10s] [ 22%] Building C object CMakeFiles/json-c-static.dir/random_seed.c.o
[4.17s] [ 23%] Building C object CMakeFiles/json-c-static.dir/strerror_override.c.o
[4.22s] [ 25%] Building C object CMakeFiles/json-c-static.dir/json_pointer.c.o
[4.27s] [ 26%] Building C object CMakeFiles/json-c.dir/printbuf.c.o
[4.30s] [ 27%] Building C object CMakeFiles/json-c-static.dir/json_patch.c.o
[4.44s] [ 28%] Building C object CMakeFiles/json-c.dir/random_seed.c.o
[4.48s] [ 29%] Building C object CMakeFiles/json-c.dir/strerror_override.c.o
[4.51s] [ 30%] Building C object CMakeFiles/json-c.dir/json_pointer.c.o
[4.51s] [ 31%] Building C object CMakeFiles/json-c.dir/json_patch.c.o
[5.07s] [ 34%] Linking C shared library libjson-c.so
[5.07s] [ 34%] Linking C static library libjson-c.a
[5.08s] [ 34%] Built target json-c-static
[5.13s] [ 34%] Built target json-c
[5.14s] [ 35%] Building C object tests/CMakeFiles/test1.dir/test1.c.o
[5.14s] [ 36%] Building C object tests/CMakeFiles/test1Formatted.dir/test1.c.o
[5.14s] [ 37%] Building C object tests/CMakeFiles/test2.dir/test2.c.o
[5.14s] [ 39%] Building C object tests/CMakeFiles/testReplaceExisting.dir/testReplaceExisting.c.o
[5.14s] [ 39%] Building C object tests/CMakeFiles/test4.dir/test4.c.o
[5.14s] [ 40%] Building C object tests/CMakeFiles/test2Formatted.dir/test2.c.o
[5.14s] [ 42%] Building C object tests/CMakeFiles/test_cast.dir/test_cast.c.o
[5.15s] [ 43%] Building C object tests/CMakeFiles/test_charcase.dir/test_charcase.c.o
[5.21s] [ 44%] Linking C executable test_charcase
[5.23s] [ 45%] Linking C executable test2
[5.24s] [ 46%] Building C object tests/CMakeFiles/test2Formatted.dir/parse_flags.c.o
[5.27s] [ 47%] Linking C executable testReplaceExisting
[5.28s] [ 48%] Linking C executable test4
[5.28s] [ 50%] Linking C executable test_cast
[5.31s] [ 50%] Built target test2
[5.32s] [ 50%] Built target test_charcase
[5.33s] [ 51%] Building C object tests/CMakeFiles/test_deep_copy.dir/test_deep_copy.c.o
[5.33s] [ 52%] Building C object tests/CMakeFiles/test_compare.dir/test_compare.c.o
[5.36s] [ 53%] Linking C executable test2Formatted
[5.37s] [ 53%] Built target testReplaceExisting
[5.38s] [ 54%] Building C object tests/CMakeFiles/test1Formatted.dir/parse_flags.c.o
[5.38s] [ 54%] Built target test4
[5.39s] [ 54%] Built target test_cast
[5.39s] [ 55%] Building C object tests/CMakeFiles/test_double_serializer.dir/test_double_serializer.c.o
[5.40s] [ 56%] Building C object tests/CMakeFiles/test_float.dir/test_float.c.o
[5.45s] [ 56%] Built target test2Formatted
[5.45s] [ 57%] Linking C executable test1
[5.46s] [ 59%] Building C object tests/CMakeFiles/test_int_add.dir/test_int_add.c.o
[5.47s] [ 60%] Building C object tests/CMakeFiles/test_int_get.dir/test_int_get.c.o
[5.47s] [ 61%] Linking C executable test_float
[5.48s] [ 62%] Linking C executable test1Formatted
[5.52s] [ 63%] Linking C executable test_double_serializer
[5.52s] [ 63%] Built target test1
[5.53s] [ 64%] Linking C executable test_compare
[5.53s] [ 65%] Building C object tests/CMakeFiles/test_locale.dir/test_locale.c.o
[5.56s] [ 65%] Built target test_float
[5.56s] [ 65%] Built target test1Formatted
[5.57s] [ 67%] Linking C executable test_deep_copy
[5.58s] [ 68%] Building C object tests/CMakeFiles/test_parse.dir/test_parse.c.o
[5.59s] [ 69%] Building C object tests/CMakeFiles/test_null.dir/test_null.c.o
[5.59s] [ 70%] Linking C executable test_int_add
[5.59s] [ 70%] Built target test_double_serializer
[5.60s] [ 71%] Building C object tests/CMakeFiles/test_parse_int64.dir/test_parse_int64.c.o
[5.60s] [ 71%] Built target test_compare
[5.61s] [ 72%] Building C object tests/CMakeFiles/test_printbuf.dir/test_printbuf.c.o
[5.64s] [ 72%] Built target test_deep_copy
[5.64s] [ 73%] Linking C executable test_locale
[5.65s] [ 73%] Built target test_int_add
[5.65s] [ 75%] Building C object tests/CMakeFiles/test_set_serializer.dir/test_set_serializer.c.o
[5.66s] [ 76%] Building C object tests/CMakeFiles/test_set_value.dir/test_set_value.c.o
[5.68s] [ 77%] Linking C executable test_null
[5.70s] [ 77%] Built target test_locale
[5.71s] [ 78%] Building C object tests/CMakeFiles/test_strerror.dir/test_strerror.c.o
[5.76s] [ 78%] Built target test_null
[5.77s] [ 79%] Linking C executable test_parse_int64
[5.77s] [ 80%] Linking C executable test_strerror
[5.78s] [ 81%] Building C object tests/CMakeFiles/test_util_file.dir/test_util_file.c.o
[5.78s] [ 82%] Linking C executable test_set_serializer
[5.80s] [ 84%] Linking C executable test_printbuf
[5.82s] [ 85%] Linking C executable test_int_get
[5.83s] [ 85%] Built target test_parse_int64
[5.84s] [ 85%] Built target test_strerror
[5.84s] [ 85%] Built target test_set_serializer
[5.85s] [ 86%] Building C object tests/CMakeFiles/test_visit.dir/test_visit.c.o
[5.85s] [ 87%] Building C object tests/CMakeFiles/test_object_iterator.dir/test_object_iterator.c.o
[5.87s] [ 88%] Building C object tests/CMakeFiles/test_json_pointer.dir/test_json_pointer.c.o
[5.87s] [ 89%] Linking C executable test_set_value
[5.88s] [ 89%] Built target test_printbuf
[5.89s] [ 90%] Building C object tests/CMakeFiles/test_json_patch.dir/test_json_patch.c.o
[5.91s] [ 90%] Built target test_int_get
[5.92s] [ 92%] Linking C executable test_parse
[5.93s] [ 93%] Building C object apps/CMakeFiles/json_parse.dir/json_parse.c.o
[5.94s] [ 94%] Linking C executable test_object_iterator
[5.95s] [ 94%] Built target test_set_value
[5.98s] [ 95%] Linking C executable test_util_file
[5.99s] [ 95%] Built target test_parse
[6.00s] [ 95%] Built target test_object_iterator
[6.01s] [ 96%] Linking C executable test_visit
[6.04s] [ 96%] Built target test_util_file
[6.05s] [ 97%] Linking C executable test_json_patch
[6.06s] [ 97%] Built target test_visit
[6.09s] [ 97%] Built target test_json_patch
[6.11s] [ 98%] Linking C executable json_parse
[6.15s] [ 98%] Built target json_parse
[6.28s] [100%] Linking C executable test_json_pointer
[6.33s] [100%] Built target test_json_pointer
[6.33s] -- Install configuration: "Release"
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/libjson-c.so.5.4.0
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/libjson-c.so.5
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/libjson-c.so
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/libjson-c.a
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/cmake/json-c/json-c-targets.cmake
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/cmake/json-c/json-c-targets-release.cmake
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/cmake/json-c/json-c-config.cmake
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/lib64/pkgconfig/json-c.pc
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_config.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/arraylist.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/debug.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_c_version.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_inttypes.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_object.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_object_iterator.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_tokener.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_types.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_util.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_visit.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/linkhash.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/printbuf.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_pointer.h
[6.33s] -- Installing: /home/brioche-runner-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/.local/share/brioche/outputs/output-be3b38acaf5b650975c93fd3fe9a3eddb58764c07f93e54b8d7e8908784fc91a/include/json-c/json_patch.h
```

</details>

I also checked for the `pstack` recipe (since it was the only one that was using the parameter `config`), and it still uses the correct build type:

```
[44.05s] -- Install configuration: "RelWithDebInfo"
```

The main difference between [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE) and [`CMAKE_CONFIGURATION_TYPES`](https://cmake.org/cmake/help/latest/variable/CMAKE_CONFIGURATION_TYPES.html#variable:CMAKE_CONFIGURATION_TYPES) is (at least for me) the support of build type inside the package being built. Multi-config generators seem to be designed for a few specific tools where single-config generators is generally more supported since it can be used with `[Makefile Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#makefile-generators) or [Ninja](https://cmake.org/cmake/help/latest/generator/Ninja.html#generator:Ninja)` generators (which are more common), and as for now, we are just using these two generators in Broche recipes.