### PR TITLE
refactor: update where Nushell clauses to remove the closure by using parentheses for clarity

### DIFF
--- a/packages/alsa_lib/project.bri
+++ b/packages/alsa_lib/project.bri
@@ -70,7 +70,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.alsa-project.org/files/pub/lib
       | lines
-      | where {|it| ($it | str contains "alsa-lib") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "alsa-lib") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="alsa-lib-(?<version>.+)\.tar\.bz2">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/ca_certificates/project.bri
+++ b/packages/ca_certificates/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://curl.se/docs/caextract.html
       | lines
-      | where {|it| $it | str contains 'href="/ca/cacert-' }
+      | where ($it | str contains 'href="/ca/cacert-')
       | parse --regex '<a href="/ca/cacert-(?<version>.+).pem"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/freetype/project.bri
+++ b/packages/freetype/project.bri
@@ -77,14 +77,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/freetype/files/freetype2
       | lines
-      | where {|it| $it | str contains 'href="/projects/freetype/files/freetype2' }
+      | where ($it | str contains 'href="/projects/freetype/files/freetype2')
       | parse --regex '<a href="/projects/freetype/files/freetype2/(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://sourceforge.net/projects/freetype/files/freetype2/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.xz') }
+      | where ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.xz')
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/freetype/files/freetype2/($sourceUrl)/freetype-" + '(?<version>[^"]+)\.tar\.xz/')
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/gengetopt/project.bri
+++ b/packages/gengetopt/project.bri
@@ -47,7 +47,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gengetopt
       | lines
-      | where {|it| ($it | str contains "gengetopt-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "gengetopt-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="gengetopt-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/gmp/project.bri
+++ b/packages/gmp/project.bri
@@ -55,7 +55,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gmp
       | lines
-      | where {|it| ($it | str contains "gmp-") and ($it | str contains ".xz") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "gmp-") and ($it | str contains ".xz") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="gmp-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/gperf/project.bri
+++ b/packages/gperf/project.bri
@@ -47,7 +47,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/gperf
       | lines
-      | where {|it| ($it | str contains "gperf-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "gperf-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="gperf-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/isl/project.bri
+++ b/packages/isl/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://libisl.sourceforge.io
       | lines
-      | where {|it| $it | str contains "isl" }
+      | where ($it | str contains "isl")
       | parse --regex '<a href="isl-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -69,7 +69,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.kernel.org/pub/linux/utils/kernel/kmod
       | lines
-      | where {|it| ($it | str contains 'href="kmod-') and ($it | str contains '.tar.gz')}
+      | where ($it | str contains 'href="kmod-') and ($it | str contains '.tar.gz')
       | parse --regex '<a href="kmod-(?<version>.+).tar.gz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/krb5/project.bri
+++ b/packages/krb5/project.bri
@@ -61,7 +61,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://web.mit.edu/Kerberos/
       | lines
-      | where {|it| $it | str contains 'Current release: <A HREF="krb5-' }
+      | where ($it | str contains 'Current release: <A HREF="krb5-')
       | parse --regex '<A HREF="krb5-.+/">krb5-(?<version>.+)</A>'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libarchive/project.bri
+++ b/packages/libarchive/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.libarchive.de/downloads
       | lines
-      | where {|it| $it | str contains "libarchive" }
+      | where ($it | str contains "libarchive")
       | parse --regex '<a href="./libarchive-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libcap/project.bri
+++ b/packages/libcap/project.bri
@@ -66,7 +66,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://git.kernel.org/pub/scm/libs/libcap/libcap.git/refs
       | lines
-      | where {|it| ($it | str contains "/pub/scm/libs/libcap/libcap.git/tag/?h=cap") and (not ($it | str contains "-rc")) }
+      | where ($it | str contains "/pub/scm/libs/libcap/libcap.git/tag/?h=cap") and (not ($it | str contains "-rc"))
       | parse --regex '/pub/scm/libs/libcap/libcap.git/tag/\\?h=cap/v(?<version>[1-9.]+)'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libev/project.bri
+++ b/packages/libev/project.bri
@@ -66,7 +66,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://dist.schmorp.de/libev
       | lines
-      | where {|it| ($it | str contains "libev") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libev") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libev-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libice/project.bri
+++ b/packages/libice/project.bri
@@ -54,7 +54,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libICE") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libICE") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libICE-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libjpeg/project.bri
+++ b/packages/libjpeg/project.bri
@@ -59,7 +59,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.ijg.org/files
       | lines
-      | where {|it| ($it | str contains "jpegsrc.") }
+      | where ($it | str contains "jpegsrc.")
       | parse --regex '<A HREF="jpegsrc.v(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libpcap/project.bri
+++ b/packages/libpcap/project.bri
@@ -51,7 +51,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.tcpdump.org/release
       | lines
-      | where {|it| ($it | str contains "libpcap") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libpcap") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libpcap-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libpng/project.bri
+++ b/packages/libpng/project.bri
@@ -53,14 +53,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/libpng/files/libpng16
       | lines
-      | where {|it| ($it | str contains 'href="/projects/libpng/files/libpng16') and (not ($it | str contains 'older-releases')) }
+      | where ($it | str contains 'href="/projects/libpng/files/libpng16') and (not ($it | str contains 'older-releases'))
       | parse --regex '<a href="/projects/libpng/files/libpng16/(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://sourceforge.net/projects/libpng/files/libpng16/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.xz') }
+      | where ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.xz')
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/libpng/files/libpng16/($sourceUrl)/libpng-" + '(?<version>[^"]+)\.tar\.xz/')
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libsm/project.bri
+++ b/packages/libsm/project.bri
@@ -57,7 +57,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libSM") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libSM") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libSM-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libsodium/project.bri
+++ b/packages/libsodium/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://download.libsodium.org/libsodium/releases
       | lines
