### PR TITLE
feat(abseil_cpp): add package

### DIFF
--- a/packages/abseil_cpp/brioche.lock
+++ b/packages/abseil_cpp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/abseil/abseil-cpp.git": {
+      "20260107.1": "255c84dadd029fd8ad25c5efb5933e47beaa00c7"
+    }
+  }
+}

--- a/packages/abseil_cpp/brioche.lock
+++ b/packages/abseil_cpp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/abseil/abseil-cpp.git": {
+      "20260526.0": "5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a"
+    }
+  }
+}

--- a/packages/abseil_cpp/project.bri
+++ b/packages/abseil_cpp/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "abseil_cpp",
+  version: "20260107.1",
+  repository: "https://github.com/abseil/abseil-cpp.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function abseilCpp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TESTING: "OFF",
+      ABSL_BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion absl_any | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, abseilCpp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/abseil_cpp/project.bri
+++ b/packages/abseil_cpp/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "abseil_cpp",
+  version: "20260526.0",
+  repository: "https://github.com/abseil/abseil-cpp.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function abseilCpp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TESTING: "OFF",
+      ABSL_BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion absl_any | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, abseilCpp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version.split(".").at(0);
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `abseil_cpp`
- **Website / repository:** `https://github.com/abseil/abseil-cpp`
- **Repology URL:** `https://repology.org/project/abseil-cpp/versions`
- **Short description:** `Abseil Common Libraries (C++) - an open-source collection of C++ code designed to augment the C++ standard library`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Fetching artifact from cache
Fetched 6 B for artifact from cache in 0.01s
Build finished, completed 1 job in 2.02s
Result: a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1234567
Process 1234567 ran in 0.02s
Build finished, completed 1 job in 7.31s
Running brioche-run
{
  "name": "abseil_cpp",
  "version": "20250814.1",
  "repository": "https://github.com/abseil/abseil-cpp.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.