### PR TITLE
feat(sdl2_mixer): add package

### DIFF
--- a/packages/sdl2_mixer/brioche.lock
+++ b/packages/sdl2_mixer/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz": {
+      "type": "sha256",
+      "value": "cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660"
+    }
+  }
+}

--- a/packages/sdl2_mixer/project.bri
+++ b/packages/sdl2_mixer/project.bri
@@ -1,0 +1,76 @@
+import * as std from "std";
+import fluidsynth from "fluidsynth";
+import gameMusicEmu from "game_music_emu";
+import libogg from "libogg";
+import libxmp from "libxmp";
+import opus from "opus";
+import opusfile from "opusfile";
+import sdl2 from "sdl2";
+import wavpack from "wavpack";
+
+export const project = {
+  name: "sdl2_mixer",
+  version: "2.8.1",
+  repository: "https://github.com/libsdl-org/SDL_mixer",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL2_mixer-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl2Mixer(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      fluidsynth,
+      gameMusicEmu,
+      libogg,
+      libxmp,
+      opus,
+      opusfile,
+      sdl2,
+      wavpack,
+    )
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SDL2_mixer | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl2Mixer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>2\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl2_mixer`
- **Website / repository:** `https://github.com/libsdl-org/SDL_mixer`
- **Repology URL:** `https://repology.org/project/sdl2_mixer/versions`
- **Short description:** `SDL2_mixer is a multi-channel audio mixer library for SDL2, supporting WAV, MOD, MIDI, Opus, FLAC, MP3, WavPack, and other audio formats.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 35.79s
Result: b23c22cb63d30145e8d202cf1238dde7e2fb91900f8b287f26e87833ecd16188
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.06s
Running brioche-run
{
  "name": "sdl2_mixer",
  "version": "2.8.1",
  "repository": "https://github.com/libsdl-org/SDL_mixer"
}
```

</p>
</details>

## Implementation notes / special instructions

None.