### PR TITLE
feat(plzip): add package

### DIFF
--- a/packages/plzip/brioche.lock
+++ b/packages/plzip/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.savannah.nongnu.org/releases/lzip/plzip/plzip-1.13.tar.gz": {
+      "type": "sha256",
+      "value": "64d49dde20daa5fdff2b3ff28e3348082de10dd54eb10df6da7d1bc6c7a6db64"
+    }
+  }
+}

--- a/packages/plzip/project.bri
+++ b/packages/plzip/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import lzlib from "lzlib";
+
+export const project = {
+  name: "plzip",
+  version: "1.13",
+};
+
+const source = Brioche.download(
+  `https://download.savannah.nongnu.org/releases/lzip/plzip/plzip-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function plzip(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, lzlib)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/plzip"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    plzip --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(plzip)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `plzip ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://download.savannah.nongnu.org/releases/lzip/plzip
+      | lines
+      | where ($it | str contains "plzip-") and ($it | str contains ".tar.gz") and (not ($it | str contains ".sig"))
+      | parse --regex '<a href="plzip-(?<version>\\d+\\.\\d+)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `plzip`
- **Website / repository:** `https://www.nongnu.org/lzip/plzip.html`
- **Repology URL:** `https://repology.org/project/plzip/versions`
- **Short description:** `A massively parallel (multithreaded) implementation of lzip for faster compression and decompression on multiprocessor machines`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 290867
[290867] plzip 1.13
[290867] Copyright (C) 2009 Laszlo Ersek.
[290867] Copyright (C) 2026 Antonio Diaz Diaz.
[290867] License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl.html>
[290867] This is free software: you are free to change and redistribute it.
[290867] There is NO WARRANTY, to the extent permitted by law.
[290867] Using lzlib 1.15
[290867] Using LZ_API_VERSION = 1015
Process 290867 ran in 0.02s
Build finished, completed 1 job in 1.59s
Result: 4a9e54439f3eab0d65882ce2aab2c28344cd29508538196328e36e270992f902
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 290980
Process 290980 ran in 0.01s
Build finished, completed 1 job in 4.25s
Running brioche-run
{
  "name": "plzip",
  "version": "1.13"
}
```

</p>
</details>

## Implementation notes / special instructions

None.