### PR TITLE
feat(lziprecover): add package

### DIFF
--- a/packages/lziprecover/brioche.lock
+++ b/packages/lziprecover/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.savannah.nongnu.org/releases/lzip/lziprecover/lziprecover-1.26.tar.gz": {
+      "type": "sha256",
+      "value": "e234005a756d5649f41686116d3e548736d4a77e5a5ec37b943ca6650787801d"
+    }
+  }
+}

--- a/packages/lziprecover/project.bri
+++ b/packages/lziprecover/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "lziprecover",
+  version: "1.26",
+};
+
+const source = Brioche.download(
+  `https://download.savannah.nongnu.org/releases/lzip/lziprecover/lziprecover-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lziprecover(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/lziprecover"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    lziprecover --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(lziprecover)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `lziprecover ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://download.savannah.nongnu.org/releases/lzip/lziprecover
+      | lines
+      | where ($it | str contains "lziprecover-") and ($it | str contains ".tar.gz") and (not ($it | str contains ".sig")) and (not ($it | str contains "-rc"))
+      | parse --regex '<a href="lziprecover-(?<version>\\d+\\.\\d+)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lziprecover`
- **Website / repository:** https://www.nongnu.org/lzip/lziprecover.html
- **Repology URL:** `https://repology.org/project/lziprecover/versions`
- **Short description:** Data recovery tool and decompressor for files in the lzip compressed data format

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 281107
[281107] lziprecover 1.26
[281107] Copyright (C) 2026 Antonio Diaz Diaz.
[281107] License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl.html>
[281107] This is free software: you are free to change and redistribute it.
[281107] There is NO WARRANTY, to the extent permitted by law.
Process 281107 ran in 0.02s
Build finished, completed 1 job in 1.51s
Result: e8e6c3efe51754f3ae80accc5215e65dca9053226d7aa551b2f5ed76882533b1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.68s
Running brioche-run
{
  "name": "lziprecover",
  "version": "1.26"
}
```

</p>
</details>

## Implementation notes / special instructions

None.