### PR TITLE
feat(libxmp): add package

### DIFF
--- a/packages/libxmp/brioche.lock
+++ b/packages/libxmp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libxmp/libxmp": {
+      "libxmp-4.7.0": "8a4fdf7d09aedc921de537853b59e1d15b534f24"
+    }
+  }
+}

--- a/packages/libxmp/project.bri
+++ b/packages/libxmp/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libxmp",
+  version: "4.7.0",
+  repository: "https://github.com/libxmp/libxmp",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `libxmp-${project.version}`,
+});
+
+export default function libxmp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      WITH_UNIT_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libxmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libxmp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^libxmp-(?<version>.*)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libxmp`
- **Website / repository:** `https://github.com/libxmp/libxmp`
- **Repology URL:** `https://repology.org/project/libxmp/versions`
- **Short description:** `A library that renders module files (MOD, S3M, XM, IT, and 90+ other formats) to PCM data`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 499902
[499902] Cloning into '/home/brioche-runner-.../.local/share/brioche/outputs/output-...'...
Process 499902 ran in 3.15s
Process 499902 finalized in 1.18s
Prepared process 499959 in 1.25s
Launched process 499959
Process 499959 ran in 0.02s
Build finished, completed 2 jobs in 10.79s
Result: 8d89b80175e8f1ba17dcfab9816c066f1e5aa4e21a5f1148274b41d4b6581184
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.38s
Running brioche-run
{
  "name": "libxmp",
  "version": "4.7.0",
  "repository": "https://github.com/libxmp/libxmp"
}
```

</p>
</details>

## Implementation notes / special instructions

None.