### PR TITLE
refactor: simplify currentDir logic in Go and Rust project files

### DIFF
--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -262,11 +262,7 @@ export function goBuild(options: GoBuildOptions): std.Recipe<std.Directory> {
     go install "\${goargs[@]}" "$package_path"
   `
     .workDir(options.source)
-    .currentDir(
-      options.currentDir != null
-        ? std.tpl`${std.workDir}/${options.currentDir}`
-        : std.workDir,
-    )
+    .currentDir(std.tpl`${std.workDir}/${options.currentDir}`)
     .dependencies(go, ...(options.dependencies ?? []))
     .env({
       GOMODCACHE: modules,
@@ -302,10 +298,7 @@ function goModDownload(
         "**/go.work",
         "**/go.work.sum",
       ]),
-      currentDir:
-        currentDir != null
-          ? std.tpl`${std.workDir}/${currentDir}`
-          : std.workDir,
+      currentDir: std.tpl`${std.workDir}/${currentDir}`,
       env: {
         GOMODCACHE: std.outputPath,
       },

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -345,10 +345,7 @@ export function cargoBuild(
       },
       dependencies: [rust, std.toolchain, ...(options.dependencies ?? [])],
       workDir: crate,
-      currentDir:
-        options.currentDir != null
-          ? std.tpl`${std.workDir}/${options.currentDir}`
-          : std.workDir,
+      currentDir: std.tpl`${std.workDir}/${options.currentDir}`,
       unsafe: options.unsafe,
     })
     .toDirectory()
@@ -413,11 +410,7 @@ function createLockfile(
   `
     .dependencies(rust)
     .outputScaffold(source)
-    .currentDir(
-      currentDir != null
-        ? std.tpl`${std.outputPath}/${currentDir}`
-        : std.outputPath,
-    )
+    .currentDir(std.tpl`${std.outputPath}/${currentDir}`)
     .unsafe({ networking: true })
     .toDirectory();
 }
@@ -453,10 +446,7 @@ export function createSkeletonCrate(
       args: ["chef", "prepare", "--recipe-path", std.outputPath],
       dependencies: [rust, cargoChef],
       workDir: source,
-      currentDir:
-        currentDir != null
-          ? std.tpl`${std.workDir}/${currentDir}`
-          : std.workDir,
+      currentDir: std.tpl`${std.workDir}/${currentDir}`,
     })
     .toFile();
 
@@ -469,10 +459,7 @@ export function createSkeletonCrate(
         currentDir != null
           ? std.directory({ [currentDir]: std.directory() })
           : std.directory(),
-      currentDir:
-        currentDir != null
-          ? std.tpl`${std.outputPath}/${currentDir}`
-          : std.outputPath,
+      currentDir: std.tpl`${std.outputPath}/${currentDir}`,
     })
     .toDirectory();
 }
@@ -556,11 +543,7 @@ export function vendorCrate(
   `
     .dependencies(rust)
     .outputScaffold(skeletonCrate)
-    .currentDir(
-      currentDir != null
-        ? std.tpl`${std.outputPath}/${currentDir}`
-        : std.outputPath,
-    )
+    .currentDir(std.tpl`${std.outputPath}/${currentDir}`)
     .unsafe({ networking: true })
     .toDirectory();
 


### PR DESCRIPTION
Simplify `currentDir` in `go` and `rust` recipes, by always using "std.tpl\`${std.workDir}/${options.currentDir}\`" instead of a ternary operator. At the end, when `options.currentDir` is null, it'll be the same path whereas we were using `std.workDir` or `std.tpl`${std.workDir}/`. The only downside of this modification is: it'll trigger a rebuild of the recipes that do not set `options.currentDir`.