### PR TITLE
feat(wayback): add package

### DIFF
--- a/packages/wayback/brioche.lock
+++ b/packages/wayback/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/wabarc/wayback/@v/v0.20.1.info": {
+      "type": "sha256",
+      "value": "e8bf6564b7f2dd3e9102d323344e63141477abd9a35a981dd9630e3f890865c4"
+    },
+    "https://proxy.golang.org/github.com/wabarc/wayback/@v/v0.20.1.zip": {
+      "type": "sha256",
+      "value": "c01edbce39a621a7069154368eebc1a24b34984d84387122a5655d45e732fa0b"
+    }
+  }
+}

--- a/packages/wayback/project.bri
+++ b/packages/wayback/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "wayback",
+  version: "0.20.1",
+  extra: {
+    moduleName: "github.com/wabarc/wayback",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function wayback(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/version.Version=${project.version}`,
+        "-X",
+        `${project.extra.moduleName}/version.Commit=${manifest.origin.hash}`,
+        "-X",
+        `${project.extra.moduleName}/version.BuildDate=${manifest.time}`,
+      ],
+    },
+    path: "./cmd/wayback",
+    runnable: "bin/wayback",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    wayback --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(wayback)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `wayback version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `wayback`
- **Website / repository:** `https://github.com/wabarc/wayback`
- **Repology URL:** `https://repology.org/project/wayback/versions`
- **Short description:** `An archiving tool with an IM-style interface, integrated with Internet Archive, archive.today, IPFS, and more`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.80s
Result: 41b5ea5dfd10792757cfd5184aa74ed5242b83ed921c0494962ed850983ced5f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "wayback",
  "version": "0.20.1",
  "extra": {
    "moduleName": "github.com/wabarc/wayback"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.