### PR TITLE
feat(helm_docs): add package

### DIFF
--- a/packages/helm_docs/brioche.lock
+++ b/packages/helm_docs/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/norwoodj/helm-docs/@v/v1.14.2.zip": {
+      "type": "sha256",
+      "value": "1a79bc10ff6163c79445ca2f327b0837eb56b21689e061e0263a264d4757ab56"
+    }
+  }
+}

--- a/packages/helm_docs/project.bri
+++ b/packages/helm_docs/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "helm_docs",
+  version: "1.14.2",
+  extra: {
+    moduleName: "github.com/norwoodj/helm-docs",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function helmDocs(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    path: "./cmd/helm-docs",
+    runnable: "bin/helm-docs",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    helm-docs --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(helmDocs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `helm-docs version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export async function liveUpdate(): Promise<std.Recipe<std.Directory>> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `helm_docs`
- **Website / repository:** https://github.com/norwoodj/helm-docs
- **Short description:** A tool for automatically generating markdown documentation for helm charts

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

**When applicable, the commands below must succeed and their output must be pasted into this PR.**

1. Run the **test** scenario:

```bash
brioche build -e test -p RECIPE_PATH
```

<details><summary>Test output (click to expand)</summary>
<p>

```
57467  │ helm-docs version 1.14.2
 0.01s ✓ Process 57467
 6.41s ✓ Process 55359
17.08s ✓ Process 55276
 0.32s ✓ Download  100% 239.8 KiB / 239.8 KiB  https://proxy.golang.org/github.com/norwoodj/helm-docs/@v/v1.14.2.zip
Build finished, completed 5 jobs in 1m35s
Result: 15b7674d7117ca19678e69b45b88f6a47cb5fbbc9a6941c045682cd083ba4663
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run -e liveUpdate -p RECIPE_PATH
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 7.65s
Running brioche-run
{
  "name": "helm_docs",
  "version": "1.14.2",
  "extra": {
    "moduleName": "github.com/norwoodj/helm-docs"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

- If this introduces breaking changes, list them and any required follow-ups.
