### PR TITLE
feat(libxkbcommon): add package

### DIFF
--- a/packages/libxkbcommon/brioche.lock
+++ b/packages/libxkbcommon/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/xkbcommon/libxkbcommon": {
+      "xkbcommon-1.13.1": "6f76d19db72b5d450e927b41e1e96cbe3252aba8"
+    }
+  }
+}

--- a/packages/libxkbcommon/project.bri
+++ b/packages/libxkbcommon/project.bri
@@ -1,0 +1,75 @@
+import * as std from "std";
+import icu from "icu";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxml2 from "libxml2";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import wayland from "wayland";
+import waylandProtocols from "wayland_protocols";
+import xkeyboardConfig from "xkeyboard_config";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libxkbcommon",
+  version: "1.13.1",
+  repository: "https://github.com/xkbcommon/libxkbcommon",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `xkbcommon-${project.version}`,
+});
+
+export default function libxkbcommon(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      ninja,
+      icu,
+      libxau,
+      libxcb,
+      libxml2,
+      wayland,
+      waylandProtocols,
+      xkeyboardConfig,
+      xorgproto,
+    ],
+    set: {
+      "enable-docs": "false",
+      "enable-tools": "false",
+      "enable-bash-completion": "false",
+      default_library: "both",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion xkbcommon | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxkbcommon)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^xkbcommon-(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libxkbcommon`
- **Website / repository:** `https://github.com/xkbcommon/libxkbcommon`
- **Repology URL:** `https://repology.org/project/libxkbcommon/versions`
- **Short description:** `Library for handling keyboard descriptions (XKB) including keymap parsing, key event handling, and compose sequences`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.69s
Result: 8a49b81ab54e86be2804531e96c7777c57683121899d37a1393d039292d5a7c9
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "libxkbcommon",
  "version": "1.13.1",
  "repository": "https://github.com/xkbcommon/libxkbcommon"
}
```

</p>
</details>

## Implementation notes / special instructions

None.