### PR TITLE
feat(avfs): add package

### DIFF
--- a/packages/avfs/brioche.lock
+++ b/packages/avfs/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/avf/avfs/1.3.0/avfs-1.3.0.tar.bz2": {
+      "type": "sha256",
+      "value": "07cd69d4c0c7ed080e80ff040d980286405ad38a443fdc52dc395efef11c44b1"
+    }
+  }
+}

--- a/packages/avfs/project.bri
+++ b/packages/avfs/project.bri
@@ -1,0 +1,77 @@
+import libfuse from "libfuse";
+import liburing from "liburing";
+import lzlib from "lzlib";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import numactl from "numactl";
+import * as std from "std";
+
+export const project = {
+  name: "avfs",
+  version: "1.3.0",
+  repository: "https://sourceforge.net/projects/avf",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/avf/avfs/${project.version}/avfs-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function avfs(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \
+      --prefix=/ \
+      --enable-fuse \
+      --enable-library \
+      --with-system-zlib \
+      --with-system-bzlib \
+      --with-xz
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libfuse, liburing, lzlib, numactl)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/avfsd"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion avfs | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, avfs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/avf/files/avfs
+      | lines
+      | where ($it | str contains 'href="/projects/avf/files/avfs/')
+      | parse --regex '<a href="/projects/avf/files/avfs/(?<version>[\\d.]+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `avfs`
- **Website / repository:** `https://avf.sourceforge.net/`
- **Repology URL:** `https://repology.org/project/avfs/versions`
- **Short description:** `A virtual filesystem that allows browsing of compressed and archived files without extracting them`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.16s
Result: 43e3699b26061b8768334f5df72db15ac034a1c7b87e0c6a0a3e482316991742
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.82s
Running brioche-run
{
  "name": "avfs",
  "version": "1.3.0",
  "repository": "https://sourceforge.net/projects/avf"
}
```

</p>
</details>

## Implementation notes / special instructions

None.