### PR TITLE
fix(std): ensure post build methods do follow symbolic links

### DIFF
--- a/packages/std/extra/libtool_sanitize_dependencies.bri
+++ b/packages/std/extra/libtool_sanitize_dependencies.bri
@@ -2,7 +2,16 @@ import * as std from "/core";
 import { runBash } from "./run_bash.bri";
 
 export const LIBTOOL_SANITIZE_DEPENDENCIES_SCRIPT = std.indoc`
-  sed -i -e "/^dependency_libs='/,/'/ s|//lib/lib\\([^[:space:]]*\\)\\.la|-l\\1|g" "$BRIOCHE_OUTPUT"/lib/*.la
+  sanitize_libtool_dependencies () {
+    local -r file="$1"
+
+    sed -i -e "/^dependency_libs='/,/'/ s|//lib/lib\\([^[:space:]]*\\)\\.la|-l\\1|g" "$file"
+  }
+
+  find -L "$BRIOCHE_OUTPUT/lib" -name '*.la' -type f -print0 \
+    | while IFS= read -r -d $'\\0' file; do
+      sanitize_libtool_dependencies "$file"
+    done
 `;
 
 /**

--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -34,7 +34,7 @@ export const PKG_CONFIG_MAKE_PATHS_RELATIVE_SCRIPT = std.indoc`
     exit 0
   fi
 
-  find "\${find_roots[@]}" -name '*.pc' -type f -print0 \
+  find -L "\${find_roots[@]}" -name '*.pc' -type f -print0 \
     | while IFS= read -r -d $'\\0' file; do
       make_pkg_config_paths_relative "$file"
     done


### PR DESCRIPTION
This is another rebuild the world PR, but I saw the issue while working on #1533.

The `json_c` package pushes all its output into `lib64` which is then symlinked to `lib` at the end of `cmakeBuild()`. Unfortunately, our post build methods do not follow the links of such files. So pkg config and libtool files weren't updated.

Also, this PR fixes a possible issue with `LIBTOOL_SANITIZE_DEPENDENCIES_SCRIPT`, previously, if the recipe wasn't containing any `*.la` files, an error was thrown. This is now handled more gracefully through the usage of `find first -> then execute command`.

Before:

```
1786204│ sed: can't read /home/brioche-runner-ea6ff3839e11210c3e3f1d16dda0739451a7cf14a5741af642e2f4038e57776f/.local/share/brioche/outputs/output-ea6ff3839e11210c3e3f1d16dda0739451a7cf14a5741af642e2f4038e577
       │ 76f/lib/*.la: No such file or directory
```

After

```
... no issue
```