### PR TITLE
feat(xkeyboard_config): add package

### DIFF
--- a/packages/xkeyboard_config/brioche.lock
+++ b/packages/xkeyboard_config/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-2.47.tar.xz": {
+      "type": "sha256",
+      "value": "e59984416a72d58b46a52bfec1b1361aa7d84354628227ee2783626c7a6db6b6"
+    }
+  }
+}

--- a/packages/xkeyboard_config/project.bri
+++ b/packages/xkeyboard_config/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import python from "python";
+
+export const project = {
+  name: "xkeyboard_config",
+  version: "2.47",
+  repository:
+    "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config",
+};
+
+const source = Brioche.download(
+  `https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function xkeyboardConfig(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, python],
+    set: {
+      nls: "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xkeyboard-config | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, xkeyboardConfig)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabTags({
+    gitlabUrl: "https://gitlab.freedesktop.org",
+    project,
+    matchTag: /^xkeyboard-config-(?<version>\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `xkeyboard_config`
- **Website / repository:** `https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config`
- **Repology URL:** `https://repology.org/project/xkeyboard-config/versions`
- **Short description:** `X keyboard configuration database providing keyboard model, layout, variant, and option descriptions for the X Window System.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.25s
Result: 5024c3e1afdbf912e6e464428ccf4f1aa109565feba34a4201e217468bd571e6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.25s
Running brioche-run
{
  "name": "xkeyboard_config",
  "version": "2.47",
  "repository": "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
}
```

</p>
</details>

## Implementation notes / special instructions

None.