### PR TITLE
feat(symfony_cli): add package

### DIFF
--- a/packages/symfony_cli/brioche.lock
+++ b/packages/symfony_cli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/symfony-cli/symfony-cli.git": {
+      "v5.17.1": "1e2a63ccefd4b18e20b7387f001bdba879499022"
+    }
+  }
+}

--- a/packages/symfony_cli/project.bri
+++ b/packages/symfony_cli/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "symfony_cli",
+  version: "5.17.1",
+  repository: "https://github.com/symfony-cli/symfony-cli.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function symfonyCli(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    runnable: "bin/symfony-cli",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    symfony-cli version --no-ansi | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(symfonyCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Symfony CLI version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `symfony_cli`
- **Website / repository:** `https://github.com/symfony-cli/symfony-cli`
- **Repology URL:** `https://repology.org/project/symfony-cli/versions`
- **Short description:** `The Symfony CLI tool for creating and managing Symfony applications, with a local web server, security checker, and cloud platform integration.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.84s
Result: 94ee28ac3ca3a0c0171a07c235d28fcbbaa4fe188685fcbd84bb408a2af17376
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.21s
Running brioche-run
{
  "name": "symfony_cli",
  "version": "5.17.1",
  "repository": "https://github.com/symfony-cli/symfony-cli.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.