### PR TITLE
Add `dumbpipe` package

### DIFF
--- a/packages/dumbpipe/brioche.lock
+++ b/packages/dumbpipe/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/n0-computer/dumbpipe.git": {
+      "v0.33.0": "4002f3ee3ca06634b42a7fc2e840b2f0e33b2c77"
+    }
+  }
+}

--- a/packages/dumbpipe/project.bri
+++ b/packages/dumbpipe/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "dumbpipe",
+  version: "0.33.0",
+  repository: "https://github.com/n0-computer/dumbpipe.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function dumbpipe(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/dumbpipe",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    dumbpipe --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dumbpipe)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `dumbpipe`
- **Website / repository:** https://www.dumbpipe.dev/
- **Short description:** Unix pipes between devices

## Related issue(s) or discussion(s)

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
brioche build -p packages/dumbpipe -e test
```

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.20s
Result: 6e8f5c5b57673ff307bad136d8dce1d5fa6f241fca1c1bb3d1d62574d7cd4ab5
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p packages/dumbpipe
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.95s
Running brioche-run
{
  "name": "dumbpipe",
  "version": "0.33.0",
  "repository": "https://github.com/n0-computer/dumbpipe.git"
}
```

</p>
</details>

## Implementation notes / special instructions

Similar to some other packages we've run into, there's no `--version` command. So I just used `--help` to validate that the binary can still be called.
