### PR TITLE
feat(sdl2_image): add package

### DIFF
--- a/packages/fftw/project.bri
+++ b/packages/fftw/project.bri
@@ -41,12 +41,12 @@ export default function fftw(): std.Recipe<std.Directory> {
  */
 function buildWithFlags(extraFlags: string): std.Recipe<std.Directory> {
   return std.runBash`
-    ./configure \
-      --prefix=/ \
-      --enable-shared \
-      --enable-static \
-      --enable-threads \
-      --enable-openmp \
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared \\
+      --enable-static \\
+      --enable-threads \\
+      --enable-openmp \\
       ${extraFlags}
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"

--- a/packages/lasso/project.bri
+++ b/packages/lasso/project.bri
@@ -22,13 +22,13 @@ const source = Brioche.download(
 
 export default function lasso(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./configure \
-      --prefix=/ \
-      --with-pkg-config="$PKG_CONFIG_PATH" \
-      --disable-perl \
-      --disable-php5 \
-      --disable-php7 \
-      --disable-python \
+    ./configure \\
+      --prefix=/ \\
+      --with-pkg-config="$PKG_CONFIG_PATH" \\
+      --disable-perl \\
+      --disable-php5 \\
+      --disable-php7 \\
+      --disable-python \\
       --disable-java
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"

--- a/packages/sdl12_compat/project.bri
+++ b/packages/sdl12_compat/project.bri
@@ -24,7 +24,7 @@ export default function sdl12Compat(): std.Recipe<std.Directory> {
     runnable: "bin/sdl-config",
   }).pipe((recipe) =>
     std.setEnv(recipe, {
-      CPATH: { append: [{ path: "include" }] },
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
       ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },

--- a/packages/sdl2/project.bri
+++ b/packages/sdl2/project.bri
@@ -37,7 +37,7 @@ export default function sdl2(): std.Recipe<std.Directory> {
     },
   }).pipe((recipe) =>
     std.setEnv(recipe, {
-      CPATH: { append: [{ path: "include" }] },
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL2" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
       CMAKE_PREFIX_PATH: { append: [{ path: "." }] },

--- a/packages/sdl2_image/brioche.lock
+++ b/packages/sdl2_image/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.10/SDL2_image-2.8.10.tar.gz": {
+      "type": "sha256",
+      "value": "ebc059d01c007a62f4b04f10cf858527c875062532296943174df9a80264fd65"
+    }
+  }
+}

--- a/packages/sdl2_image/project.bri
+++ b/packages/sdl2_image/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libavif from "libavif";
+import libjpegTurbo from "libjpeg_turbo";
+import libjxl from "libjxl";
+import libpng from "libpng";
+import libtiff from "libtiff";
+import libwebp from "libwebp";
+import sdl2 from "sdl2";
+
+export const project = {
+  name: "sdl2_image",
+  version: "2.8.10",
+  repository: "https://github.com/libsdl-org/SDL_image",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL2_image-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2Image(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      sdl2,
+      libavif,
+      libjpegTurbo,
+      libjxl,
+      libpng,
+      libtiff,
+      libwebp,
+    ],
+    set: {
+      SDL2IMAGE_VENDORED: "OFF",
+      SDL2IMAGE_BACKEND_STB: "OFF",
+      SDL2IMAGE_DEPS_SHARED: "OFF",
+      SDL2IMAGE_SAMPLES: "OFF",
+      SDL2IMAGE_TESTS: "OFF",
+      SDL2IMAGE_JXL: "ON",
+      SDL2IMAGE_JPG_SAVE: "ON",
+      SDL2IMAGE_PNG_SAVE: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL2" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SDL2_image | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2Image)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>2\.\d+\.\d+)$/,
+  });
+}

--- a/packages/sdl2_sound/project.bri
+++ b/packages/sdl2_sound/project.bri
@@ -50,5 +50,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGithubReleases({ project });
-}
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^v(?<version>2\.\d+\.\d+)$/,
+  });}

--- a/packages/sdl2_sound/project.bri
+++ b/packages/sdl2_sound/project.bri
@@ -53,4 +53,5 @@ export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
     matchTag: /^v(?<version>2\.\d+\.\d+)$/,
-  });}
+  });
+}

--- a/packages/xmlsec/project.bri
+++ b/packages/xmlsec/project.bri
@@ -17,10 +17,10 @@ const source = Brioche.download(
 
 export default function xmlsec(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./configure \
-      --prefix=/ \
-      --with-openssl \
-      --with-default-crypto=openssl \
+    ./configure \\
+      --prefix=/ \\
+      --with-openssl \\
+      --with-default-crypto=openssl \\
       --disable-docs
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2_image`
- **Website / repository:** `https://github.com/libsdl-org/SDL_image`
- **Repology URL:** `https://repology.org/project/sdl2_image/versions`
- **Short description:** `Image loading library for SDL2, supporting AVIF, BMP, GIF, JPEG, JPEG-XL, LBM, PCX, PNG, PNM, QOI, SVG, TGA, TIFF, WebP, XCF, XPM, and XV formats`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 346883
[346883] 2.8.10
Process 346883 ran in 0.02s
Build finished, completed 1 job in 52.59s
Result: 97b712eb601d4ff83b929e649160bdc1b0b2e9e825203c215bc7d554f35c1a30
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Running brioche-run
{
  "name": "sdl2_image",
  "version": "2.8.10",
  "repository": "https://github.com/libsdl-org/SDL_image"
}
```

</p>
</details>

## Implementation notes / special instructions

None.