### PR TITLE
feat(cargo_update): add package

### DIFF
--- a/packages/cargo_update/brioche.lock
+++ b/packages/cargo_update/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-update/20.0.0/download": {
+      "type": "sha256",
+      "value": "58431a90224d89e09f91835c9d0082e1128b40f0bf97b8636ab3cc61023d8185"
+    }
+  }
+}

--- a/packages/cargo_update/project.bri
+++ b/packages/cargo_update/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+import curl from "curl";
+import libgit2 from "libgit2";
+import libssh2 from "libssh2";
+import openssl from "openssl";
+
+export const project = {
+  name: "cargo_update",
+  version: "20.0.0",
+  extra: {
+    crateName: "cargo-update",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoUpdate(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [openssl, libgit2, libssh2, curl],
+    runnable: "bin/cargo-install-update",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo install-update --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoUpdate)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-install-update ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_update`
- **Website / repository:** `https://github.com/nabijaczleweli/cargo-update`
- **Repology URL:** `https://repology.org/project/cargo-update/versions`
- **Short description:** `A cargo subcommand for checking and applying updates to installed executables`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.64s
Result: 6a9825de722482f8327b4dad53ad45da1827900f00d3c3e0c93c41cf9ec7b531
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.00s
Running brioche-run
{
  "name": "cargo_update",
  "version": "20.0.0",
  "extra": {
    "crateName": "cargo-update"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.