### PR TITLE
feat(cargo_outdated): add package

### DIFF
--- a/packages/cargo_outdated/brioche.lock
+++ b/packages/cargo_outdated/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-outdated/0.17.0/download": {
+      "type": "sha256",
+      "value": "44b3609d8eb75f60eb0df95a671e5f6a2c8e42678ee9313ec64c6835b766215d"
+    }
+  }
+}

--- a/packages/cargo_outdated/project.bri
+++ b/packages/cargo_outdated/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import openssl from "openssl";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_outdated",
+  version: "0.17.0",
+  extra: {
+    crateName: "cargo-outdated",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoOutdated(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [openssl],
+    runnable: "bin/cargo-outdated",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo outdated --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoOutdated)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-outdated-outdated ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_outdated`
- **Website / repository:** https://github.com/kbknapp/cargo-outdated
- **Short description:** A cargo subcommand for displaying when Rust dependencies are out of date

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
1945170│ cargo-outdated-outdated 0.17.0
 0.04s ✓ Process 1945170
 5m18s ✓ Process 1939420
13.55s ✓ Process 1939327
 0.04s ✓ Process 1939322
Build finished, completed 8 jobs in 6m12s
Result: 44b02a6944786d1caecca1d75afa645343734537012b916bd8fc76d59ac0c095
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 13.67s
Running brioche-run
{
  "name": "cargo_outdated",
  "version": "0.17.0",
  "extra": {
    "crateName": "cargo-outdated"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
