### PR TITLE
feat(webpack_cli): add package

### DIFF
--- a/packages/webpack_cli/brioche.lock
+++ b/packages/webpack_cli/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/webpack_cli/project.bri
+++ b/packages/webpack_cli/project.bri
@@ -1,0 +1,38 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "webpack_cli",
+  version: "7.0.2",
+  extra: {
+    packageName: "webpack-cli",
+  },
+};
+
+export default function webpackCli(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/webpack-cli"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    webpack-cli --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(webpackCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `webpack_cli`
- **Website / repository:** `https://github.com/webpack/webpack-cli`
- **Repology URL:** `https://repology.org/project/webpack-cli/versions`
- **Short description:** `CLI for webpack, the build tool for modern web applications`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.43s
Result: 22918c14279c81a4068cfe0d3f7c85b5e571d993121e4cacb15d4550790927a2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "webpack_cli",
  "version": "7.0.2",
  "extra": {
    "packageName": "webpack-cli"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.