### PR TITLE
feat(sdl3_mixer): add package

### DIFF
--- a/packages/sdl3_mixer/brioche.lock
+++ b/packages/sdl3_mixer/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_mixer/releases/download/release-3.2.0/SDL3_mixer-3.2.0.tar.gz": {
+      "type": "sha256",
+      "value": "1f86fae7226d58f2ad210ca4d9e06488db722230032803423d83bad6d35fc395"
+    }
+  }
+}

--- a/packages/sdl3_mixer/project.bri
+++ b/packages/sdl3_mixer/project.bri
@@ -1,0 +1,82 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import flac from "flac";
+import fluidsynth from "fluidsynth";
+import gameMusicEmu from "game_music_emu";
+import libogg from "libogg";
+import libvorbis from "libvorbis";
+import libxmp from "libxmp";
+import mpg123 from "mpg123";
+import opus from "opus";
+import opusfile from "opusfile";
+import sdl3 from "sdl3";
+import wavpack from "wavpack";
+
+export const project = {
+  name: "sdl3_mixer",
+  version: "3.2.0",
+  repository: "https://github.com/libsdl-org/SDL_mixer",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL3_mixer-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl3Mixer(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      flac,
+      fluidsynth,
+      gameMusicEmu,
+      libogg,
+      libvorbis,
+      libxmp,
+      mpg123,
+      opus,
+      opusfile,
+      sdl3,
+      wavpack,
+    ],
+    set: {
+      SDLMIXER_VENDORED: "OFF",
+      SDLMIXER_TESTS: "OFF",
+      SDLMIXER_EXAMPLES: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: {
+        append: [{ path: "include" }, { path: "include/SDL3_mixer" }],
+      },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl3-mixer | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl3Mixer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>3\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl3_mixer`
- **Website / repository:** `https://github.com/libsdl-org/SDL_mixer`
- **Repology URL:** `https://repology.org/project/sdl3-mixer/versions`
- **Short description:** `SDL3_mixer is a sample multi-channel audio mixer library for SDL3, supporting FLAC, MP3, Ogg Vorbis, Opus, MIDI, MOD, WavPack, and more.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3m22s
Result: fdcdf5a79a377fe454d3d6f0738bf90947fa30bbc72a4a4e999e969383f1b8e2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 18.54s
Running brioche-run
{
  "name": "sdl3_mixer",
  "version": "3.2.0",
  "repository": "https://github.com/libsdl-org/SDL_mixer"
}
```

</p>
</details>

## Implementation notes / special instructions

None.