### PR TITLE
feat(sdl2_net): add package

### DIFF
--- a/packages/sdl2_net/brioche.lock
+++ b/packages/sdl2_net/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-2.2.0.tar.gz": {
+      "type": "sha256",
+      "value": "4e4a891988316271974ff4e9585ed1ef729a123d22c08bd473129179dc857feb"
+    }
+  }
+}

--- a/packages/sdl2_net/project.bri
+++ b/packages/sdl2_net/project.bri
@@ -1,0 +1,62 @@
+import * as std from "std";
+import { cmakeSanitizePaths } from "cmake";
+import sdl2 from "sdl2";
+
+export const project = {
+  name: "sdl2_net",
+  version: "2.2.0",
+  repository: "https://github.com/libsdl-org/SDL_net",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL2_net-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2Net(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-sdltest
+    make -j "$(nproc)" noinst_PROGRAMS=
+    make install DESTDIR="$BRIOCHE_OUTPUT" noinst_PROGRAMS=
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, sdl2)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe(cmakeSanitizePaths)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }, { path: "include/SDL2" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SDL2_net | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2Net)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>2\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2_net`
- **Website / repository:** `https://github.com/libsdl-org/SDL_net`
- **Repology URL:** `https://repology.org/project/sdl2-net/versions`
- **Short description:** `A small cross-platform networking library for SDL2`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 500311
[500311] 2.2.0
Process 500311 ran in 0.03s
Build finished, completed 1 job in 30.50s
Result: 15f9c84d275f48391d128096d0513c702f19c7e381eaafe464ede8ebc20f7c59
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.37s
Running brioche-run
{
  "name": "sdl2_net",
  "version": "2.2.0",
  "repository": "https://github.com/libsdl-org/SDL_net"
}
```

</p>
</details>

## Implementation notes / special instructions

None.