### PR TITLE
feat(cargo_make): add package

### DIFF
--- a/packages/cargo_make/brioche.lock
+++ b/packages/cargo_make/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-make/0.37.24/download": {
+      "type": "sha256",
+      "value": "7f304f6f709b5dbbc0efe9c84af1f42af22e0636e625c54799a60ec3d6efb64f"
+    }
+  }
+}

--- a/packages/cargo_make/project.bri
+++ b/packages/cargo_make/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_make",
+  version: "0.37.24",
+  extra: {
+    crateName: "cargo-make",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoMake(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-make",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo make --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoMake)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-make ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_make`
- **Website / repository:** https://github.com/sagiegurari/cargo-make
- **Short description:** Rust task runner and build tool.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
1936111│ cargo-make 0.37.24
 0.07s ✓ Process 1936111
 1m59s ✓ Process 1933761
 9.16s ✓ Process 1933728
 0.03s ✓ Process 1933725
Build finished, completed 8 jobs in 2m39s
Result: 44064eed4f4522afa9b2a2fc7a3e14706ad2af76ecba1efabb03a7ffee17e51e
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 13.53s
Running brioche-run
{
  "name": "cargo_make",
  "version": "0.37.24",
  "extra": {
    "crateName": "cargo-make"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
