### PR TITLE
feat(fluidsynth): add package

### DIFF
--- a/packages/fluidsynth/brioche.lock
+++ b/packages/fluidsynth/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/FluidSynth/fluidsynth": {
+      "v2.5.3": "6b8fabbd60f0df3b6e2f5b5df8478a1b43315acd"
+    }
+  }
+}

--- a/packages/fluidsynth/project.bri
+++ b/packages/fluidsynth/project.bri
@@ -1,0 +1,73 @@
+import * as std from "std";
+import alsa_lib from "alsa_lib";
+import { cmakeBuild } from "cmake";
+import dbus from "dbus";
+import glib from "glib";
+import libsndfile from "libsndfile";
+import pipewire from "pipewire";
+import portaudio from "portaudio";
+import readline from "readline";
+
+export const project = {
+  name: "fluidsynth",
+  version: "2.5.3",
+  repository: "https://github.com/FluidSynth/fluidsynth",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+  options: {
+    submodules: true,
+  },
+});
+
+export default function fluidsynth(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      alsa_lib,
+      dbus,
+      glib,
+      libsndfile,
+      pipewire,
+      portaudio,
+      readline,
+    ],
+    set: {
+      BUILD_TESTING: "OFF",
+      "enable-portaudio": "ON",
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+    runnable: "bin/fluidsynth",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion fluidsynth | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, fluidsynth)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `fluidsynth`
- **Website / repository:** `https://github.com/FluidSynth/fluidsynth`
- **Repology URL:** `https://repology.org/project/fluidsynth/versions`
- **Short description:** `A real-time software synthesizer based on the SoundFont 2 specifications`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.73s
Result: 5f020231eb16dcca40cdec4996be6b91fe1d54fe6fcb4cea4dae650ed2e5709e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.31s
Running brioche-run
{
  "name": "fluidsynth",
  "version": "2.5.3",
  "repository": "https://github.com/FluidSynth/fluidsynth"
}
```

</p>
</details>

## Implementation notes / special instructions

None.