### PR TITLE
fix: update some parameters descriptions in TSDoc

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -282,7 +282,7 @@ function isCMakeVariableValue(
 /**
  * Creates a relative symlink from lib64 to lib folder if lib64 folder exists.
  *
- * @param recipe The recipe to create the symlink for.
+ * @param recipe - The recipe to create the symlink for.
  *
  * @returns The recipe with the symlink created.
  */

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -312,8 +312,8 @@ export function npmInstallGlobal(
 /*
  * Wraps the binaries of a nodejs package with the nodejs interpreter.
  *
- * @param recipe The recipe to wrap the binaries of.
- * @param nodejs The Node.js recipe to use.
+ * @param recipe - The recipe to wrap the binaries of.
+ * @param nodejs - The Node.js recipe to use.
  */
 async function wrapNodejsBins(
   recipe: std.RecipeLike<std.Directory>,

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -189,8 +189,8 @@ export function pnpmInstallGlobal(
  *
  * @remark pnpm installs bins using a shell script binstub.
  *
- * @param recipe The recipe to wrap binstubs for.
- * @param nodejs The Node.js recipe to use.
+ * @param recipe - The recipe to wrap binstubs for.
+ * @param nodejs - The Node.js recipe to use.
  */
 async function wrapBinstubs(
   recipe: std.RecipeLike<std.Directory>,


### PR DESCRIPTION
We have currently 255 (2^8-1, is it a hazard, I don't think so 🥲) parameters documented, and they were 5 not following the pattern: `@param NAME - DESCRIPTION`.