### PR TITLE
build(rust): update version to 1.91.0

### DIFF
--- a/packages/rust/brioche.lock
+++ b/packages/rust/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://static.rust-lang.org/dist/channel-rust-1.90.0.toml": {
+    "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml": {
       "type": "sha256",
-      "value": "489c19f20d331765ab2835661eb546de90f6446a107a8db83045e7371e45cae2"
+      "value": "d9e59cdf15532aa839c0a4871b0b755e833f914042eb2dcc59f2a0ef8667f9f6"
     }
   }
 }

--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -5,7 +5,7 @@ import * as t from "typer";
 
 export const project = {
   name: "rust",
-  version: "1.90.0",
+  version: "1.91.0",
   repository: "https://github.com/rust-lang/rust",
 };
 


### PR DESCRIPTION
I don't know but the live update checking of `rust` is failing since a few weeks as shown below:

Extracted from this [report](https://github.com/brioche-dev/brioche-packages/actions/runs/18831189969/job/53722812082): 

<details>

```
packages/rust (17 / 300)
  From https://github.com/brioche-dev/brioche-packages
   * branch            live-update/rust -> FETCH_HEAD
   * [new branch]      live-update/rust -> origin/live-update/rust
  Previous HEAD position was 57d600b build(deps): Bump actions/upload-artifact from 4 to 5 (#1538)
  HEAD is now at 7f035b7 [live-update] packages/rust
  Fetching artifact from cache
  Fetched 0 B for artifact from cache in 0.00s
  Fetching artifact from cache
  Fetched 3.8 MiB for artifact from cache in 0.40s
  Finished unarchiving 3.8 MiB in 0.03s
  Launched process 3935
  Process 3935 ran in 0.01s
  Fetching artifact from cache
  Fetched 1.1 GiB for artifact from cache in 17.25s
  Fetching artifact from cache
  Fetching artifact from cache
  Fetching artifact from cache
  Fetched 40.1 MiB for artifact from cache in 4.65s
  Fetched 156.1 MiB for artifact from cache in 8.05s
  Fetched 367.7 MiB for artifact from cache in 17.26s
  Prepared process 3974 in 15.93s
  Launched process 3974
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/cargo
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/rust-gdb
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/rust-gdbgui
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/rust-lldb
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/lib/librustc_driver-890dfd19c9b338c0.so
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/rustc
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/bin/rustdoc
  [3974] autopacked /home/brioche-runner-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/.local/share/brioche/outputs/output-3fb3fb4ce03ba2e6ca3a43660bfd5555e705a7d156540b3ffd8d35253c560779/libexec/rust-analyzer-proc-macro-srv
  Process 3974 ran in 1.70s
  Fetching artifact from cache
  Fetching artifact from cache
  Fetching artifact from cache
  Fetched 27.6 MiB for artifact from cache in 1.46s
  Fetched 16.9 MiB for artifact from cache in 2.12s
  Fetching artifact from cache
  Fetched 176.3 KiB for artifact from cache in 0.07s
  Fetched 39.5 MiB for artifact from cache in 3.11s
  Prepared process 3979 in 1.03s
  Launched process 3979
  Process 3979 ran in 0.01s
  Launched process 3981
  [3981]     Updating crates.io index
  [3981]  Downloading crates ...
  [3981]   Downloaded assert_fs v1.1.2
  [3981]   Downloaded windows-targets v0.52.6
  [3981]   Downloaded serde v1.0.217
  [3981]   Downloaded windows_x86_64_gnullvm v0.52.6
  [3981]   Downloaded windows_x86_64_gnu v0.52.6
  [3981]   Downloaded winapi-util v0.1.9
  [3981]   Downloaded wasi v0.11.0+wasi-snapshot-preview1
  [3981]   Downloaded thiserror-impl v1.0.69
  [3981]   Downloaded walkdir v2.5.0
  [3981]   Downloaded toml_edit v0.22.22
  [3981]   Downloaded serde_derive v1.0.217
  [3981]   Downloaded ryu v1.0.19
  [3981]   Downloaded clap_derive v4.5.24
  [3981]   Downloaded anyhow v1.0.95
  [3981]   Downloaded unicode-ident v1.0.16
  [3981]   Downloaded serde_json v1.0.138
  [3981]   Downloaded thiserror-impl v2.0.11
  [3981]   Downloaded winnow v0.6.25
  [3981]   Downloaded clap_builder v4.5.27
  [3981]   Downloaded tempfile v3.15.0
  [3981]   Downloaded regex v1.11.1
  [3981]   Downloaded semver v1.0.25
  [3981]   Downloaded syn v2.0.96
  [3981]   Downloaded memchr v2.7.4
  [3981]   Downloaded indexmap v2.7.1
  [3981]   Downloaded clap_lex v0.7.4
  [3981]   Downloaded windows_aarch64_gnullvm v0.52.6
  [3981]   Downloaded rustix v0.38.44
  [3981]   Downloaded regex-syntax v0.8.5
  [3981]   Downloaded cargo-platform v0.1.9
  [3981]   Downloaded termtree v0.5.1
  [3981]   Downloaded windows_i686_gnullvm v0.52.6
  [3981]   Downloaded termcolor v1.4.1
  [3981]   Downloaded strsim v0.11.1
  [3981]   Downloaded same-file v1.0.6
  [3981]   Downloaded globwalk v0.8.1
  [3981]   Downloaded autocfg v1.4.0
  [3981]   Downloaded wait-timeout v0.2.0
  [3981]   Downloaded regex-automata v0.4.9
  [3981]   Downloaded windows_x86_64_msvc v0.52.6
  [3981]   Downloaded utf8parse v0.2.2
  [3981]   Downloaded libc v0.2.169
  [3981]   Downloaded toml_datetime v0.6.8
  [3981]   Downloaded toml v0.8.19
  [3981]   Downloaded proc-macro2 v1.0.93
  [3981]   Downloaded predicates-core v1.0.9
  [3981]   Downloaded predicates v3.1.3
  [3981]   Downloaded pathdiff v0.2.3
  [3981]   Downloaded once_cell v1.20.2
  [3981]   Downloaded num-traits v0.2.19
  [3981]   Downloaded log v0.4.25
  [3981]   Downloaded is_terminal_polyfill v1.70.1
  [3981]   Downloaded hermit-abi v0.4.0
  [3981]   Downloaded globwalk v0.9.1
  [3981]   Downloaded getrandom v0.2.15
  [3981]   Downloaded fastrand v2.3.0
  [3981]   Downloaded env_logger v0.10.2
  [3981]   Downloaded dissimilar v1.0.9
  [3981]   Downloaded assert_cmd v2.0.16
  [3981]   Downloaded anstyle-wincon v3.0.7
  [3981]   Downloaded anstyle-query v1.1.2
  [3981]   Downloaded anstyle-parse v0.2.6
  [3981]   Downloaded anstream v0.6.18
  [3981]   Downloaded normalize-line-endings v0.3.0
  [3981]   Downloaded ignore v0.4.23
  [3981]   Downloaded float-cmp v0.10.0
  [3981]   Downloaded expect-test v1.5.1
  [3981]   Downloaded equivalent v1.0.1
  [3981]   Downloaded doc-comment v0.3.3
  [3981]   Downloaded difflib v0.4.0
  [3981]   Downloaded crossbeam-utils v0.8.21
  [3981]   Downloaded crossbeam-deque v0.8.6
  [3981]   Downloaded colorchoice v1.0.3
  [3981]   Downloaded clap v4.5.27
  [3981]   Downloaded cfg-if v1.0.0
  [3981]   Downloaded cargo-manifest v0.18.1
  [3981]   Downloaded anstyle v1.0.10
  [3981]   Downloaded windows_i686_msvc v0.52.6
  [3981]   Downloaded windows_i686_gnu v0.52.6
  [3981]   Downloaded windows_aarch64_msvc v0.52.6
  [3981]   Downloaded bstr v1.11.3
  [3981]   Downloaded aho-corasick v1.1.3
  [3981]   Downloaded hashbrown v0.15.2
  [3981]   Downloaded crossbeam-epoch v0.9.18
  [3981]   Downloaded camino v1.1.9
  [3981]   Downloaded bitflags v1.3.2
  [3981]   Downloaded thiserror v2.0.11
  [3981]   Downloaded thiserror v1.0.69
  [3981]   Downloaded serde_spanned v0.6.8
  [3981]   Downloaded quote v1.0.38
  [3981]   Downloaded predicates-tree v1.0.12
  [3981]   Downloaded itoa v1.0.14
  [3981]   Downloaded is-terminal v0.4.15
  [3981]   Downloaded humantime v2.1.0
  [3981]   Downloaded heck v0.5.0
  [3981]   Downloaded globset v0.4.15
  [3981]   Downloaded fs-err v2.11.0
  [3981]   Downloaded errno v0.3.10
  [3981]   Downloaded cargo_metadata v0.15.4
  [3981]   Downloaded bitflags v2.8.0
  [3981]   Downloaded linux-raw-sys v0.4.15
  [3981]   Downloaded windows-sys v0.59.0
  [3981]    Vendoring aho-corasick v1.1.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aho-corasick-1.1.3) to vendor/aho-corasick
  [3981]    Vendoring anstream v0.6.18 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstream-0.6.18) to vendor/anstream
  [3981]    Vendoring anstyle v1.0.10 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-1.0.10) to vendor/anstyle
  [3981]    Vendoring anstyle-parse v0.2.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-parse-0.2.6) to vendor/anstyle-parse
  [3981]    Vendoring anstyle-query v1.1.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-query-1.1.2) to vendor/anstyle-query
  [3981]    Vendoring anstyle-wincon v3.0.7 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstyle-wincon-3.0.7) to vendor/anstyle-wincon
  [3981]    Vendoring anyhow v1.0.95 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.95) to vendor/anyhow
  [3981]    Vendoring assert_cmd v2.0.16 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assert_cmd-2.0.16) to vendor/assert_cmd
  [3981]    Vendoring assert_fs v1.1.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assert_fs-1.1.2) to vendor/assert_fs
  [3981]    Vendoring autocfg v1.4.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/autocfg-1.4.0) to vendor/autocfg
  [3981]    Vendoring bitflags v1.3.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitflags-1.3.2) to vendor/bitflags-1.3.2
  [3981]    Vendoring bitflags v2.8.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bitflags-2.8.0) to vendor/bitflags
  [3981]    Vendoring bstr v1.11.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bstr-1.11.3) to vendor/bstr
  [3981]    Vendoring camino v1.1.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/camino-1.1.9) to vendor/camino
  [3981]    Vendoring cargo-manifest v0.18.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-manifest-0.18.1) to vendor/cargo-manifest
  [3981]    Vendoring cargo-platform v0.1.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-platform-0.1.9) to vendor/cargo-platform
  [3981]    Vendoring cargo_metadata v0.15.4 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo_metadata-0.15.4) to vendor/cargo_metadata
  [3981]    Vendoring cfg-if v1.0.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cfg-if-1.0.0) to vendor/cfg-if
  [3981]    Vendoring clap v4.5.27 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap-4.5.27) to vendor/clap
  [3981]    Vendoring clap_builder v4.5.27 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.27) to vendor/clap_builder
  [3981]    Vendoring clap_derive v4.5.24 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_derive-4.5.24) to vendor/clap_derive
  [3981]    Vendoring clap_lex v0.7.4 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_lex-0.7.4) to vendor/clap_lex
  [3981]    Vendoring colorchoice v1.0.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/colorchoice-1.0.3) to vendor/colorchoice
  [3981]    Vendoring crossbeam-deque v0.8.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-deque-0.8.6) to vendor/crossbeam-deque
  [3981]    Vendoring crossbeam-epoch v0.9.18 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-epoch-0.9.18) to vendor/crossbeam-epoch
  [3981]    Vendoring crossbeam-utils v0.8.21 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossbeam-utils-0.8.21) to vendor/crossbeam-utils
  [3981]    Vendoring difflib v0.4.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/difflib-0.4.0) to vendor/difflib
  [3981]    Vendoring dissimilar v1.0.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dissimilar-1.0.9) to vendor/dissimilar
  [3981]    Vendoring doc-comment v0.3.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/doc-comment-0.3.3) to vendor/doc-comment
  [3981]    Vendoring env_logger v0.10.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/env_logger-0.10.2) to vendor/env_logger
  [3981]    Vendoring equivalent v1.0.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/equivalent-1.0.1) to vendor/equivalent
  [3981]    Vendoring errno v0.3.10 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/errno-0.3.10) to vendor/errno
  [3981]    Vendoring expect-test v1.5.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/expect-test-1.5.1) to vendor/expect-test
  [3981]    Vendoring fastrand v2.3.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/fastrand-2.3.0) to vendor/fastrand
  [3981]    Vendoring float-cmp v0.10.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/float-cmp-0.10.0) to vendor/float-cmp
  [3981]    Vendoring fs-err v2.11.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/fs-err-2.11.0) to vendor/fs-err
  [3981]    Vendoring getrandom v0.2.15 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.2.15) to vendor/getrandom
  [3981]    Vendoring globset v0.4.15 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/globset-0.4.15) to vendor/globset
  [3981]    Vendoring globwalk v0.8.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/globwalk-0.8.1) to vendor/globwalk-0.8.1
  [3981]    Vendoring globwalk v0.9.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/globwalk-0.9.1) to vendor/globwalk
  [3981]    Vendoring hashbrown v0.15.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.15.2) to vendor/hashbrown
  [3981]    Vendoring heck v0.5.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/heck-0.5.0) to vendor/heck
  [3981]    Vendoring hermit-abi v0.4.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hermit-abi-0.4.0) to vendor/hermit-abi
  [3981]    Vendoring humantime v2.1.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/humantime-2.1.0) to vendor/humantime
  [3981]    Vendoring ignore v0.4.23 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ignore-0.4.23) to vendor/ignore
  [3981]    Vendoring indexmap v2.7.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indexmap-2.7.1) to vendor/indexmap
  [3981]    Vendoring is-terminal v0.4.15 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/is-terminal-0.4.15) to vendor/is-terminal
  [3981]    Vendoring is_terminal_polyfill v1.70.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/is_terminal_polyfill-1.70.1) to vendor/is_terminal_polyfill
  [3981]    Vendoring itoa v1.0.14 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/itoa-1.0.14) to vendor/itoa
  [3981]    Vendoring libc v0.2.169 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libc-0.2.169) to vendor/libc
  [3981]    Vendoring linux-raw-sys v0.4.15 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/linux-raw-sys-0.4.15) to vendor/linux-raw-sys
  [3981]    Vendoring log v0.4.25 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.25) to vendor/log
  [3981]    Vendoring memchr v2.7.4 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/memchr-2.7.4) to vendor/memchr
  [3981]    Vendoring normalize-line-endings v0.3.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/normalize-line-endings-0.3.0) to vendor/normalize-line-endings
  [3981]    Vendoring num-traits v0.2.19 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/num-traits-0.2.19) to vendor/num-traits
  [3981]    Vendoring once_cell v1.20.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/once_cell-1.20.2) to vendor/once_cell
  [3981]    Vendoring pathdiff v0.2.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pathdiff-0.2.3) to vendor/pathdiff
  [3981]    Vendoring predicates v3.1.3 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/predicates-3.1.3) to vendor/predicates
  [3981]    Vendoring predicates-core v1.0.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/predicates-core-1.0.9) to vendor/predicates-core
  [3981]    Vendoring predicates-tree v1.0.12 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/predicates-tree-1.0.12) to vendor/predicates-tree
  [3981]    Vendoring proc-macro2 v1.0.93 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proc-macro2-1.0.93) to vendor/proc-macro2
  [3981]    Vendoring quote v1.0.38 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/quote-1.0.38) to vendor/quote
  [3981]    Vendoring regex v1.11.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regex-1.11.1) to vendor/regex
  [3981]    Vendoring regex-automata v0.4.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regex-automata-0.4.9) to vendor/regex-automata
  [3981]    Vendoring regex-syntax v0.8.5 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regex-syntax-0.8.5) to vendor/regex-syntax
  [3981]    Vendoring rustix v0.38.44 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.38.44) to vendor/rustix
  [3981]    Vendoring ryu v1.0.19 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ryu-1.0.19) to vendor/ryu
  [3981]    Vendoring same-file v1.0.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/same-file-1.0.6) to vendor/same-file
  [3981]    Vendoring semver v1.0.25 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semver-1.0.25) to vendor/semver
  [3981]    Vendoring serde v1.0.217 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.217) to vendor/serde
  [3981]    Vendoring serde_derive v1.0.217 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_derive-1.0.217) to vendor/serde_derive
  [3981]    Vendoring serde_json v1.0.138 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.138) to vendor/serde_json
  [3981]    Vendoring serde_spanned v0.6.8 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_spanned-0.6.8) to vendor/serde_spanned
  [3981]    Vendoring strsim v0.11.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/strsim-0.11.1) to vendor/strsim
  [3981]    Vendoring syn v2.0.96 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.96) to vendor/syn
  [3981]    Vendoring tempfile v3.15.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tempfile-3.15.0) to vendor/tempfile
  [3981]    Vendoring termcolor v1.4.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/termcolor-1.4.1) to vendor/termcolor
  [3981]    Vendoring termtree v0.5.1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/termtree-0.5.1) to vendor/termtree
  [3981]    Vendoring thiserror v1.0.69 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/thiserror-1.0.69) to vendor/thiserror-1.0.69
  [3981]    Vendoring thiserror v2.0.11 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/thiserror-2.0.11) to vendor/thiserror
  [3981]    Vendoring thiserror-impl v1.0.69 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/thiserror-impl-1.0.69) to vendor/thiserror-impl-1.0.69
  [3981]    Vendoring thiserror-impl v2.0.11 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/thiserror-impl-2.0.11) to vendor/thiserror-impl
  [3981]    Vendoring toml v0.8.19 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/toml-0.8.19) to vendor/toml
  [3981]    Vendoring toml_datetime v0.6.8 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/toml_datetime-0.6.8) to vendor/toml_datetime
  [3981]    Vendoring toml_edit v0.22.22 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/toml_edit-0.22.22) to vendor/toml_edit
  [3981]    Vendoring unicode-ident v1.0.16 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unicode-ident-1.0.16) to vendor/unicode-ident
  [3981]    Vendoring utf8parse v0.2.2 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/utf8parse-0.2.2) to vendor/utf8parse
  [3981]    Vendoring wait-timeout v0.2.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wait-timeout-0.2.0) to vendor/wait-timeout
  [3981]    Vendoring walkdir v2.5.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/walkdir-2.5.0) to vendor/walkdir
  [3981]    Vendoring wasi v0.11.0+wasi-snapshot-preview1 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasi-0.11.0+wasi-snapshot-preview1) to vendor/wasi
  [3981]    Vendoring winapi-util v0.1.9 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winapi-util-0.1.9) to vendor/winapi-util
  [3981]    Vendoring windows-sys v0.59.0 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows-sys-0.59.0) to vendor/windows-sys
  [3981]    Vendoring windows-targets v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows-targets-0.52.6) to vendor/windows-targets
  [3981]    Vendoring windows_aarch64_gnullvm v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_aarch64_gnullvm-0.52.6) to vendor/windows_aarch64_gnullvm
  [3981]    Vendoring windows_aarch64_msvc v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_aarch64_msvc-0.52.6) to vendor/windows_aarch64_msvc
  [3981]    Vendoring windows_i686_gnu v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_i686_gnu-0.52.6) to vendor/windows_i686_gnu
  [3981]    Vendoring windows_i686_gnullvm v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_i686_gnullvm-0.52.6) to vendor/windows_i686_gnullvm
  [3981]    Vendoring windows_i686_msvc v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_i686_msvc-0.52.6) to vendor/windows_i686_msvc
  [3981]    Vendoring windows_x86_64_gnu v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_x86_64_gnu-0.52.6) to vendor/windows_x86_64_gnu
  [3981]    Vendoring windows_x86_64_gnullvm v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_x86_64_gnullvm-0.52.6) to vendor/windows_x86_64_gnullvm
  [3981]    Vendoring windows_x86_64_msvc v0.52.6 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows_x86_64_msvc-0.52.6) to vendor/windows_x86_64_msvc
  [3981]    Vendoring winnow v0.6.25 (/home/brioche-runner-0e936817ec44b89a12c92738734d5b3838e54ba1376075350edac75215eb2bea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winnow-0.6.25) to vendor/winnow
  [3981] To use vendored sources, add this to your .cargo/config.toml for this project:
  Process 3981 ran in 1.71s
  Process 3981 finalized in 3.23s
  Prepared process 3990 in 1.15s
  Launched process 3990
  [3990]   Installing cargo-chef v0.1.72 (/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work)
  [3990]    Compiling proc-macro2 v1.0.93
  [3990]    Compiling unicode-ident v1.0.16
  [3990]    Compiling serde v1.0.217
  [3990]    Compiling memchr v2.7.4
  [3990]    Compiling crossbeam-utils v0.8.21
  [3990] error: linking with `cc` failed: exit status: 1
  [3990]   |
  [3990]   = note:  "cc" "-m64" "/tmp/rustcZtrEnl/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcZtrEnl/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work/target/release/build/serde-173e18c28c24603a/build_script_build-173e18c28c24603a" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-debug" "-nodefaultlibs"
  [3990]   = note: some arguments are omitted. use `--verbose` to show all linker arguments
  [3990]   = note: collect2: fatal error: execvp: No such file or directory
  [3990]           compilation terminated.
  [3990]           
  [3990] error: could not compile `serde` (build script) due to 1 previous error
  [3990] warning: build failed, waiting for other jobs to finish...
  [3990] error: linking with `cc` failed: exit status: 1
  [3990]   |
  [3990]   = note:  "cc" "-m64" "/tmp/rustcIoHGGx/symbols.o" "<3 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcIoHGGx/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work/target/release/build/proc-macro2-e9b487bb9e78193b/build_script_build-e9b487bb9e78193b" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-debug" "-nodefaultlibs"
  [3990]   = note: some arguments are omitted. use `--verbose` to show all linker arguments
  [3990]   = note: collect2: fatal error: execvp: No such file or directory
  [3990]           compilation terminated.
  [3990]           
  [3990] error: could not compile `proc-macro2` (build script) due to 1 previous error
  [3990] error: linking with `cc` failed: exit status: 1
  [3990]   |
  [3990]   = note:  "cc" "-m64" "/tmp/rustc46J3Gk/symbols.o" "<3 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustc46J3Gk/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work/target/release/build/crossbeam-utils-33f7787954bad4ec/build_script_build-33f7787954bad4ec" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-debug" "-nodefaultlibs"
  [3990]   = note: some arguments are omitted. use `--verbose` to show all linker arguments
  [3990]   = note: collect2: fatal error: execvp: No such file or directory
  [3990]           compilation terminated.
  [3990]           
  [3990] error: could not compile `crossbeam-utils` (build script) due to 1 previous error
  [3990] error: failed to compile `cargo-chef v0.1.72 (/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work)`, intermediate artifacts can be found at `/home/brioche-runner-f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8/work/target`.
  [3990] To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
   INFO run_build:bake:bake_process:bake_process_finalize: brioche_core::bake::process: keeping temporary bake dir /home/runner/.local/share/brioche/process-temp/01K8J3J72DD02GMVWCPXXGG7ZZ recipe_hash=f1605f91cd98db993c00927586820530d9395a3079509411620be8bf009076a8 bake_dir=/home/runner/.local/share/brioche/process-temp/01K8J3J72DD02GMVWCPXXGG7ZZ
  Error: process failed, view full output by running `brioche jobs logs /home/runner/.local/share/brioche/process-temp/01K8J3J72DD02GMVWCPXXGG7ZZ/events.bin.zst`: process exited with status code exit status: 101
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:300:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/cargo_chef/project.bri:16:10
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/recipe.bri:83:50
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/recipe.bri:132:19
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:196:51
      at <unknown>
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:196:34
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:333:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:336:29
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:337:29
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:230:14
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:411:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:476:7
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:226:17
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/project.bri:53:19
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/proxy.bri:49:48
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/proxy.bri:56:8
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:416:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:221:14
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:423:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:424:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/process.bri:257:14
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:507:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/proxy.bri:65:20
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:508:6
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:518:27
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/project.bri:60:5
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/project.bri:59:34
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:516:17
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/rust/project.bri:523:17
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/project.bri:67:14
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/recipe.bri:344:23
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/runnable.bri:279:31
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/runnable.bri:249:34
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/runnable.bri:171:32
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/runnable.bri:72:12
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/nushell_runnable.bri:116:22
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/nushell/nushell_runnable.bri:128:14
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/live_update/from_github_releases.bri:94:7
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/extra/runnable.bri:210:17
      at file:///home/runner/work/brioche-packages/brioche-packages/packages/std/core/recipes/recipe.bri:83:44
  🔴 Failed to update packages/rust
  Error: Failed to update packages/rust
```

</details>

It seems the recipe is being rebuilt during the live update check 😅 so I force the update with this PR to see if it solves the issue for the next live update run.