### PR TITLE
feat(sdl2_sound): add package

### DIFF
--- a/packages/sdl2_sound/brioche.lock
+++ b/packages/sdl2_sound/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/icculus/SDL_sound/releases/download/v2.0.4/SDL2_sound-2.0.4.tar.gz": {
+      "type": "sha256",
+      "value": "f73f6720dba2e677c0bf70d0c76ca3c96d865d04025e49a8b161711685961931"
+    }
+  }
+}

--- a/packages/sdl2_sound/project.bri
+++ b/packages/sdl2_sound/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import sdl2 from "sdl2";
+
+export const project = {
+  name: "sdl2_sound",
+  version: "2.0.4",
+  repository: "https://github.com/icculus/SDL_sound",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/SDL2_sound-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2Sound(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, sdl2],
+    set: {
+      SDLSOUND_BUILD_TEST: "OFF",
+      SDLSOUND_BUILD_SHARED: "ON",
+      SDLSOUND_BUILD_STATIC: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SDL2_sound | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2Sound)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2_sound`
- **Website / repository:** `https://github.com/icculus/SDL_sound`
- **Repology URL:** `https://repology.org/project/sdl2_sound/versions`
- **Short description:** `A library that handles the decoding of several popular sound file formats (WAV, MP3, FLAC, OGG Vorbis, AIFF, and more) for use with SDL2.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 39.69s
Result: e9c4dd4dfa4724e3dac8aab16a8964fb6125dfb61d9e3ce36947dd689858d19d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "sdl2_sound",
  "version": "2.0.4",
  "repository": "https://github.com/icculus/SDL_sound"
}
```

</p>
</details>

## Implementation notes / special instructions

None.