### PR TITLE
feat(asc): add package

### DIFF
--- a/packages/asc/brioche.lock
+++ b/packages/asc/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/rudrankriyam/App-Store-Connect-CLI.git": {
+      "1.2.0": "b0f11fa8fe34e68fcd5e892fdcfcbb60d3314d29"
+    }
+  }
+}

--- a/packages/asc/project.bri
+++ b/packages/asc/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "asc",
+  version: "1.2.0",
+  repository: "https://github.com/rudrankriyam/App-Store-Connect-CLI.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function asc(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+  })
+    .pipe(
+      // Rename binary file
+      (recipe) =>
+        recipe
+          .insert("bin/asc", recipe.get("bin/App-Store-Connect-CLI"))
+          .remove("bin/App-Store-Connect-CLI"),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/asc"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    asc --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(asc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `${project.version} (commit: unknown, date: unknown)`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `asc`
- **Website / repository:** `https://github.com/rudrankriyam/App-Store-Connect-CLI`
- **Repology URL:** `https://repology.org/project/asc/versions`
- **Short description:** `Fast, lightweight CLI for App Store Connect`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 318401
[318401] 1.2.0 (commit: unknown, date: unknown)
Process 318401 ran in 0.24s
Build finished, completed 1 job in 3.02s
Result: 4db8c0ef548f60b2f2e3362286d5756b4038f0e713b3e85c575b7da41521c8ea
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 318503
Process 318503 ran in 0.01s
Build finished, completed 1 job in 3.56s
Running brioche-run
{
  "name": "asc",
  "version": "1.2.0",
  "repository": "https://github.com/rudrankriyam/App-Store-Connect-CLI.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.