### PR TITLE
chore(rust): resolve typos in `vendorCrate`

### DIFF
--- a/packages/rust/project.bri
+++ b/packages/rust/project.bri
@@ -500,7 +500,7 @@ export function vendorCrate(
     unsafeGenerateLockfile = false,
   } = options;
 
-  // Generate the Cargo.lock file exists if not already generated
+  // Generate the Cargo.lock file if it is not already created
   const completeSource = createLockfile({
     source,
     currentDir,


### PR DESCRIPTION
This PR rewrites a sentence in `vendorCrate` that was not correct. Plus, I removed a double usage of `generate` in a same sentence