### PR TITLE
chore(process_compose): remove binary `bin/src`

### DIFF
--- a/packages/process_compose/project.bri
+++ b/packages/process_compose/project.bri
@@ -36,7 +36,10 @@ export default function processCompose(): std.Recipe<std.Directory> {
   })
     .pipe(
       // Rename main binary from `bin/src` to `bin/process-compose`
-      (recipe) => recipe.insert("bin/process-compose", recipe.get("bin/src")),
+      (recipe) =>
+        recipe
+          .insert("bin/process-compose", recipe.get("bin/src"))
+          .remove("bin/src"),
     )
     .pipe(
       // Add a link for `brioche run`


### PR DESCRIPTION
Before:

```bash
> ls -al /tmp/output/bin/
total 69136
drwxr-xr-x 2 jaudiger jaudiger     4096 Nov  5 20:45 .
drwxr-xr-x 3 jaudiger jaudiger     4096 Nov  5 20:45 ..
-rwxr-xr-x 1 jaudiger jaudiger 35389624 Nov  5 20:45 process-compose
-rwxr-xr-x 1 jaudiger jaudiger 35389624 Nov  5 20:45 src
```

After:

```bash
> ls -al /tmp/output/bin/
total 69136
drwxr-xr-x 2 jaudiger jaudiger     4096 Nov  5 20:45 .
drwxr-xr-x 3 jaudiger jaudiger     4096 Nov  5 20:45 ..
-rwxr-xr-x 1 jaudiger jaudiger 35389624 Nov  5 20:45 process-compose
```

It basically reduces by twice the size of the `process_compose` recipe's output ! From 70Mo to 35Mo.  