### PR TITLE
feat(bacon): add package

### DIFF
--- a/packages/bacon/brioche.lock
+++ b/packages/bacon/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/bacon/3.19.0/download": {
+      "type": "sha256",
+      "value": "0bf3622c4f3b94a0adf5cc798c0a40bd0fa8008752c290dfd28ae21f1619fcc5"
+    }
+  }
+}

--- a/packages/bacon/project.bri
+++ b/packages/bacon/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "bacon",
+  version: "3.19.0",
+  extra: {
+    crateName: "bacon",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function bacon(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/bacon",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    bacon --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bacon)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `bacon ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `bacon`
- **Website / repository:** https://github.com/Canop/bacon
- **Short description:** background code checker

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.17s
Result: f46a641db7566891a0ddf592539b41c5a4849a888aae31c37bf50a34cb2e94d5
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 2 jobs in 13.90s
Running brioche-run
{
  "name": "bacon",
  "version": "3.19.0",
  "extra": {
    "crateName": "bacon"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
