### PR TITLE
refactor: replace cd with workDir in `python` and `moreutils`

### DIFF
--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -99,7 +99,6 @@ function wrapPerlShebangs(
     recipe = recipe.insert(".local/libexec/moreutils/perl", perlEnv());
 
     const perlShebangPathList = await std.runBash`
-      cd "$recipe"
       find bin -type f -executable \\
       | while read file; do
         if [[ "$(head -c 2 "$file")" == '#!' ]] && head -n1 "$file" | grep -q perl; then
@@ -107,7 +106,7 @@ function wrapPerlShebangs(
         fi
       done
     `
-      .env({ recipe })
+      .workDir(recipe)
       .toFile()
       .read();
     const perlShebangPaths = perlShebangPathList

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -209,7 +209,6 @@ export async function fixScriptShebangs(
   // directly. See this function from Pip:
   // https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_vendor/distlib/scripts.py#L154
   const pythonShebangPathList = await std.runBash`
-    cd "$recipe"
     find bin ! -name 'python*-config' -type f -executable \\
     | while read file; do
       if [[ "$(head -c 2 "$file")" == '#!' ]]; then
@@ -217,7 +216,7 @@ export async function fixScriptShebangs(
       fi
     done
   `
-    .env({ recipe })
+    .workDir(recipe)
     .toFile()
     .read();
   const pythonShebangPaths = pythonShebangPathList
@@ -227,7 +226,6 @@ export async function fixScriptShebangs(
   // Get the list of shebang shell scripts. We only handle the `python-config`
   // script.
   const shellShebangPathList = await std.runBash`
-    cd "$recipe"
     find bin -name 'python*-config' -type f -executable \\
     | while read file; do
       if [[ "$(head -c 2 "$file")" == '#!' ]]; then
@@ -235,7 +233,7 @@ export async function fixScriptShebangs(
       fi
     done
   `
-    .env({ recipe })
+    .workDir(recipe)
     .toFile()
     .read();
   const shellShebangPaths = shellShebangPathList


### PR DESCRIPTION
One more PR to simplify a `cd` we were doing in multiple locations. I replaced it with `.workDir()`