### PR TITLE
feat(sdl3): add package

### DIFF
--- a/packages/sdl3/brioche.lock
+++ b/packages/sdl3/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL/releases/download/release-3.4.4/SDL3-3.4.4.tar.gz": {
+      "type": "sha256",
+      "value": "ee712dbe6a89bb140bbfc2ce72358fb5ee5cc2240abeabd54855012db30b3864"
+    }
+  }
+}

--- a/packages/sdl3/project.bri
+++ b/packages/sdl3/project.bri
@@ -1,0 +1,75 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import dbus from "dbus";
+import libdrm from "libdrm";
+import libffi from "libffi";
+import libusb from "libusb";
+import libudevZero from "libudev_zero";
+import libxkbcommon from "libxkbcommon";
+import mesa from "mesa";
+import pipewire from "pipewire";
+import wayland from "wayland";
+
+export const project = {
+  name: "sdl3",
+  version: "3.4.4",
+  repository: "https://github.com/libsdl-org/SDL",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL3-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl3(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      dbus,
+      libdrm,
+      libffi,
+      libusb,
+      libudevZero,
+      libxkbcommon,
+      mesa,
+      pipewire,
+      wayland,
+    ],
+    set: {
+      SDL_TEST_LIBRARY: "OFF",
+      SDL_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL3" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl3)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>3\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl3`
- **Website / repository:** `https://github.com/libsdl-org/SDL`
- **Repology URL:** `https://repology.org/project/sdl3/versions`
- **Short description:** `Simple DirectMedia Layer 3, a cross-platform library for low-level access to audio, keyboard, mouse, joystick, and graphics hardware`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 533671
[533671] 3.4.4
Process 533671 ran in 0.11s
Build finished, completed 1 job in 31.89s
Result: d0b9b8349a87682892a57c113bb05648018e399959e30fcbe1f820ff215d56bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.17s
Running brioche-run
{
  "name": "sdl3",
  "version": "3.4.4",
  "repository": "https://github.com/libsdl-org/SDL"
}
```

</p>
</details>

## Implementation notes / special instructions

None.