### PR TITLE
feat(sdl3_image): add package

### DIFF
--- a/packages/sdl3_image/brioche.lock
+++ b/packages/sdl3_image/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libsdl-org/SDL_image/releases/download/release-3.4.2/SDL3_image-3.4.2.tar.gz": {
+      "type": "sha256",
+      "value": "82fdb88cf1a9cbdc1c77797aaa3292e6d22ce12586be718c8ea43530df1536b4"
+    }
+  }
+}

--- a/packages/sdl3_image/project.bri
+++ b/packages/sdl3_image/project.bri
@@ -1,0 +1,76 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libavif from "libavif";
+import libjpegTurbo from "libjpeg_turbo";
+import libjxl from "libjxl";
+import libpng from "libpng";
+import libtiff from "libtiff";
+import libwebp from "libwebp";
+import sdl3 from "sdl3";
+
+export const project = {
+  name: "sdl3_image",
+  version: "3.4.2",
+  repository: "https://github.com/libsdl-org/SDL_image",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/release-${project.version}/SDL3_image-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sdl3Image(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      sdl3,
+      libavif,
+      libjpegTurbo,
+      libjxl,
+      libpng,
+      libtiff,
+      libwebp,
+    ],
+    set: {
+      SDLIMAGE_VENDORED: "OFF",
+      SDLIMAGE_DEPS_SHARED: "OFF",
+      SDLIMAGE_SAMPLES: "OFF",
+      SDLIMAGE_TESTS: "OFF",
+      SDLIMAGE_JXL: "ON",
+      SDLIMAGE_JPG_SAVE: "ON",
+      SDLIMAGE_PNG_SAVE: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }, { path: "include/SDL3_image" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sdl3-image | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sdl3Image)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^release-(?<version>3\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sdl3_image`
- **Website / repository:** `https://github.com/libsdl-org/SDL_image`
- **Repology URL:** `https://repology.org/project/sdl3-image/versions`
- **Short description:** `SDL3_image is a simple library to load images of various formats as SDL surfaces, providing support for AVIF, BMP, GIF, JPEG, JXL, LBM, PCX, PNG, PNM, QOI, SVG, TGA, TIFF, WebP, XCF, XPM, and XV formats.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 6642 in 1.95s
Launched process 6642
[6642] 3.4.2
Process 6642 ran in 0.26s
Build finished, completed 1 job in 2m13s
Result: d0c2aac3abf54cd0aa73c8842b65e471011836fa7dada52552e402fbc15a26df
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 34.43s
Running brioche-run
{
  "name": "sdl3_image",
  "version": "3.4.2",
  "repository": "https://github.com/libsdl-org/SDL_image"
}
```

</p>
</details>

## Implementation notes / special instructions

None.