-      | where {|it| ($it | str contains "libsodium") and (not ($it | str contains ".sig")) and (not ($it | str contains ".minisig")) }
+      | where ($it | str contains "libsodium") and (not ($it | str contains ".sig")) and (not ($it | str contains ".minisig"))
       | parse --regex '<a href="libsodium-(?<version>[^-]+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libssh2/project.bri
+++ b/packages/libssh2/project.bri
@@ -55,7 +55,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.libssh2.org/download
       | lines
-      | where {|it| ($it | str contains "libssh2") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libssh2") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libssh2-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libtirpc/project.bri
+++ b/packages/libtirpc/project.bri
@@ -55,14 +55,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/libtirpc/files/libtirpc
       | lines
-      | where {|it| $it | str contains 'href="/projects/libtirpc/files/libtirpc/' }
+      | where ($it | str contains 'href="/projects/libtirpc/files/libtirpc/')
       | parse --regex '<a href="/projects/libtirpc/files/libtirpc/(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.bz2') }
+      | where ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.bz2')
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/libtirpc/files/libtirpc/($sourceUrl)/libtirpc-" + '(?<version>[^"]+)\.tar\.bz2/')
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libunistring/project.bri
+++ b/packages/libunistring/project.bri
@@ -68,7 +68,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/libunistring
       | lines
-      | where {|it| ($it | str contains "libunistring-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libunistring-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libunistring-(?<version>[0-9.]+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libx11/project.bri
+++ b/packages/libx11/project.bri
@@ -64,7 +64,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libX11") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libX11") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libX11-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxau/project.bri
+++ b/packages/libxau/project.bri
@@ -53,7 +53,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXau") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXau") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXau-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxaw/project.bri
+++ b/packages/libxaw/project.bri
@@ -75,7 +75,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXaw") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXaw") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXaw-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxcb/project.bri
+++ b/packages/libxcb/project.bri
@@ -70,7 +70,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libxcb") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libxcb") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libxcb-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxdmcp/project.bri
+++ b/packages/libxdmcp/project.bri
@@ -55,7 +55,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXdmcp") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXdmcp") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXdmcp-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxext/project.bri
+++ b/packages/libxext/project.bri
@@ -57,7 +57,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXext") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXext") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXext-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxfixes/project.bri
+++ b/packages/libxfixes/project.bri
@@ -57,7 +57,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXfixes") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXfixes") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXfixes-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxi/project.bri
+++ b/packages/libxi/project.bri
@@ -67,7 +67,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXi") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXi") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXi-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxinerama/project.bri
+++ b/packages/libxinerama/project.bri
@@ -58,7 +58,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXinerama") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXinerama") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXinerama-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -76,14 +76,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://download.gnome.org/sources/libxml2
       | lines
