### PR TITLE
build(seaweedfs): update version check logic to remove a hack

### DIFF
--- a/packages/seaweedfs/project.bri
+++ b/packages/seaweedfs/project.bri
@@ -30,9 +30,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  // HACK: SeaweedFS 3.86 returns a version number of 3.85!
-  // https://github.com/seaweedfs/seaweedfs/issues/6717
-  const expected = project.version === "3.86" ? "3.85" : project.version;
+  const expected = project.version;
   std.assert(
     result.includes(` ${expected} `),
     `expected '${expected}', got '${result}'`,


### PR DESCRIPTION
Remove an old hack we had to check the version of the `seaweedfs` recipe. The current version of `seaweedfs` is `3.99`.