### PR TITLE
feat(datafusion_cli): add package

### DIFF
--- a/packages/datafusion_cli/brioche.lock
+++ b/packages/datafusion_cli/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/datafusion-cli/50.3.0/download": {
+      "type": "sha256",
+      "value": "6a0b9c821d14e79070f42ea3a6d6618ced04d94277f0a32301918d7a022c250f"
+    }
+  }
+}

--- a/packages/datafusion_cli/project.bri
+++ b/packages/datafusion_cli/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "datafusion_cli",
+  version: "50.3.0",
+  extra: {
+    crateName: "datafusion-cli",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function datafusionCli(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/datafusion-cli",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    datafusion-cli --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(datafusionCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `datafusion-cli ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `datafusion_cli`
- **Website / repository:** https://github.com/apache/datafusion/tree/main/datafusion-cli
- **Short description:** DataFusion CLI (datafusion-cli) is a small command line utility that runs SQL queries using the DataFusion engine.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
   brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.22s
Result: c9b3b24a95d7db9f2096b1658164edf98feda2c8e6cf1c1af250528efcdccefb
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 10.81s
Running brioche-run
{
  "name": "datafusion_cli",
  "version": "50.3.0",
  "extra": {
    "crateName": "datafusion-cli"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
