### PR TITLE
fix(amber): add includePrerelease to liveUpdate function

### DIFF
--- a/packages/amber/project.bri
+++ b/packages/amber/project.bri
@@ -36,5 +36,8 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGithubReleases({ project });
+  return std.liveUpdateFromGithubReleases({
+    project,
+    includePrerelease: true,
+  });
 }


### PR DESCRIPTION
This PR resolves the last known failed recipe when doing a live update check as seen [here](https://github.com/brioche-dev/brioche-packages/actions/runs/19159934037).

Before:

```
Build finished, completed (no new jobs) in 7.35s
Running brioche-run
Error: nu::shell::error

  × No tag does match regex ^v?(?<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
    ╭─[/home/jaudiger.linux/.local/share/brioche/locals/1cd56e3ce99b8226e126e5631df0849f669dccec281116a9fed36fcf74cb0f47/brioche-run.d/recipe-0:37:3]
 36 │ if ($releases | is-empty) {
 37 │   error make { msg: $'No tag does match regex ($env.matchTag)' }
    ·   ─────┬────
    ·        ╰── originates from here
 38 │ }
    ╰────
```

After:

```
Build finished, completed (no new jobs) in 8.10s
Running brioche-run
{
  "name": "amber",
  "version": "0.4.0-alpha",
  "repository": "https://github.com/amber-lang/amber.git"
}
```

After that, we should be fine for the next round of live update checking