### PR TITLE
feat(pipewire): add package

### DIFF
--- a/packages/fftw/project.bri
+++ b/packages/fftw/project.bri
@@ -14,19 +14,11 @@ const source = Brioche.download(
   .peel();
 
 export default function fftw(): std.Recipe<std.Directory> {
-  return std.runBash`
-    ./configure \\
-      --prefix=/ \\
-      --enable-shared \\
-      --enable-static \\
-      --enable-threads \\
-      --enable-openmp
-    make -j "$(nproc)"
-    make install DESTDIR="$BRIOCHE_OUTPUT"
-  `
-    .workDir(source)
-    .dependencies(std.toolchain)
-    .toDirectory()
+  const doublePrecision = buildWithFlags("");
+  const singlePrecision = buildWithFlags("--enable-float");
+
+  return std
+    .merge(doublePrecision, singlePrecision)
     .pipe(std.libtoolSanitizeDependencies)
     .pipe(std.pkgConfigMakePathsRelative)
     .pipe(cmakeSanitizePaths)
@@ -38,6 +30,30 @@ export default function fftw(): std.Recipe<std.Directory> {
         CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
       }),
     );
+}
+
+/**
+ * Build FFTW with the given extra configure flags.
+ *
+ * @param extraFlags - Extra configure flags to append.
+ *
+ * @returns A recipe containing the built FFTW libraries.
+ */
+function buildWithFlags(extraFlags: string): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-shared \
+      --enable-static \
+      --enable-threads \
+      --enable-openmp \
+      ${extraFlags}
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory();
 }
 
 export async function test(): Promise<std.Recipe<std.File>> {

--- a/packages/libdrm/project.bri
+++ b/packages/libdrm/project.bri
@@ -28,7 +28,7 @@ export default function libdrm(): std.Recipe<std.Directory> {
     },
   }).pipe((recipe) =>
     std.setEnv(recipe, {
-      CPATH: { append: [{ path: "include" }] },
+      CPATH: { append: [{ path: "include" }, { path: "include/libdrm" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
     }),

--- a/packages/pipewire/brioche.lock
+++ b/packages/pipewire/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.2/pipewire-1.6.2.tar.bz2": {
+      "type": "sha256",
+      "value": "3649ff3502c93036088b61154aa12dc375c95031db18efb2c4abab691d2e758e"
+    }
+  }
+}

--- a/packages/pipewire/project.bri
+++ b/packages/pipewire/project.bri
@@ -1,0 +1,100 @@
+import * as std from "std";
+import alsaLib from "alsa_lib";
+import cmake from "cmake";
+import dbus from "dbus";
+import fftw from "fftw";
+import flac from "flac";
+import glib from "glib";
+import lame from "lame";
+import libdrm from "libdrm";
+import libebur128 from "libebur128";
+import libogg from "libogg";
+import libsndfile from "libsndfile";
+import libudevZero from "libudev_zero";
+import libvorbis from "libvorbis";
+import { mesonBuild } from "meson";
+import mpg123 from "mpg123";
+import ninja from "ninja";
+import openssl from "openssl";
+import opus from "opus";
+import pcre2 from "pcre2";
+import python from "python";
+
+export const project = {
+  name: "pipewire",
+  version: "1.6.2",
+  repository: "https://gitlab.freedesktop.org/pipewire/pipewire",
+};
+
+const source = Brioche.download(
+  `${project.repository}/-/archive/${project.version}/pipewire-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function pipewire(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      cmake,
+      ninja,
+      python,
+      alsaLib,
+      dbus,
+      fftw,
+      flac,
+      glib,
+      lame,
+      libdrm,
+      libebur128,
+      libogg,
+      libsndfile,
+      libudevZero,
+      libvorbis,
+      mpg123,
+      openssl,
+      opus,
+      pcre2,
+    ],
+    set: {
+      default_library: "both",
+      tests: "disabled",
+      examples: "disabled",
+      "session-managers": "[]",
+      "pipewire-jack": "disabled",
+      "pipewire-v4l2": "disabled",
+      flatpak: "disabled",
+      "rlimits-install": "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libpipewire-0.3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, pipewire)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({
+    gitlabUrl: "https://gitlab.freedesktop.org",
+    project,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pipewire`
- **Website / repository:** `https://gitlab.freedesktop.org/pipewire/pipewire`
- **Repology URL:** `https://repology.org/project/pipewire/versions`
- **Short description:** `PipeWire is a multimedia framework for audio/video routing and processing on Linux`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.28s
Result: 37e99344f254977fe2cdce986eccf6d952e883123c31d60e259b7cf11964da38
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.94s
Running brioche-run
{
  "name": "pipewire",
  "version": "1.6.3",
  "repository": "https://gitlab.freedesktop.org/pipewire/pipewire"
}
```

</p>
</details>

## Implementation notes / special instructions

Dependencies include transitive pkg-config deps (flac, libogg, libvorbis, mpg123, lame, pcre2) needed for Meson to resolve `Requires.private` entries in sndfile.pc and glib-2.0.pc.