### PR TITLE
feat(httping): add package

### DIFF
--- a/packages/httping/brioche.lock
+++ b/packages/httping/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/folkertvanheusden/HTTPing": {
+      "v4.4.0": "6854bb0298eb6cc948c30179a37781a008b4f046"
+    }
+  }
+}

--- a/packages/httping/project.bri
+++ b/packages/httping/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import openssl from "openssl";
+import fftw from "fftw";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "httping",
+  version: "4.4.0",
+  repository: "https://github.com/folkertvanheusden/HTTPing",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function httping(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, openssl, fftw],
+    set: {
+      USE_SSL: "ON",
+      USE_TUI: "ON",
+      USE_FFTW3: "ON",
+      USE_GETTEXT: "ON",
+    },
+    runnable: "bin/httping",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    httping -V 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httping)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `HTTPing v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `httping`
- **Website / repository:** `https://github.com/folkertvanheusden/HTTPing`
- **Repology URL:** `https://repology.org/project/httping/versions`
- **Short description:** `Ping with HTTP requests - measures latency and throughput of HTTP(S) servers`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 22836
[22836] HTTPing v4.4.0, (C) 2003-2023 folkert@vanheusden.com
[22836]  * SSL support included (-l)
[22836]  * ncurses interface with FFT included (-K)
[22836]  * TFO (TCP fast open) support included (-F)
Process 22836 ran in 0.02s
Build finished, completed 1 job in 3.77s
Result: e30ef90aec37cf0fd9ca342d8856aecedb6bda7bd42849d01cf294a4988b0e46
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "httping",
  "version": "4.4.0",
  "repository": "https://github.com/folkertvanheusden/HTTPing"
}
```

</p>
</details>

## Implementation notes / special instructions

None.