### PR TITLE
feat(vault_unseal): add package

### DIFF
--- a/packages/vault_unseal/brioche.lock
+++ b/packages/vault_unseal/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/lrstanley/vault-unseal/@v/v1.0.0.info": {
+      "type": "sha256",
+      "value": "8a656c58f28c307974bca498ac97b736f580a225baf8eb11002ca9c9486fa460"
+    },
+    "https://proxy.golang.org/github.com/lrstanley/vault-unseal/@v/v1.0.0.zip": {
+      "type": "sha256",
+      "value": "eaf063f5067fb4c75a713de1ef4416eff108840a383e59cc58c6c145ec14e021"
+    }
+  }
+}

--- a/packages/vault_unseal/project.bri
+++ b/packages/vault_unseal/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "vault_unseal",
+  version: "1.0.0",
+  extra: {
+    moduleName: "github.com/lrstanley/vault-unseal",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function vaultUnseal(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.version=${project.version}`,
+        "-X",
+        `main.commit=${manifest.origin.hash}`,
+        "-X",
+        `main.date=${manifest.time}`,
+      ],
+    },
+    runnable: "bin/vault-unseal",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    vault-unseal --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(vaultUnseal)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `vault-unseal :: ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `vault_unseal`
- **Website / repository:** `https://github.com/lrstanley/vault-unseal`
- **Repology URL:** `https://repology.org/project/vault-unseal/versions`
- **Short description:** `Auto-unseal utility for HashiCorp Vault clusters`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.72s
Result: 3adc69cdc04abe5ecc2cf8db3d2988a121c593024b3727530a61c225b5e58cbc
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.35s
Running brioche-run
{
  "name": "vault_unseal",
  "version": "1.0.0",
  "extra": {
    "moduleName": "github.com/lrstanley/vault-unseal"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.