### PR TITLE
feat(libebur128): add package

### DIFF
--- a/packages/libebur128/brioche.lock
+++ b/packages/libebur128/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/jiixyj/libebur128.git": {
+      "v1.2.6": "67b33abe1558160ed76ada1322329b0e9e058b02"
+    }
+  }
+}

--- a/packages/libebur128/project.bri
+++ b/packages/libebur128/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libebur128",
+  version: "1.2.6",
+  repository: "https://github.com/jiixyj/libebur128.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libebur128(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      ENABLE_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libebur128 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libebur128)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libebur128`
- **Website / repository:** `https://github.com/jiixyj/libebur128`
- **Repology URL:** `https://repology.org/project/libebur128/versions`
- **Short description:** `A library implementing the EBU R 128 loudness standard for loudness normalisation`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 235594
[235594] 1.2.6
Process 235594 ran in 0.03s
Build finished, completed 1 job in 3.20s
Result: ed23977807711a5b8a29a2e5cf6350b0573444f56cb4902483e6fd692c189fba
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.03s
Running brioche-run
{
  "name": "libebur128",
  "version": "1.2.6",
  "repository": "https://github.com/jiixyj/libebur128.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.