### PR TITLE
feat(azcopy): add package

### DIFF
--- a/packages/azcopy/brioche.lock
+++ b/packages/azcopy/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/!azure/azure-storage-azcopy/v10/@v/v10.32.3.zip": {
+      "type": "sha256",
+      "value": "faa3f2277a9c911929a6ed66693a31a223946c885e63bb3c3d3e712e45501317"
+    }
+  }
+}

--- a/packages/azcopy/project.bri
+++ b/packages/azcopy/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "azcopy",
+  version: "10.32.3",
+  extra: {
+    moduleName: "github.com/!azure/azure-storage-azcopy/v10",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(4);
+
+export default function azcopy(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+  })
+    .pipe(
+      // Rename binary file
+      (recipe) =>
+        recipe
+          .insert("bin/azcopy", recipe.get("bin/azure-storage-azcopy"))
+          .remove("bin/azure-storage-azcopy"),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/azcopy"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    azcopy --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(azcopy)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `azcopy version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `azcopy`
- **Website / repository:** `https://github.com/Azure/azure-storage-azcopy`
- **Repology URL:** `https://repology.org/project/azcopy/versions`
- **Short description:** `Azure Storage data transfer utility for copying data to and from Azure Blob, File, and Table storage`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.83s
Result: b576edc9b75477d5c7d319ed9b7de1b3f0492a3e9201daef71fa46f0d4039dec
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "azcopy",
  "version": "10.32.3",
  "extra": {
    "moduleName": "github.com/!azure/azure-storage-azcopy/v10"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.