### PR TITLE
feat(sdl12_compat): add package

### DIFF
--- a/packages/sdl12_compat/brioche.lock
+++ b/packages/sdl12_compat/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/sdl12-compat/releases/download/release-1.2.76/sdl12-compat-1.2.76.tar.gz": {
+      "type": "sha256",
+      "value": "a68477009c24bc6e876326b1e8dd0bedec2b0c37acbddbddf90acba48fba4b38"
+    }
+  }
+}

--- a/packages/sdl12_compat/project.bri
+++ b/packages/sdl12_compat/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import sdl2 from "sdl2";
+
+export const project = {
+  name: "sdl12_compat",
+  version: "1.2.76",
+  repository: "https://github.com/libsdl-org/sdl12-compat",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/sdl12-compat-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl12Compat(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, sdl2],
+    set: {
+      SDL12TESTS: "OFF",
+    },
+    runnable: "bin/sdl-config",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl12_compat | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl12Compat)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl12_compat`
- **Website / repository:** `https://github.com/libsdl-org/sdl12-compat`
- **Repology URL:** `https://repology.org/project/sdl12-compat/versions`
- **Short description:** `An SDL 1.2 compatibility layer that uses SDL 2.0 behind the scenes`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 316858
[316858] 1.2.76
Process 316858 ran in 0.06s
Build finished, completed 1 job in 34.27s
Result: df658402c53a7be2fc28fac6467f58e8a5577e80674422e057f12e2c99ab1352
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.40s
Running brioche-run
{
  "name": "sdl12_compat",
  "version": "1.2.76",
  "repository": "https://github.com/libsdl-org/sdl12-compat"
}
```

</p>
</details>

## Implementation notes / special instructions

None.