### PR TITLE
feat(wavpack): add package

### DIFF
--- a/packages/wavpack/brioche.lock
+++ b/packages/wavpack/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/dbry/WavPack/releases/download/5.9.0/wavpack-5.9.0.tar.xz": {
+      "type": "sha256",
+      "value": "b5291bc4e6d69ebbd3da3800c5bf4a70f19bb92679b23e09b3b612c1e648d1ff"
+    }
+  }
+}

--- a/packages/wavpack/project.bri
+++ b/packages/wavpack/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+
+export const project = {
+  name: "wavpack",
+  version: "5.9.0",
+  repository: "https://github.com/dbry/WavPack",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/wavpack-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function wavpack(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/wavpack"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion wavpack | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, wavpack)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `wavpack`
- **Website / repository:** `https://github.com/dbry/WavPack`
- **Repology URL:** `https://repology.org/project/wavpack/versions`
- **Short description:** `WavPack is a hybrid lossless audio compression format with both lossy and lossless encoding modes, plus CLI tools for encoding, decoding, gain adjustment, and tagging.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 517881
[517881] 5.9.0
Process 517881 ran in 0.03s
Build finished, completed 1 job in 1.47s
Result: f556b13d1012bd55ff10c728d76abc8e3f285a9a6f6fc7ecfbda73fa2e06d0da
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.98s
Running brioche-run
{
  "name": "wavpack",
  "version": "5.9.0",
  "repository": "https://github.com/dbry/WavPack"
}
```

</p>
</details>

## Implementation notes / special instructions

None.