-      | where {|it| $it | str contains 'href="' }
+      | where ($it | str contains 'href="')
       | parse --regex '<a href="(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://download.gnome.org/sources/libxml2/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="libxml2') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
+      | where ($it | str contains '<a href="libxml2') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news'))
       | parse --regex '<a href="libxml2-(?<version>[^"]+)\.tar\.xz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxmu/project.bri
+++ b/packages/libxmu/project.bri
@@ -71,7 +71,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXmu") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXmu") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXmu-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxpm/project.bri
+++ b/packages/libxpm/project.bri
@@ -58,7 +58,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXpm") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXpm") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXpm-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxrandr/project.bri
+++ b/packages/libxrandr/project.bri
@@ -67,7 +67,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXrandr") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXrandr") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXrandr-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxrender/project.bri
+++ b/packages/libxrender/project.bri
@@ -57,7 +57,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXrender") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXrender") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXrender-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -64,14 +64,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://download.gnome.org/sources/libxslt
       | lines
-      | where {|it| $it | str contains 'href="' }
+      | where ($it | str contains 'href="')
       | parse --regex '<a href="(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://download.gnome.org/sources/libxslt/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="libxslt') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news')) }
+      | where ($it | str contains '<a href="libxslt') and (not ($it | str contains '.sha256sum')) and (not ($it | str contains '.news'))
       | parse --regex '<a href="libxslt-(?<version>[^"]+)\.tar\.xz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxt/project.bri
+++ b/packages/libxt/project.bri
@@ -67,7 +67,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXt") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXt") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXt-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libxtst/project.bri
+++ b/packages/libxtst/project.bri
@@ -69,7 +69,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "libXtst") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "libXtst") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="libXtst-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/libzip/project.bri
+++ b/packages/libzip/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://libzip.org/download
       | lines
-      | where {|it| $it | str contains 'href="libzip-' }
+      | where ($it | str contains 'href="libzip-')
       | parse --regex '<a href="libzip-(?<version>.+).tar.gz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -179,7 +179,7 @@ export function liveUpdate(): NushellRunnable {
 
     let version = http get $"https://cdn.kernel.org/pub/linux/kernel/v($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains 'linux') and ($it | str contains '.tar.xz') }
+      | where ($it | str contains 'linux') and ($it | str contains '.tar.xz')
       | parse --regex '<a href="linux-(?<version>[^"]+)\.tar\.xz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/lzo/project.bri
+++ b/packages/lzo/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.oberhumer.com/opensource/lzo/download
       | lines
-      | where {|it| ($it | str contains "lzo-") }
+      | where ($it | str contains "lzo-")
       | parse --regex '<a href="lzo-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/lzop/project.bri
+++ b/packages/lzop/project.bri
@@ -47,7 +47,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.lzop.org/download
       | lines
-      | where {|it| ($it | str contains "lzop-") }
+      | where ($it | str contains "lzop-")
       | parse --regex '<a href="lzop-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/moreutils/project.bri
+++ b/packages/moreutils/project.bri
@@ -56,7 +56,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://git.joeyh.name/git/moreutils.git/refs/tags
       | lines
-      | where {|it| ($it | str contains 'href="') and (not ($it | str contains 'sponge')) }
+      | where ($it | str contains 'href="') and (not ($it | str contains 'sponge'))
       | parse --regex '<a href="(?<version>[0-9.]+)"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/mpdecimal/project.bri
+++ b/packages/mpdecimal/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.bytereef.org/mpdecimal/download.html
       | lines
-      | where {|it| ($it | str contains "mpdecimal") and (not ($it | str contains "doc")) and (not ($it | str contains "testit")) }
+      | where ($it | str contains "mpdecimal") and (not ($it | str contains "doc")) and (not ($it | str contains "testit"))
       | parse --regex '<a class="reference external" href="../software/mpdecimal/releases/mpdecimal-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/mpfr/project.bri
+++ b/packages/mpfr/project.bri
@@ -54,7 +54,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/mpfr
       | lines
