### PR TITLE
feat(httm): add package

### DIFF
--- a/packages/httm/brioche.lock
+++ b/packages/httm/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/httm/0.49.9/download": {
+      "type": "sha256",
+      "value": "a142edcfbf4f305c8329c078e63a71c660de1a432b81ecc2c8db2f7082119936"
+    }
+  }
+}

--- a/packages/httm/project.bri
+++ b/packages/httm/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "httm",
+  version: "0.49.9",
+  extra: {
+    crateName: "httm",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function httm(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/httm",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    httm --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httm)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `httm ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `httm`
- **Website / repository:** https://github.com/kimono-koans/httm
- **Short description:** nteractive, file-level Time Machine-like tool for ZFS/btrfs/nilfs2 (and even Time Machine and Restic backups!)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
114876 │ httm 0.49.9
 0.03s ✓ Process 114876
21.88s ✓ Process 113257
 9.79s ✓ Process 113226
 0.02s ✓ Process 113223
Build finished, completed 7 jobs in 52.24s
Result: bfd005a1753523773b00bda7c35397047fd41c55b496c942ceb904cc4378ae41
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 11.37s
Running brioche-run
{
  "name": "httm",
  "version": "0.49.9",
  "extra": {
    "crateName": "httm"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
