### PR TITLE
feat(cargo_release): add package

### DIFF
--- a/packages/cargo_release/brioche.lock
+++ b/packages/cargo_release/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-release/0.25.20/download": {
+      "type": "sha256",
+      "value": "a4c19c10f6cda5f645a268885108b81a34d134d4a17e9053a7841a60949073d5"
+    }
+  }
+}

--- a/packages/cargo_release/project.bri
+++ b/packages/cargo_release/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_release",
+  version: "0.25.20",
+  extra: {
+    crateName: "cargo-release",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoRelease(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-release",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo release --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoRelease)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-release ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_release`
- **Website / repository:** https://github.com/crate-ci/cargo-release
- **Short description:** Cargo subcommand `release`: everything about releasing a rust crate.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
111119 │ cargo-release 0.25.20
 0.03s ✓ Process 111119
 4m 3s ✓ Process 98194
21.13s ✓ Process 97927
 0.03s ✓ Process 97923
Build finished, completed 8 jobs in 5m 5s
Result: 74b0bafe7f7e97b1c74518c02d7cedc59a45d58463b4c732e6e6c69c0f0795d4
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 13.19s
Running brioche-run
{
  "name": "cargo_release",
  "version": "0.25.20",
  "extra": {
    "crateName": "cargo-release"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
