### PR TITLE
Add libimagequant package

### DIFF
--- a/packages/libimagequant/brioche.lock
+++ b/packages/libimagequant/brioche.lock
@@ -1,9 +1,8 @@
 {
   "dependencies": {},
-  "downloads": {
-    "https://crates.io/api/v1/crates/imagequant-sys/4.1.0/download": {
-      "type": "sha256",
-      "value": "b5361d7aab1d0c5623172cd6d18920bf21ef56f6e21d7290f1e31e0794c4a76e"
+  "git_refs": {
+    "https://github.com/ImageOptim/libimagequant.git": {
+      "4.4.1": "24e2956a37cd7ad1f4b81c0e20318e3239eb71dc"
     }
   }
 }

--- a/packages/libimagequant/project.bri
+++ b/packages/libimagequant/project.bri
@@ -3,22 +3,25 @@ import { cargoCBuild } from "cargo_c";
 
 export const project = {
   name: "libimagequant",
-  version: "4.1.0",
-  extra: {
-    crateName: "imagequant-sys",
-  },
+  version: "4.4.1",
+  repository: "https://github.com/ImageOptim/libimagequant.git",
 };
 
-const source = Brioche.download(
-  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
-)
-  .unarchive("tar", "gzip")
-  .peel();
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
 
 export default function libimagequant(): std.Recipe<std.Directory> {
   return cargoCBuild({
     source,
+    currentDir: "imagequant-sys",
     dependencies: [std.toolchain],
+    unsafeGenerateLockfile: true,
+
+    // cargo-chef doesn't handled well a project with the structure of two
+    // Cargo.toml, one for the Rust crate and one for the C library.
+    cargoChefPrepare: false,
   }).pipe((recipe) =>
     std.setEnv(recipe, {
       CPATH: { append: [{ path: "include" }] },
@@ -38,12 +41,14 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = project.version;
+  // HACK: the C built library doesn't seem to report its version correctly.
+  // See https://github.com/ImageOptim/libimagequant/issues/126
+  const expected = project.version === "4.4.1" ? "4.1.0" : project.version;
   std.assert(result === expected, `expected '${expected}', got '${result}'`);
 
   return script;
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromRustCrates({ project });
+  return std.liveUpdateFromGithubTags({ project });
 }


### PR DESCRIPTION
# Add a new Brioche recipe

Based on #1749 

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libimagequant`
- **Website / repository:** https://pngquant.org/lib/
- **Short description:** Convert 24/32-bit images to 8-bit palette with alpha channel. C API/FFI libimagequant that powers pngquant lossy PNG compressor.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
51556  │ 4.1.0
 0.05s ✓ Process 51556
Build finished, completed 1 job in 8.02s
Result: 03528a775a15e6a9a3d1f84a29052733505bcb268defadcc0aa7c4aacafc1c0f
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 12.12s
Running brioche-run
{
  "name": "libimagequant",
  "version": "4.1.0",
  "extra": {
    "crateName": "imagequant-sys"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
