### PR TITLE
feat(dprint): add package

### DIFF
--- a/packages/dprint/brioche.lock
+++ b/packages/dprint/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/dprint/0.54.0/download": {
+      "type": "sha256",
+      "value": "276832f406faf1b31c819972f0221eec7a6ff9d896866f5c007bc6ab88000697"
+    }
+  }
+}

--- a/packages/dprint/project.bri
+++ b/packages/dprint/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "dprint",
+  version: "0.54.0",
+  extra: {
+    crateName: "dprint",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function dprint(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/dprint",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dprint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dprint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `dprint ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `dprint`
- **Website / repository:** `https://github.com/dprint/dprint`
- **Repology URL:** `https://repology.org/project/dprint/versions`
- **Short description:** `A pluggable and configurable code formatting platform`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 58.35s
Result: c9c12a69802bd3d611da445473e52008254dcc6f2288acc67bfde54b1efaa10e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 38.41s
Running brioche-run
{
  "name": "dprint",
  "version": "0.54.0",
  "extra": {
    "crateName": "dprint"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.