### PR TITLE
ci: improve live update workflow when a branch already exists

### DIFF
--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -57,24 +57,24 @@ jobs:
             if grep -q 'export.*liveUpdate' "$package/project.bri"; then
               echo "::group::$label"
 
-              if git fetch --depth=1 origin "$branch_name"; then
-                git checkout -f "origin/${branch_name}"
-                git clean -ffdx
+              if git fetch --depth=1 origin "$branch_name" 2>/dev/null; then
+                git checkout -f "origin/${branch_name}" 2>/dev/null
+                git clean -ffdx 2>/dev/null
 
-                git fetch --depth=1 origin main
+                git fetch --depth=1 origin main 2>/dev/null
                 if ! git merge origin/main --no-edit 2>&1 | grep -v "^Already up to date"; then
                   echo "🔴 Failed to merge main into $branch_name"
                   echo "::error file=$package/project.bri::Failed to merge main into $branch_name"
                   failed_packages+=("$package")
-                  git merge --abort
+                  git merge --abort 2>/dev/null
 
                   echo "::endgroup::"
                   continue
                 fi
               else
                 echo "No existing branch for package $package"
-                git checkout -f "${git_head}"
-                git clean -ffdx
+                git checkout -f "${git_head}" 2>/dev/null
+                git clean -ffdx 2>/dev/null
               fi
 
               if ! brioche live-update -p "$package" --locked; then
@@ -87,9 +87,9 @@ jobs:
               fi
 
               if [ -n "$(git status --porcelain)" ]; then
-                git checkout -b "$branch_name"
-                git add "$package"
-                git commit -m "[live-update] $package"
+                git checkout -b "$branch_name" 2>/dev/null
+                git add "$package" 2>/dev/null
+                git commit -m "[live-update] $package" 2>/dev/null
                 echo "🟢 Updated $package"
               else
                 echo "⚪ No updates for $package"


### PR DESCRIPTION
As discussed on Discord, this PR tries to improve live update workflow when a branch already exists by merging main into it.

I also merged the commands `git restore` and `git checkout` by using the flag `--force` from `git checkout`:

```
       -f, --force
           When switching branches, proceed even if the index or the working tree differs from HEAD, and even if there are untracked files in the way. This is used to throw away local changes and any untracked files or
           directories that are in the way.

           When checking out paths from the index, do not fail upon unmerged entries; instead, unmerged entries are ignored.
```

There is one difference from what I proposed on Discord, no comment is pushed if a PR is already opened, it was adding too much code for something that is maybe not worth it, right now. So, as for now, only a log is produced to inform a error was encountered. 