### PR TITLE
feat(sdl2_ttf): add package

### DIFF
--- a/packages/iniparser/project.bri
+++ b/packages/iniparser/project.bri
@@ -8,7 +8,7 @@ export const project = {
 };
 
 const source = Brioche.gitCheckout({
-  repository: `${project.repository}.git`,
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 

--- a/packages/reproc/project.bri
+++ b/packages/reproc/project.bri
@@ -8,7 +8,7 @@ export const project = {
 };
 
 const source = Brioche.gitCheckout({
-  repository: `${project.repository}.git`,
+  repository: project.repository,
   ref: `v${project.version}`,
 });
 

--- a/packages/sdl2_ttf/brioche.lock
+++ b/packages/sdl2_ttf/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.24.0/SDL2_ttf-2.24.0.tar.gz": {
+      "type": "sha256",
+      "value": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd"
+    }
+  }
+}

--- a/packages/sdl2_ttf/project.bri
+++ b/packages/sdl2_ttf/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import { cmakeSanitizePaths } from "cmake";
+import freetype from "freetype";
+import harfbuzz from "harfbuzz";
+import sdl2 from "sdl2";
+
+export const project = {
+  name: "sdl2_ttf",
+  version: "2.24.0",
+  repository: "https://github.com/libsdl-org/SDL_ttf",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL2_ttf-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2Ttf(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, freetype, harfbuzz, sdl2)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe(cmakeSanitizePaths)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }, { path: "include/SDL2" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SDL2_ttf | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2Ttf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>2\.\d+\.\d+)$/,
+  });
+}

--- a/packages/yajl/project.bri
+++ b/packages/yajl/project.bri
@@ -8,7 +8,7 @@ export const project = {
 };
 
 const source = Brioche.gitCheckout({
-  repository: `${project.repository}.git`,
+  repository: project.repository,
   ref: project.version,
 }).pipe((source) =>
   // Patch deprecated GET_TARGET_PROPERTY(... LOCATION) and the


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2_ttf`
- **Website / repository:** `https://github.com/libsdl-org/SDL_ttf`
- **Repology URL:** `https://repology.org/project/sdl2-ttf/versions`
- **Short description:** `SDL2_ttf is a wrapper around FreeType and HarfBuzz, allowing TrueType font rendering in SDL2 applications.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 490352
[490352] 2.24.0
Process 490352 ran in 0.05s
Build finished, completed 1 job in 52.46s
Result: 0f288862d0acadd9caa5b5435159194f114fd820a1a22de3ec1f1ffa68f32404
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.32s
Running brioche-run
{
  "name": "sdl2_ttf",
  "version": "2.24.0",
  "repository": "https://github.com/libsdl-org/SDL_ttf"
}
```

</p>
</details>

## Implementation notes / special instructions

None.