### PR TITLE
feat(caligula): add package

### DIFF
--- a/packages/caligula/brioche.lock
+++ b/packages/caligula/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/ifd3f/caligula.git": {
+      "v0.4.10": "2ea18aeea2e5f40a010021b041a79e30d46a0409"
+    }
+  }
+}

--- a/packages/caligula/project.bri
+++ b/packages/caligula/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "caligula",
+  version: "0.4.10",
+  repository: "https://github.com/ifd3f/caligula.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function caligula(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/caligula",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    caligula --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(caligula)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `caligula ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `caligula`
- **Website / repository:** `https://github.com/ifd3f/caligula`
- **Repology URL:** `https://repology.org/project/caligula/versions`
- **Short description:** `A lightweight, user-friendly disk imaging tool`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 266619
[266619] caligula 0.4.10
Process 266619 ran in 0.03s
Build finished, completed 1 job in 2.10s
Result: 70bd72f93375637723bd7a7fc25b42e742e63dade6ab5f567b12e3bcd3b4d96d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 266893
Process 266893 ran in 0.02s
Build finished, completed 1 job in 4.63s
Running brioche-run
{
  "name": "caligula",
  "version": "0.4.10",
  "repository": "https://github.com/ifd3f/caligula.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.