### PR TITLE
refactor(std): tweak live update scripts to be more idiomatic

### DIFF
--- a/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
@@ -1,24 +1,16 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
 # Retrieve the most recent releases from Gitea
 let releases = http get $'https://gitea.com/api/v1/repos/($env.repoOwner)/($env.repoName)/releases'
   # Extract the version(s)
   | each {|release|
-    let parsedTag = $release.tag_name
+    $release.tag_name
       | parse --regex $env.matchTag
-
-    # If no tag is matched, a nil value will be returned
-    # and this value will be ignored by 'each'
-    if ($parsedTag | length) != 0 {
-      { version: $parsedTag.0.version }
-    }
+      | into record
   }
+  | where (($it | get -o version) | is-not-empty)
   | sort-by --natural version
 
-if ($releases | length) == 0 {
-  error make { msg: $'No tag did match regex ($env.matchTag)' }
+if ($releases | is-empty) {
+  error make { msg: $'No tag does match regex ($env.matchTag)' }
 }
 
 # Get the latest release
@@ -32,6 +24,10 @@ if $env.normalizeVersion == "true" {
   $version = $version
     | str replace --all --regex "(-|_)" "."
 }
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version

--- a/packages/std/extra/live_update/scripts/live_update_from_gitea_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitea_tags.nu
@@ -1,7 +1,3 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
 # Retrieve the most recent tags from Gitea
 let tags = http get $'https://gitea.com/api/v1/repos/($env.repoOwner)/($env.repoName)/tags'
   # Extract the tag(s)
@@ -9,12 +5,13 @@ let tags = http get $'https://gitea.com/api/v1/repos/($env.repoOwner)/($env.repo
   | each {|name|
     $name
       | parse --regex $env.matchTag
-      | get -o 0
+      | into record
   }
+  | where (($it | get -o version) | is-not-empty)
   | sort-by --natural version
 
-if ($tags | length) == 0 {
-  error make { msg: $'No tag did match regex ($env.matchTag)' }
+if ($tags | is-empty) {
+  error make { msg: $'No tag does match regex ($env.matchTag)' }
 }
 
 # Get the latest tag
@@ -29,6 +26,10 @@ if $env.normalizeVersion == "true" {
   $version = $version
     | str replace --all --regex "(-|_)" "."
 }
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -1,24 +1,16 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
 # Retrieve the most recent releases from GitLab
 let releases = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/releases'
   # Extract the version(s)
   | each {|release|
-    let parsedTag = $release.tag_name
+    $release.tag_name
       | parse --regex $env.matchTag
-
-    # If no tag is matched, a nil value will be returned
-    # and this value will be ignored by 'each'
-    if ($parsedTag | length) != 0 {
-      { version: $parsedTag.0.version }
-    }
+      | into record
   }
+  | where (($it | get -o version) | is-not-empty)
   | sort-by --natural version
 
-if ($releases | length) == 0 {
-  error make { msg: $'No tag did match regex ($env.matchTag)' }
+if ($releases | is-empty) {
+  error make { msg: $'No tag does match regex ($env.matchTag)' }
 }
 
 # Get the latest release
@@ -32,6 +24,10 @@ if $env.normalizeVersion == "true" {
   $version = $version
     | str replace --all --regex "(-|_)" "."
 }
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_tags.nu
@@ -1,7 +1,3 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
 # Retrieve the most recent tags from GitLab
 let tags = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($env.repoName)/repository/tags'
   # Extract the tag(s)
@@ -9,12 +5,13 @@ let tags = http get $'https://gitlab.com/api/v4/projects/($env.repoOwner)%2F($en
   | each {|name|
     $name
       | parse --regex $env.matchTag
-      | get -o 0
+      | into record
   }
+  | where (($it | get -o version) | is-not-empty)
   | sort-by --natural version
 
-if ($tags | length) == 0 {
-  error make { msg: $'No tag did match regex ($env.matchTag)' }
+if ($tags | is-empty) {
+  error make { msg: $'No tag does match regex ($env.matchTag)' }
 }
 
 # Get the latest tag
@@ -29,6 +26,10 @@ if $env.normalizeVersion == "true" {
   $version = $version
     | str replace --all --regex "(-|_)" "."
 }
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version

--- a/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
@@ -1,25 +1,17 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
-  # Retrieve the most recent releases from Go proxy registry
+# Retrieve the most recent releases from Go proxy registry
 let releases = http get $'https://proxy.golang.org/($env.moduleName)/@v/list'
   | lines
   # Extract the version(s)
   | each {|release|
-    let parsedVersion = $release
+    $release
       | parse --regex $env.matchVersion
-
-    # If no version is matched, a nil value will be returned
-    # and this value will be ignored by 'each'
-    if ($parsedVersion | length) != 0 {
-      { version: $parsedVersion.0.version }
-    }
+      | into record
   }
+  | where (($it | get -o version) | is-not-empty)
   | sort-by --natural version
 
-if ($releases | length) == 0 {
-  error make { msg: $'No version did match regex ($env.matchVersion)' }
+if ($releases | is-empty) {
+  error make { msg: $'No version does match regex ($env.matchVersion)' }
 }
 
 # Get the latest release
@@ -27,7 +19,11 @@ let latestReleaseInfo = $releases
   | last
 
 # Get the version
-mut version = $latestReleaseInfo.version
+let version = $latestReleaseInfo.version
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version

--- a/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
@@ -1,24 +1,21 @@
-# Get project metadata
-mut project = $env.project
-  | from json
-
 # Retrieve the crate information from crates.io registry
 let crateInfo = http get $'https://crates.io/api/v1/crates/($env.crateName)'
 
 # Get the version
-let version = $crateInfo
+let parsedVersion = $crateInfo
   | get crate.max_version
-
-let parsedVersion = $version
   | parse --regex $env.matchVersion
-if ($parsedVersion | length) == 0 {
-  error make { msg: $'Latest release ($version) did not match regex ($env.matchVersion)' }
+  | into record
+if (($parsedVersion | get -o version) | is-empty) {
+  error make { msg: $'Latest release does not match regex ($env.matchVersion)' }
 }
 
-let version = $parsedVersion.0.version?
-if $version == null {
-  error make { msg: $'Regex ($env.matchVersion) did not include version when matching latest release ($version)' }
-}
+# Get the version
+let version = $parsedVersion.version
+
+# Get project metadata, and update it
+mut project = $env.project
+  | from json
 
 $project = $project
   | update version $version


### PR DESCRIPTION
This PR tries to simplify a bit the Nushell scripts used for the live update, and try to be more idiomatic:

- Replace `($var | length) != 0` with `$var | is-not-empty`
- Replace `($var | length) == 0` with `$var | is-empty`
- Replace `get -o 0` with `into record`
- Streamline the filtering of versions with a `where` statement
- Use pipes when creating the record containing the version instead of using an intermediate variable 
- Reduce the scope of `mut project`