### PR TITLE
refactor(std): removes all the asert with Brioche version

### DIFF
--- a/packages/std/core/global.bri
+++ b/packages/std/core/global.bri
@@ -5,9 +5,6 @@ import {
   createRecipe,
 } from "./recipes";
 import { source } from "./source.bri";
-import { BRIOCHE_VERSION } from "./runtime.bri";
-import { semverMatches } from "./semver.bri";
-import { assert } from "./utils.bri";
 
 /**
  * Options for retrieving a git ref commit hash.
@@ -232,11 +229,6 @@ declare global {
   });
 };
 (globalThis as any).Brioche.download ??= (url: string): Recipe<File> => {
-  assert(
-    semverMatches(BRIOCHE_VERSION, ">=0.1.2"),
-    "Brioche.download(...) requires Brioche v0.1.2 or later",
-  );
-
   const sourceFrame = source({ depth: 1 }).at(0);
   if (sourceFrame === undefined) {
     throw new Error(`Could not find source file to download ${url}`);
@@ -260,11 +252,6 @@ declare global {
 (globalThis as any).Brioche.gitRef ??= async (
   options: GitRefOptions,
 ): Promise<GitRefResult> => {
-  assert(
-    semverMatches(BRIOCHE_VERSION, ">=0.1.2"),
-    "Brioche.gitRef(...) requires Brioche v0.1.2 or later",
-  );
-
   const sourceFrame = source({ depth: 1 }).at(0);
   if (sourceFrame === undefined) {
     throw new Error(

--- a/packages/std/core/recipes/attach_resources.bri
+++ b/packages/std/core/recipes/attach_resources.bri
@@ -1,6 +1,3 @@
-import { BRIOCHE_VERSION } from "../runtime.bri";
-import { semverMatches } from "../semver.bri";
-import { assert } from "../utils.bri";
 import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
@@ -15,8 +12,6 @@ export function attachResources(
   return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
-      assert(semverMatches(BRIOCHE_VERSION, ">=0.1.4"));
-
       const recipeValue =
         typeof recipe === "function" ? await recipe() : await recipe;
       const serializedRecipe = await recipeValue.briocheSerialize();

--- a/packages/std/core/recipes/collect_references.bri
+++ b/packages/std/core/recipes/collect_references.bri
@@ -1,6 +1,3 @@
-import { BRIOCHE_VERSION } from "../runtime.bri";
-import { semverMatches } from "../semver.bri";
-import { assert } from "../utils.bri";
 import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
@@ -16,8 +13,6 @@ export function collectReferences(
   return createRecipe(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
-      assert(semverMatches(BRIOCHE_VERSION, ">=0.1.1"));
-
       const recipeValue =
         typeof recipe === "function" ? await recipe() : await recipe;
       const serializedRecipe = await recipeValue.briocheSerialize();

--- a/packages/std/core/recipes/glob.bri
+++ b/packages/std/core/recipes/glob.bri
@@ -1,6 +1,4 @@
 import * as runtime from "../runtime.bri";
-import { assert } from "../utils.bri";
-import { semverMatches } from "../semver.bri";
 import { type Recipe, type RecipeLike, createRecipe } from "./recipe.bri";
 import type { Directory } from "./directory.bri";
 
@@ -33,11 +31,6 @@ export function glob(
   return createRecipe<Directory>(["directory"], {
     sourceDepth: 1,
     briocheSerialize: async (meta) => {
-      assert(
-        semverMatches(runtime.BRIOCHE_VERSION, ">=0.1.2"),
-        "std.glob requires Brioche v0.1.2 or later",
-      );
-
       const recipeValue =
         typeof recipe === "function" ? await recipe() : await recipe;
       const serializedRecipe = await recipeValue.briocheSerialize();

--- a/packages/std/core/runtime.bri
+++ b/packages/std/core/runtime.bri
@@ -1,11 +1,5 @@
 function getBriocheVersion(): string {
   const { op_brioche_version } = (globalThis as any).Deno.core.ops;
-
-  // TODO: Remove this check once v0.1.0 is deprecated! Brioche v0.1.0 was
-  // the only version that did not have this op
-  if (op_brioche_version === undefined) {
-    return "0.1.0";
-  }
   return op_brioche_version();
 }
 

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -44,7 +44,7 @@ export function ociContainerImage(
       ),
     );
 
-    const layerTar = tar(collectReferences(options.recipe));
+    const layerTar = tar(std.collectReferences(options.recipe));
     const { sha256Digest: layerSha256Digest } = await describeBlob(layerTar);
     const diffId = `sha256:${layerSha256Digest}`;
 
@@ -180,43 +180,6 @@ async function describeBlob(
   }
 
   return { sha256Digest, size: parseInt(size) };
-}
-
-// TODO: Remove once Brioche v0.1.0 is no longer supported
-function collectReferences(
-  recipe: std.RecipeLike<std.Directory>,
-): std.Recipe<std.Directory> {
-  if (std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.1")) {
-    return std.collectReferences(recipe);
-  }
-
-  console.warn(
-    "Using fallback to collect references from artifact, container will be much larger than it should be! Run `brioche self-update` to upgrade to the latest version of Brioche",
-  );
-  return runBash`
-    if [ -d "$BRIOCHE_RESOURCE_DIR" -a -n "$(ls -A "$BRIOCHE_RESOURCE_DIR")" ]; then
-      mkdir -p "$BRIOCHE_OUTPUT"/brioche-resources.d/
-      cp \\
-        -dr \\
-        --no-preserve=mode,ownership,timestamps \\
-        "$BRIOCHE_RESOURCE_DIR"/* "$BRIOCHE_OUTPUT"/brioche-resources.d/
-    fi
-
-    oldifs="$IFS"
-    IFS=":"
-    for resource_dir in $BRIOCHE_INPUT_RESOURCE_DIRS; do
-      if [ -d "$resource_dir" -a -n "$(ls -A "$resource_dir")" ]; then
-        mkdir -p "$BRIOCHE_OUTPUT"/brioche-resources.d/
-        cp \\
-          -dr \\
-          --no-preserve=mode,ownership,timestamps \\
-          "$resource_dir"/* "$BRIOCHE_OUTPUT"/brioche-resources.d/
-      fi
-    done
-    IFS="$oldifs"
-  `
-    .outputScaffold(recipe)
-    .toDirectory();
 }
 
 function tar(recipe: std.RecipeLike<std.Directory>): std.Recipe<std.File> {

--- a/packages/std/extra/set_env.bri
+++ b/packages/std/extra/set_env.bri
@@ -61,21 +61,11 @@ export function setEnv(
         );
       }
     } else if ("fallback" in value && "path" in value.fallback) {
-      std.assert(
-        std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.2"),
-        "fallback env vars require Brioche v0.1.2 or later",
-      );
-
       result = result.insert(
         `brioche-env.d/env/${key}`,
         std.symlink({ target: `../../${value.fallback.path}` }),
       );
     } else if ("fallback" in value && "value" in value.fallback) {
-      std.assert(
-        std.semverMatches(std.BRIOCHE_VERSION, ">=0.1.2"),
-        "fallback env vars require Brioche v0.1.2 or later",
-      );
-
       result = result.insert(
         `brioche-env.d/env/${key}`,
         std.file(value.fallback.value),


### PR DESCRIPTION
This PR tends to simplify, a bit, some of the std methods by removing the assert with old Brioche versions. They were asserts for:

- Brioche 0.1.0: 1
- Brioche 0.1.1: 2
- Brioche 0.1.2: 5
- Brioche 0.1.4: 1

[Brioche `0.1.4`](https://github.com/brioche-dev/brioche/releases/tag/v0.1.4) was released in January 2025, and [Brioche `0.1.2`](https://github.com/brioche-dev/brioche/releases/tag/v0.1.2) in September 2024.

I think (at least I hope) that most of the users now use the release of Brioche `0.1.5` or now `0.1.6`. I don't know if we have any statistics on that, I mean, a statistic that could show which version of Brioche was used when the registry was accessed (for example).

Maybe I'm too radical here, and I could re-add the assert to check until Brioche `0.1.4`, or maybe this PR is too early. What do you think @kylewlacy ?