### PR TITLE
feat(sdl2): add package

### DIFF
--- a/packages/sdl2/brioche.lock
+++ b/packages/sdl2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL/releases/download/release-2.32.10/SDL2-2.32.10.tar.gz": {
+      "type": "sha256",
+      "value": "5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165"
+    }
+  }
+}

--- a/packages/sdl2/project.bri
+++ b/packages/sdl2/project.bri
@@ -1,0 +1,69 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libdrm from "libdrm";
+import libudevZero from "libudev_zero";
+import libxkbcommon from "libxkbcommon";
+import mesa from "mesa";
+import pipewire from "pipewire";
+import wayland from "wayland";
+
+export const project = {
+  name: "sdl2",
+  version: "2.32.10",
+  repository: "https://github.com/libsdl-org/SDL",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL2-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      libdrm,
+      libudevZero,
+      libxkbcommon,
+      mesa,
+      pipewire,
+      wayland,
+    ],
+    set: {
+      SDL_TEST: "OFF",
+      SDL2_DISABLE_SDL2MAIN: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>2\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2`
- **Website / repository:** `https://github.com/libsdl-org/SDL`
- **Repology URL:** `https://repology.org/project/sdl2/versions`
- **Short description:** `Simple DirectMedia Layer, a cross-platform library for low-level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL/Vulkan`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 33.87s
Result: 6828d5a11324fcf77364e87ffef5354d13607aaca7668a3e7134f2534de28e6e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.92s
Running brioche-run
{
  "name": "sdl2",
  "version": "2.32.10",
  "repository": "https://github.com/libsdl-org/SDL"
}
```

</p>
</details>

## Implementation notes / special instructions

Uses `matchTag` regex to restrict live updates to SDL2 (2.x) releases only, since the same repository also hosts SDL3 releases.