### PR TITLE
feat(cargo_readme): add package

### DIFF
--- a/packages/cargo_readme/brioche.lock
+++ b/packages/cargo_readme/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-readme/3.3.2/download": {
+      "type": "sha256",
+      "value": "755f2bb7858a521023b39b9decd6b1e5b30e384f3b97517819f6f41df4a49c1e"
+    }
+  }
+}

--- a/packages/cargo_readme/project.bri
+++ b/packages/cargo_readme/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_readme",
+  version: "3.3.2",
+  extra: {
+    crateName: "cargo-readme",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoReadme(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-readme",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo readme --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoReadme)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-readme-readme ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_readme`
- **Website / repository:** `https://github.com/webern/cargo-readme`
- **Repology URL:** `https://repology.org/project/cargo-readme/versions`
- **Short description:** `A cargo subcommand to generate README.md content from doc comments`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 252545
[252545] cargo-readme 3.3.2
Process 252545 ran in 0.07s
Build finished, completed 1 job in 4.30s
Result: 6c16eeb433c4213079499c7d94be36e7250ab7f550fbc28e65217779bed89949
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "cargo_readme",
  "version": "3.3.2",
  "extra": {
    "crateName": "cargo-readme"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.