### PR TITLE
feat(clzip): add package

### DIFF
--- a/packages/clzip/brioche.lock
+++ b/packages/clzip/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.savannah.nongnu.org/releases/lzip/clzip/clzip-1.16.tar.gz": {
+      "type": "sha256",
+      "value": "f339a3a5dfc2220532dc36f937a7a58e3a3278b174f2815cc5615107e55966e4"
+    }
+  }
+}

--- a/packages/clzip/project.bri
+++ b/packages/clzip/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "clzip",
+  version: "1.16",
+};
+
+const source = Brioche.download(
+  `https://download.savannah.nongnu.org/releases/lzip/clzip/clzip-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function clzip(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/clzip"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    clzip --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(clzip)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `clzip ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://download.savannah.nongnu.org/releases/lzip/clzip
+      | lines
+      | where ($it | str contains "clzip-") and ($it | str contains ".tar.gz") and (not ($it | str contains ".sig"))
+      | parse --regex '<a href="clzip-(?<version>\\d+\\.\\d+)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `clzip`
- **Website / repository:** `https://www.nongnu.org/lzip/clzip.html`
- **Repology URL:** `https://repology.org/project/clzip/versions`
- **Short description:** `C language version of the lzip lossless data compressor, intended for systems lacking a C++ compiler`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 280578
[280578] clzip 1.16
[280578] Copyright (C) 2026 Antonio Diaz Diaz.
[280578] License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl.html>
[280578] This is free software: you are free to change and redistribute it.
[280578] There is NO WARRANTY, to the extent permitted by law.
Process 280578 ran in 0.02s
Build finished, completed 1 job in 2.03s
Result: bbf1289df05bcf6e90a76eb669dc1564165faa79d9a29fa7b65d7516d07d21d6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 280666
Process 280666 ran in 0.03s
Build finished, completed 1 job in 4.22s
Running brioche-run
{
  "name": "clzip",
  "version": "1.16"
}
```

</p>
</details>

## Implementation notes / special instructions

None.