### PR TITLE
feat(codebook): add package

### DIFF
--- a/packages/codebook/brioche.lock
+++ b/packages/codebook/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/codebook-lsp/0.3.37/download": {
+      "type": "sha256",
+      "value": "1db8a9f43dd53eef77aba7aa678b1d13d4c25084f23fd0cc5c27bfd828c2a984"
+    }
+  }
+}

--- a/packages/codebook/project.bri
+++ b/packages/codebook/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "codebook",
+  version: "0.3.37",
+  repository: "https://github.com/blopker/codebook.git",
+  extra: {
+    crateName: "codebook-lsp",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function codebook(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/codebook-lsp",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    codebook-lsp --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(codebook)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `codebook-lsp ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `codebook`
- **Website / repository:** `https://github.com/blopker/codebook`
- **Repology URL:** `https://repology.org/project/codebook/versions`
- **Short description:** `A code-aware spell checker with LSP support for editor integration`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.28s
Result: 922fdc7946c201ba882d6cf22d61ab5dfe783d504e051f0c89cea913f981bbac
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.22s
Running brioche-run
{
  "name": "codebook",
  "version": "0.3.37",
  "repository": "https://github.com/blopker/codebook.git",
  "extra": {
    "crateName": "codebook-lsp"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.