-      | where {|it| ($it | str contains "mpfr-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "mpfr-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="mpfr-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/ncurses/project.bri
+++ b/packages/ncurses/project.bri
@@ -65,7 +65,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/ncurses
       | lines
-      | where {|it| ($it | str contains "ncurses-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "ncurses-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="ncurses-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/nodejs/find-nodejs-bins.nu
+++ b/packages/nodejs/find-nodejs-bins.nu
@@ -11,7 +11,7 @@ ls bin/**/*
 
     { name: $bin.name, target: $target, firstLine: $firstLine }
   }
-  | where {|bin| $bin.firstLine | str contains "node"}
+  | where ($it.firstLine | str contains "node")
   | select name target
   | to json
   | save $env.BRIOCHE_OUTPUT

--- a/packages/patch/project.bri
+++ b/packages/patch/project.bri
@@ -47,7 +47,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/patch
       | lines
-      | where {|it| ($it | str contains "patch-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "patch-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="patch-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/pcre/project.bri
+++ b/packages/pcre/project.bri
@@ -67,14 +67,14 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let sourceUrl = http get https://sourceforge.net/projects/pcre/files/pcre
       | lines
-      | where {|it| $it | str contains 'href="/projects/pcre/files/pcre/' }
+      | where ($it | str contains 'href="/projects/pcre/files/pcre/')
       | parse --regex '<a href="/projects/pcre/files/pcre/(?<version>.+)/"'
       | sort-by --natural --reverse version
       | get 0.version
 
     let version = http get $"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)"
       | lines
-      | where {|it| ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.gz') and (not ($it | str contains '.sig')) }
+      | where ($it | str contains '<a href="https://sourceforge.net') and ($it | str contains '.tar.gz') and (not ($it | str contains '.sig'))
       | parse --regex ($"<a href=\\"https://sourceforge.net/projects/pcre/files/pcre/($sourceUrl)/pcre-" + '(?<version>[^"]+)\.tar\.gz/')
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/pnpm/find-pnpm-binstubs.nu
+++ b/packages/pnpm/find-pnpm-binstubs.nu
@@ -7,7 +7,7 @@ ls .bin/**/*
 
     { name: $bin.name, firstLine: $firstLine }
   }
-  | where {|bin| $bin.firstLine | str contains "bin/sh"}
+  | where ($it.firstLine | str contains "bin/sh")
   | select name
   | to json
   | save $env.BRIOCHE_OUTPUT

--- a/packages/pv/project.bri
+++ b/packages/pv/project.bri
@@ -47,7 +47,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ivarch.com/programs/pv.shtml
       | lines
-      | where {|it| ($it | str contains "/s/pv") and (not ($it | str contains "sig")) }
+      | where ($it | str contains "/s/pv") and (not ($it | str contains "sig"))
       | parse --regex '<a href="/s/pv-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/readline/project.bri
+++ b/packages/readline/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://ftp.gnu.org/gnu/readline
       | lines
-      | where {|it| ($it | str contains "readline-") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "readline-") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="readline-(?<version>[0-9]+.[0-9]+(.[0-9]+)?)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/scdoc/project.bri
+++ b/packages/scdoc/project.bri
@@ -66,7 +66,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://git.sr.ht/~sircmpwn/scdoc/refs
       | lines
-      | where {|it| $it | str contains "~sircmpwn/scdoc/refs/" }
+      | where ($it | str contains "~sircmpwn/scdoc/refs/")
       | parse --regex '<a href="/~sircmpwn/scdoc/refs/(?<version>.+)">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/slang/project.bri
+++ b/packages/slang/project.bri
@@ -81,7 +81,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.jedsoft.org/releases/slang
       | lines
-      | where {|it| ($it | str contains '<a href="slang-') and (not ($it | str contains ".asc")) }
+      | where ($it | str contains '<a href="slang-') and (not ($it | str contains ".asc"))
       | parse --regex '<a href="slang-(?<version>.+)\.tar\.bz2">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/socat/project.bri
+++ b/packages/socat/project.bri
@@ -54,7 +54,7 @@ export function liveUpdate(): std.Recipe<std.Directory> {
   return nushellRunnable`
     let version = http get http://www.dest-unreach.org/socat/
       | lines
-      | where {|it| $it | str contains 'href="download/socat-' }
+      | where ($it | str contains 'href="download/socat-')
       | parse --regex '<a href="download/socat-(?<version>(?<major>[\\d]+)\\.(?<minor>[\\d]+)(?:\\.(?<patch>[\\d]+)(?:\\.(?<extra>[\\d]+))?)?)\\.tar.gz"'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -78,7 +78,7 @@ if ($project | get extra?.otherVersions?) != null {
   let otherVersions = $project.extra.otherVersions
     | items {|key, value|
       let latestVersion = $releases
-        | where { |releaseInfo| $releaseInfo.version | str starts-with $key }
+        | where ($it.version | str starts-with $key)
         | last
         | get version
 

--- a/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
@@ -82,7 +82,7 @@ if ($project | get extra?.otherVersions?) != null {
   let otherVersions = $project.extra.otherVersions
     | items {|key, value|
       let latestVersion = $tags
-        | where { |parsedTag| $parsedTag.version | str starts-with $key }
+        | where ($it.version | str starts-with $key)
         | last
         | get version
 

--- a/packages/talloc/project.bri
+++ b/packages/talloc/project.bri
@@ -52,7 +52,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.samba.org/ftp/talloc
       | lines
-      | where {|it| ($it | str contains "talloc") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "talloc") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="talloc-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/tcpdump/project.bri
+++ b/packages/tcpdump/project.bri
@@ -48,7 +48,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.tcpdump.org/release
       | lines
-      | where {|it| ($it | str contains "tcpdump") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "tcpdump") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="tcpdump-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/tcsh/project.bri
+++ b/packages/tcsh/project.bri
@@ -48,7 +48,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://astron.com/pub/tcsh
       | lines
-      | where {|it| ($it | str contains "tcsh") and (not ($it | str contains ".asc")) }
+      | where ($it | str contains "tcsh") and (not ($it | str contains ".asc"))
       | parse --regex '<a href="tcsh-(?<version>.+)\.tar\.[^"]+">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/unixodbc/project.bri
+++ b/packages/unixodbc/project.bri
@@ -56,7 +56,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.unixodbc.org/download.html
       | lines
-      | where {|it| $it | str contains "unixODBC" }
+      | where ($it | str contains "unixODBC")
       | parse --regex '<a  HREF="unixODBC-(?<version>.+)\.tar\.gz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/util_macros/project.bri
+++ b/packages/util_macros/project.bri
@@ -50,7 +50,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/util
       | lines
-      | where {|it| ($it | str contains "util-macros") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "util-macros") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="util-macros-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/xcb_proto/project.bri
+++ b/packages/xcb_proto/project.bri
@@ -50,7 +50,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/proto
       | lines
-      | where {|it| ($it | str contains "xcb-proto") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "xcb-proto") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="xcb-proto-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/xorgproto/project.bri
+++ b/packages/xorgproto/project.bri
@@ -68,7 +68,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/proto
       | lines
-      | where {|it| ($it | str contains "xorgproto") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "xorgproto") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="xorgproto-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/xtrans/project.bri
+++ b/packages/xtrans/project.bri
@@ -53,7 +53,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://www.x.org/archive/individual/lib
       | lines
-      | where {|it| ($it | str contains "xtrans") and (not ($it | str contains ".sig")) }
+      | where ($it | str contains "xtrans") and (not ($it | str contains ".sig"))
       | parse --regex '<a href="xtrans-(?<version>.+)\.tar\.xz">'
       | sort-by --natural --reverse version
       | get 0.version

--- a/packages/zlib/project.bri
+++ b/packages/zlib/project.bri
@@ -51,7 +51,7 @@ export function liveUpdate(): NushellRunnable {
   return nushellRunnable`
     let version = http get https://zlib.net
       | lines
-      | where {|it| $it | str contains '<B> zlib ' }
+      | where ($it | str contains '<B> zlib ')
       | parse --regex '<B> zlib (?<version>[^"]+)</B>'
       | sort-by --natural --reverse version
       | get 0.version


### PR DESCRIPTION
This PR refactor all the `where` Nushell clauses to:

- Remove the closure, and add parenthesis where it's needed 
- Use `$it`

Basically this improve this readability of these clauses ans aligns with the `where` documentation where they make a differentiation between `$it` and a named variable, see https://www.nushell.sh/commands/docs/where.html