### PR TITLE
feat(sesh): add package

### DIFF
--- a/packages/sesh/brioche.lock
+++ b/packages/sesh/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/joshmedeski/sesh/v2/@v/v2.25.0.zip": {
+      "type": "sha256",
+      "value": "0fef25a6af7a4b60baaa7ace4bbf3a720d902bd537f12d0f3a52d4338e578b07"
+    }
+  }
+}

--- a/packages/sesh/project.bri
+++ b/packages/sesh/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "sesh",
+  version: "2.25.0",
+  repository: "https://github.com/joshmedeski/sesh.git",
+  extra: {
+    moduleName: "github.com/joshmedeski/sesh/v2",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(4);
+
+export default function sesh(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    runnable: "bin/sesh",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    sesh --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(sesh)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `sesh version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sesh`
- **Website / repository:** `https://github.com/joshmedeski/sesh`
- **Repology URL:** `https://repology.org/project/sesh/versions`
- **Short description:** `Smart terminal session manager for tmux with zoxide integration`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.89s
Result: 766ef0936361e4061a54b3aad752d89c1ab8042678f1f776ec94136898b80605
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.47s
Running brioche-run
{
  "name": "sesh",
  "version": "2.25.0",
  "repository": "https://github.com/joshmedeski/sesh.git",
  "extra": {
    "moduleName": "github.com/joshmedeski/sesh/v2"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.