### PR TITLE
refactor: remove 'v' prefix from some Go recipes

### DIFF
--- a/packages/cosign/project.bri
+++ b/packages/cosign/project.bri
@@ -25,7 +25,7 @@ export default function cosign(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `sigs.k8s.io/release-utils/version.gitVersion=v${project.version}`,
+        `sigs.k8s.io/release-utils/version.gitVersion=${project.version}`,
         "-X",
         `sigs.k8s.io/release-utils/version.gitCommit=${gitRef.commit}`,
         "-X",
@@ -47,7 +47,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
     .toFile();
 
   const result = (await script.read()).trim();
-  const versionMatch = result.match(/^GitVersion:\s+(v[0-9\.]+)$/m);
+  const versionMatch = result.match(/^GitVersion:\s+([0-9\.]+)$/m);
   std.assert(
     versionMatch != null,
     `'cosign version' output did not match regex: ${result}`,
@@ -55,7 +55,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
   // Check that the result contains the expected version
   const version = versionMatch[1];
-  const expected = `v${project.version}`;
+  const expected = project.version;
   std.assert(version === expected, `expected '${expected}', got '${version}'`);
 
   return script;

--- a/packages/dagger/project.bri
+++ b/packages/dagger/project.bri
@@ -20,7 +20,7 @@ export default function dagger(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `github.com/dagger/dagger/engine.Version=v${project.version}`,
+        `github.com/dagger/dagger/engine.Version=${project.version}`,
         // The engine can be downloaded from `docker-image://registry.dagger.io/engine`.
         // Here, we need to enforce the correct tag for the engine.
         // Which is the same as the CLI version.
@@ -43,7 +43,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `dagger v${project.version}`;
+  const expected = `dagger ${project.version}`;
   std.assert(
     result.startsWith(expected),
     `expected '${expected}', got '${result}'`,

--- a/packages/kubent/project.bri
+++ b/packages/kubent/project.bri
@@ -17,7 +17,7 @@ export default function kubent(): std.Recipe<std.Directory> {
     source,
     path: "./cmd/kubent",
     buildParams: {
-      ldflags: ["-s", "-w", "-X", `main.version=v${project.version}`],
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
     },
     runnable: "bin/kubent",
   });
@@ -32,7 +32,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
   const result = (await script.read()).trim();
 
-  const versionMatch = result.match(/version v([^\s]+)/);
+  const versionMatch = result.match(/version ([^\s]+)/);
   const version = versionMatch?.[1] ?? "";
 
   // Check that the result contains the expected version

--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -25,7 +25,7 @@ export default function processCompose(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `github.com/f1bonacc1/process-compose/src/config.Version=v${project.version}`,
+        `github.com/f1bonacc1/process-compose/src/config.Version=${project.version}`,
         "-X",
         `github.com/f1bonacc1/process-compose/src/config.Date=${project.extra.releaseDate}`,
         "-X",
@@ -53,7 +53,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
   const result = (await script.read()).trim();
 
-  const version = result.match(/^Version:\s*v([\d.]+)$/m)?.at(1);
+  const version = result.match(/^Version:\s*([\d.]+)$/m)?.at(1);
 
   // Check that the result contains the expected version
   const expected = project.version;


### PR DESCRIPTION
This PR updates some of the Brioche Go recipes to remove the prefix `v` in version. This is mainly to uniformize the way we format version in our recipes, nothing more.