### PR TITLE
feat(sdl3_ttf): add package

### DIFF
--- a/packages/sdl3_ttf/brioche.lock
+++ b/packages/sdl3_ttf/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_ttf/releases/download/release-3.2.2/SDL3_ttf-3.2.2.tar.gz": {
+      "type": "sha256",
+      "value": "63547d58d0185c833213885b635a2c0548201cc8f301e6587c0be1a67e1e045d"
+    }
+  }
+}

--- a/packages/sdl3_ttf/project.bri
+++ b/packages/sdl3_ttf/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import freetype from "freetype";
+import harfbuzz from "harfbuzz";
+import sdl3 from "sdl3";
+
+export const project = {
+  name: "sdl3_ttf",
+  version: "3.2.2",
+  repository: "https://github.com/libsdl-org/SDL_ttf",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL3_ttf-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl3Ttf(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, freetype, harfbuzz, sdl3],
+    set: {
+      SDL3TTF_SAMPLES: "OFF",
+      SDL3TTF_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL3_ttf" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl3-ttf | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl3Ttf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>3\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl3_ttf`
- **Website / repository:** `https://github.com/libsdl-org/SDL_ttf`
- **Repology URL:** `https://repology.org/project/sdl3_ttf/versions`
- **Short description:** `SDL3_ttf is a TrueType font rendering library for SDL3, providing text rendering with FreeType and HarfBuzz.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3m26s
Result: f12f3ac4264b7f04c7c295ed0b0e096a96e7b5e1a5014339c0485461f4b4755b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 10.90s
Running brioche-run
{
  "name": "sdl3_ttf",
  "version": "3.2.2",
  "repository": "https://github.com/libsdl-org/SDL_ttf"
}
```

</p>
</details>

## Implementation notes / special instructions

None.