### PR TITLE
feat(libfuse): add package

### DIFF
--- a/packages/libfuse/brioche.lock
+++ b/packages/libfuse/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libfuse/libfuse/releases/download/fuse-3.18.2/fuse-3.18.2.tar.gz": {
+      "type": "sha256",
+      "value": "f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298"
+    }
+  }
+}

--- a/packages/libfuse/project.bri
+++ b/packages/libfuse/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import liburing from "liburing";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import numactl from "numactl";
+
+export const project = {
+  name: "libfuse",
+  version: "3.18.2",
+  repository: "https://github.com/libfuse/libfuse",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/fuse-${project.version}/fuse-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libfuse(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, liburing, numactl],
+    set: {
+      default_library: "both",
+      tests: "false",
+      examples: "false",
+      utils: "false",
+      useroot: "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion fuse3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libfuse)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^fuse-(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libfuse`
- **Website / repository:** `https://github.com/libfuse/libfuse`
- **Repology URL:** `https://repology.org/project/libfuse/versions`
- **Short description:** `Reference implementation of the Linux FUSE (Filesystem in Userspace) interface`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 269907
[269907] 3.18.2
Process 269907 ran in 0.01s
Build finished, completed 1 job in 1.60s
Result: 69cd951559ebdd697852d20d4ca93c539cf44ea66780f5ae311d91a91a67e1d9
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.27s
Running brioche-run
{
  "name": "libfuse",
  "version": "3.18.2",
  "repository": "https://github.com/libfuse/libfuse"
}
```

</p>
</details>

## Implementation notes / special instructions

None.