### PR TITLE
feat(vfox): add package

### DIFF
--- a/packages/vfox/brioche.lock
+++ b/packages/vfox/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/version-fox/vfox/@v/v0.9.2.zip": {
+      "type": "sha256",
+      "value": "41a17fd8efbe5db8693c9d31fed5a602dd4a605ac0f9c0856d6b1525f61ac33b"
+    }
+  }
+}

--- a/packages/vfox/project.bri
+++ b/packages/vfox/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "vfox",
+  version: "0.9.2",
+  extra: {
+    moduleName: "github.com/version-fox/vfox",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function vfox(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/vfox",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    vfox --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(vfox)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `vfox version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `vfox`
- **Website / repository:** https://github.com/version-fox/vfox
- **Short description:** A cross-platform and extendable version manager with support for Java, Node.js, Golang, Python, Flutter, .NET & more

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
 0.02s ✓ Process 155613
 7.87s ✓ Process 153117
 9.05s ✓ Process 153014
 0.18s ✓ Unarchive 100% Unarchive: 3.3 MiB                                                                                                                                                                   
Build finished, completed 4 jobs in 34.68s
Result: ea3bde2fd3579992e4eafde61578b782747d6adaa28a9029c3b46e95270e9321
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 7.35s
Running brioche-run
{
  "name": "vfox",
  "version": "0.9.2",
  "extra": {
    "moduleName": "github.com/version-fox/vfox"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
