### PR TITLE
feat(xxhash): add package

### DIFF
--- a/packages/xxhash/brioche.lock
+++ b/packages/xxhash/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Cyan4973/xxHash": {
+      "v0.8.3": "e626a72bc2321cd320e953a0ccf1584cad60f363"
+    }
+  }
+}

--- a/packages/xxhash/project.bri
+++ b/packages/xxhash/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+
+export const project = {
+  name: "xxhash",
+  version: "0.8.3",
+  repository: "https://github.com/Cyan4973/xxHash",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function xxhash(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/xxhsum"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libxxhash | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xxhash)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** xxhash
- **Website / repository:** https://github.com/Cyan4973/xxHash
- **Short description:** Extremely fast non-cryptographic hash algorithm

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.79s
Result: d5cb8cd8e65388583c5ea2e0a3eed7b67df6535eb5b5449479705b8c11924a10
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 9.22s
Running brioche-run
{
  "name": "xxhash",
  "version": "0.8.3",
  "repository": "https://github.com/Cyan4973/xxHash"
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
