### PR TITLE
feat(nbytes): add package

### DIFF
--- a/packages/nbytes/brioche.lock
+++ b/packages/nbytes/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nodejs/nbytes.git": {
+      "v0.1.4": "3e858fde1f941bf38dd0a6512e54fb13d88f344f"
+    }
+  }
+}

--- a/packages/nbytes/project.bri
+++ b/packages/nbytes/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "",
+  version: "0.1.4",
+  repository: "https://github.com/nodejs/nbytes.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function nbytes(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      NBYTES_ENABLE_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion nbytes | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, nbytes)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `nbytes`
- **Website / repository:** `https://github.com/nodejs/nbytes`
- **Repology URL:** `https://repology.org/project/nbytes/versions`
- **Short description:** `A library of byte handling functions extracted from Node.js core`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 235813
[235813] 0.1.4
Process 235813 ran in 0.02s
Build finished, completed 1 job in 2.84s
Result: 25d7662b34912d45353cb8d2c78b4dac23ef9098aa630d648d7278b83f4e414d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 235903
Process 235903 ran in 0.02s
Build finished, completed 1 job in 3.60s
Running brioche-run
{
  "name": "",
  "version": "0.1.4",
  "repository": "https://github.com/nodejs/nbytes.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.