### PR TITLE
feat: add --buildtype=release to both bubblewrap and kmod meson setup commands

### DIFF
--- a/packages/bubblewrap/project.bri
+++ b/packages/bubblewrap/project.bri
@@ -17,7 +17,9 @@ const source = Brioche.download(
 
 export default function bubblewrap(): std.Recipe<std.Directory> {
   return std.runBash`
-    meson setup _builddir --prefix /
+    meson setup _builddir \
+      --buildtype=release \
+      --prefix=/
     meson compile -C _builddir
     meson install -C _builddir --destdir "$BRIOCHE_OUTPUT"
   `

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -18,7 +18,10 @@ const source = Brioche.download(
 
 export default function kmod(): std.Recipe<std.Directory> {
   return std.runBash`
-    meson setup build --prefix=/ -Dmanpages=false
+    meson setup build \
+      -Dmanpages=false \
+      --buildtype=release \
+      --prefix=/
     meson compile -C build
     DESTDIR="$BRIOCHE_OUTPUT" meson install -C build
 


### PR DESCRIPTION
Similar to what was done with Python and CMake recently. At some point, we should have a `mesonBuild()` method. Locally I have a fix for https://github.com/brioche-dev/brioche-packages/issues/838, I just need to better write it before to open a PR.