### PR TITLE
feat(game_music_emu): add package

### DIFF
--- a/packages/game_music_emu/brioche.lock
+++ b/packages/game_music_emu/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libgme/game-music-emu": {
+      "0.6.4": "f0d9517c5c3e0b712f553baa62e213336587d52e"
+    }
+  }
+}

--- a/packages/game_music_emu/project.bri
+++ b/packages/game_music_emu/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import zlib from "zlib";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "game_music_emu",
+  version: "0.6.4",
+  repository: "https://github.com/libgme/game-music-emu",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function gameMusicEmu(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, zlib],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      GME_BUILD_TESTING: "OFF",
+      GME_BUILD_EXAMPLES: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libgme | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gameMusicEmu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `game_music_emu`
- **Website / repository:** `https://github.com/libgme/game-music-emu`
- **Repology URL:** `https://repology.org/project/game-music-emu/versions`
- **Short description:** `Video game music file emulation library supporting NES, SNES, Game Boy, Sega, and other classic console formats`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 501152
[501152] 0.6.4
Process 501152 ran in 0.02s
Build finished, completed 1 job in 1.79s
Result: d3e8f3ed0d65412633f8f627cd677b8bde5f404ac9e78d480a37c1ff138be67f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.01s
Running brioche-run
{
  "name": "game_music_emu",
  "version": "0.6.4",
  "repository": "https://github.com/libgme/game-music-emu"
}
```

</p>
</details>

## Implementation notes / special instructions

None.