### PR TITLE
feat(std): introduce a recursive function to find the latest major version of a Go module

### DIFF
--- a/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
@@ -1,5 +1,44 @@
+# Recursive function to get the latest module name
+# In other words, it finds the latest major version of a module
+def get-latest-module-name [
+  moduleName: string # The module name to check
+]: nothing -> string {
+  let parsedModuleName = $moduleName
+    | parse --regex "^(?<name>.+?)(?:\/v(?<version>[0-9]+))?$"
+    | into record
+  if ($parsedModuleName | is-empty) {
+      return $moduleName
+  }
+
+  let majorVersion = if ($parsedModuleName.version | is-not-empty) {
+    $parsedModuleName.version
+      | into int
+  } else {
+    1
+  }
+
+  let nextLatestModuleName = $'($parsedModuleName.name)/v($majorVersion + 1)'
+
+  http get --allow-errors $'https://proxy.golang.org/($nextLatestModuleName)/@latest'
+    # Check the response status
+    | metadata access {|meta|
+      match $meta.http_response.status {
+        200 => {
+          # If the version is found, try the next one
+          get-latest-module-name $nextLatestModuleName
+        }
+        _ => {
+          # On error, return the current module name
+          $moduleName
+        }
+      }
+    }
+}
+
+let moduleName = get-latest-module-name $env.moduleName
+
 # Retrieve the most recent releases from Go proxy registry
-let releases = http get $'https://proxy.golang.org/($env.moduleName)/@v/list'
+let releases = http get $'https://proxy.golang.org/($moduleName)/@v/list'
   | lines
   # Extract the version(s)
   | each {|release|
@@ -27,6 +66,7 @@ mut project = $env.project
 
 $project = $project
   | update version $version
+  | update extra.moduleName $moduleName
 
 # Return back the project metadata encoded as JSON
 $project


### PR DESCRIPTION
With the recently introduced `std.liveUpdateFromGoModules()`, one thing wasn't handled correctly. This function works, but not for one use case: when a new major version is out.

If a Go module has X.Y.Z where `X == 0` or `X == 1`, the module name will be: `MODULE_NAME`. But if `X > 1`, the module name will be: `MODULE_NAME/vX`. It means that calling this API: `https://proxy.golang.org/($env.moduleName)/@v/list` will always list all the versions for ONE major version.

The issue is, when a new major version is released, the current check won't detect it. This PR is here to resolve this problem, by always looking for the latest major release of a Go module.

Here is the results with a dummy recipe:

```ts
import * as std from "std";

export const project = {
  name: "traefik",
  version: "2.11.30",
  extra: {
    moduleName: "github.com/traefik/traefik/v2",
  },
};

...

export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
  return std.liveUpdateFromGoModules({ project });
}
```

Before this PR:

```
Build finished, completed (no new jobs) in 7.65s
Running brioche-run
{
  "name": "traefik",
  "version": "2.11.30",
  "extra": {
    "moduleName": "github.com/traefik/traefik/v2"
  }
}
```

After this PR:

```
Build finished, completed 1 job in 8.39s
Running brioche-run
{
  "name": "traefik",
  "version": "3.5.4",
  "extra": {
    "moduleName": "github.com/traefik/traefik/v3"
  }
}
```

One step further in the right direction 🚀  
  