### PR TITLE
fix(std): update regex to allow exclamation mark in go module name for live update

### DIFF
--- a/packages/std/extra/live_update/from_go_modules.bri
+++ b/packages/std/extra/live_update/from_go_modules.bri
@@ -83,7 +83,7 @@ interface GoModuleInfo {
 function tryParseGoModule(
   extraOptions: LiveUpdateFromGoModulesProjectExtraOptions,
 ): GoModuleInfo | null {
-  const match = extraOptions.moduleName.match(/^(?<moduleName>[\w\./-]+)$/);
+  const match = extraOptions.moduleName.match(/^(?<moduleName>[\w\./!-]+)$/);
 
   const { moduleName } = match?.groups ?? {};
   if (moduleName == null) {


### PR DESCRIPTION
[Per specification](https://github.com/golang/vgo/blob/f621561646e8078690ff9966602bf506a52f9475/vendor/cmd/go/internal/modfetch/proxy.go#L56-L59). I saw it while further experimenting with the newly added live update methods.