### PR TITLE
feat(httpie): add package

### DIFF
--- a/packages/httpie/brioche.lock
+++ b/packages/httpie/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/httpie/cli.git": {
+      "3.2.4": "2105caa49bae87c5809c274e407619a0de2639d1"
+    }
+  }
+}

--- a/packages/httpie/project.bri
+++ b/packages/httpie/project.bri
@@ -1,0 +1,70 @@
+import * as std from "std";
+import python, { getLatestVersion as getPythonVersion } from "python";
+import uv from "uv";
+
+export const project = {
+  name: "httpie",
+  version: "3.2.4",
+  repository: "https://github.com/httpie/cli.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function httpie(): std.Recipe<std.Directory> {
+  return std.runBash`
+    uv tool install .
+  `
+    .workDir(source)
+    .dependencies(python, uv)
+    .env({
+      UV_NO_MANAGED_PYTHON: "1",
+      UV_LINK_MODE: "copy",
+      UV_TOOL_DIR: std.outputPath,
+    })
+    .unsafe({ networking: true })
+    .toDirectory()
+    .pipe((recipe) => {
+      recipe = recipe.insert("brioche-run.d/python", python);
+      const binaries = ["http", "https", "httpie"];
+      for (const binary of binaries) {
+        recipe = std.addRunnable(recipe, `bin/${binary}`, {
+          command: { relativePath: "brioche-run.d/python/bin/python" },
+          args: [{ relativePath: `httpie/bin/${binary}` }],
+          env: {
+            PYTHONPATH: {
+              prepend: {
+                relativePath: `httpie/lib/python${getPythonVersion()}/site-packages`,
+              },
+              separator: ":",
+            },
+          },
+        });
+      }
+
+      return recipe;
+    })
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/http"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    http --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httpie)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/iniparser/brioche.lock
+++ b/packages/iniparser/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/ndevilla/iniparser.git": {
+    "https://github.com/ndevilla/iniparser": {
       "v4.2.6": "4bef811283e0ec1658c60e09950bd5a1ddc92e4b"
     }
   }

--- a/packages/reproc/brioche.lock
+++ b/packages/reproc/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/DaanDeMeyer/reproc.git": {
+    "https://github.com/DaanDeMeyer/reproc": {
       "v14.2.5": "3179928ae7b085e41dfb846d987519fa7c12ffb3"
     }
   }

--- a/packages/yajl/brioche.lock
+++ b/packages/yajl/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://github.com/lloyd/yajl.git": {
+    "https://github.com/lloyd/yajl": {
       "2.1.0": "66cb08ca2ad8581080b626a75dfca266a890afb2"
     }
   }


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `httpie`
- **Website / repository:** `https://github.com/httpie/cli`
- **Repology URL:** `https://repology.org/project/httpie/versions`
- **Short description:** `A user-friendly command-line HTTP client for the API era`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.24s
Result: 0012e835525a3c2424a5d6f912a646b6c7137df799d1c90b6fade9e5919c215c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "httpie",
  "version": "3.2.4",
  "repository": "https://github.com/httpie/cli.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.