### PR TITLE
feat(infisical): add package

### DIFF
--- a/packages/infisical/brioche.lock
+++ b/packages/infisical/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Infisical/cli.git": {
+      "v0.43.72": "c6a4cf04734d5dca90fc382aacf68f05dd75fbb7"
+    }
+  }
+}

--- a/packages/infisical/project.bri
+++ b/packages/infisical/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "infisical",
+  version: "0.43.72",
+  repository: "https://github.com/Infisical/cli.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function infisical(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/Infisical/infisical-merge/packages/util.CLI_VERSION=${project.version}`,
+      ],
+    },
+  })
+    .pipe(
+      // Rename binary file
+      (recipe) =>
+        recipe
+          .insert("bin/infisical", recipe.get("bin/infisical-merge"))
+          .remove("bin/infisical-merge"),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/infisical"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    infisical --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(infisical)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `infisical version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `infisical`
- **Website / repository:** `https://github.com/Infisical/cli`
- **Repology URL:** `https://repology.org/project/infisical/versions`
- **Short description:** `CLI tool for injecting secrets into applications and managing Infisical infrastructure`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 318632
[318632] infisical version 0.43.72
Process 318632 ran in 0.08s
Build finished, completed 1 job in 2.68s
Result: 1c2c5e7a4f4115e37a02dbbbbc22bb3db9799181b22161130ce35c2718df2135
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.28s
Running brioche-run
{
  "name": "infisical",
  "version": "0.43.72",
  "repository": "https://github.com/Infisical/cli.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.