### PR TITLE
feat(json_c): add package

### DIFF
--- a/packages/json_c/brioche.lock
+++ b/packages/json_c/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/json-c/json-c.git": {
+      "json-c-0.18-20240915": "41a55cfcedb54d9c1874f2f0eb07b504091d7e37"
+    }
+  }
+}

--- a/packages/json_c/project.bri
+++ b/packages/json_c/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "json_c",
+  version: "0.18-20240915",
+  repository: "https://github.com/json-c/json-c.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `json-c-${project.version}`,
+});
+
+export default function jsonC(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion json-c | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, jsonC)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version.split("-").at(0);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^json-c-(?<version>.+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `json-c`
- **Website / repository:** https://github.com/json-c/json-c
- **Short description:** Implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
1775276│ 0.18
 0.02s ✓ Process 1775276
Build finished, completed 1 job in 1.84s
Result: 89ab0014be15c49669e563c4e9781c01eb1ac9ff28c23700167f45f0df97fba2
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 10.35s
Running brioche-run
{
  "name": "json_c",
  "version": "0.18-20240915",
  "repository": "https://github.com/json-c/json-c.git"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
