### PR TITLE
feat(netbird): add package

### DIFF
--- a/packages/netbird/brioche.lock
+++ b/packages/netbird/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/netbirdio/netbird/@v/v0.68.1.zip": {
+      "type": "sha256",
+      "value": "1cdd8d90dbfa3e24ee17a08beff51e6074cbb9ecf15b90218774dedee5043e1f"
+    }
+  }
+}

--- a/packages/netbird/project.bri
+++ b/packages/netbird/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "netbird",
+  version: "0.68.1",
+  extra: {
+    moduleName: "github.com/netbirdio/netbird",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function netbird(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/version.version=${project.version}`,
+      ],
+    },
+    path: "./client",
+  })
+    .pipe(
+      // Rename binary file
+      (recipe) =>
+        recipe
+          .insert("bin/netbird", recipe.get("bin/client"))
+          .remove("bin/client"),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/netbird"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    netbird version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(netbird)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `netbird`
- **Website / repository:** `https://github.com/netbirdio/netbird`
- **Repology URL:** `https://repology.org/project/netbird/versions`
- **Short description:** `Open-source zero trust networking platform built on WireGuard for creating secure private networks`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.85s
Result: 827c522351d0a6c6c8e4fa3a73c0823e10521f5f8ab752cf3193c11fae16c794
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 236103
Process 236103 ran in 0.01s
Build finished, completed 1 job in 5.12s
Running brioche-run
{
  "name": "netbird",
  "version": "0.68.1",
  "extra": {
    "moduleName": "github.com/netbirdio/netbird"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.