### PR TITLE
refactor(go): update goModDownload function to use `std.process`

### DIFF
--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -292,25 +292,25 @@ function goModDownload(
 ): std.Recipe<std.Directory> {
   // Includes all the modules in the specified directory and its subdirectories
   // If a workspace file exists also include it
-  return std.runBash`
-    go mod download all
-  `
-    .workDir(
-      std.glob(goModule, [
+  return std
+    .process({
+      command: std.tpl`${go}/bin/go`,
+      args: ["mod", "download", "all"],
+      workDir: std.glob(goModule, [
         "**/go.mod",
         "**/go.sum",
         "**/go.work",
         "**/go.work.sum",
       ]),
-    )
-    .dependencies(go)
-    .env({
-      GOMODCACHE: std.outputPath,
+      currentDir:
+        currentDir != null
+          ? std.tpl`${std.workDir}/${currentDir}`
+          : std.workDir,
+      env: {
+        GOMODCACHE: std.outputPath,
+      },
+      unsafe: { networking: true },
     })
-    .currentDir(
-      currentDir != null ? std.tpl`${std.workDir}/${currentDir}` : std.workDir,
-    )
-    .unsafe({ networking: true })
     .toDirectory();
 }
 


### PR DESCRIPTION
Tested with `carapace` recipe:

```
Build finished, completed (no new jobs) in 1.15s
Result: d7176fbe8121f2227ebe68fa577ea55ae220bab572f90fddcd1b5598dd09cfce

⏵ Task `Run package test` finished successfully
```