### PR TITLE
refactor: remove redundant path field from go project recipes

### DIFF
--- a/packages/chezmoi/project.bri
+++ b/packages/chezmoi/project.bri
@@ -18,7 +18,6 @@ export default function chezmoi(): std.Recipe<std.Directory> {
     buildParams: {
       ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
     },
-    path: ".",
     runnable: "bin/chezmoi",
   });
 }

--- a/packages/fzf/project.bri
+++ b/packages/fzf/project.bri
@@ -28,7 +28,6 @@ export default function fzf(): std.Recipe<std.Directory> {
         `main.revision=${gitRef.commit}`,
       ],
     },
-    path: ".",
     runnable: "bin/fzf",
   });
 }

--- a/packages/go_mockery/project.bri
+++ b/packages/go_mockery/project.bri
@@ -24,7 +24,6 @@ export default function goMockery(): std.Recipe<std.Directory> {
         `github.com/vektra/mockery/v3/internal/logging.SemVer=${project.version}`,
       ],
     },
-    path: ".",
     runnable: "bin/mockery",
   });
 }

--- a/packages/hugo/project.bri
+++ b/packages/hugo/project.bri
@@ -30,7 +30,6 @@ export default function hugo(): std.Recipe<std.Directory> {
         `github.com/gohugoio/hugo/common/hugo.buildDate=${project.extra.releaseDate}`,
       ],
     },
-    path: ".",
     runnable: "bin/hugo",
   });
 }

--- a/packages/terraform_docs/project.bri
+++ b/packages/terraform_docs/project.bri
@@ -18,7 +18,6 @@ export default function terraformDocs(): std.Recipe<std.Directory> {
     buildParams: {
       ldflags: ["-s", "-w"],
     },
-    path: ".",
     runnable: "bin/terraform-docs",
   });
 }

--- a/packages/terraform_ls/project.bri
+++ b/packages/terraform_ls/project.bri
@@ -18,7 +18,6 @@ export default function terraformLs(): std.Recipe<std.Directory> {
     buildParams: {
       ldflags: ["-s", "-w"],
     },
-    path: ".",
     runnable: "bin/terraform-ls",
   });
 }


### PR DESCRIPTION
This PR removes setting `path` to `.` for Go recipes. This is already the default when this option is not set:

```ts
package_path: options.path ?? ".",
```