### PR TITLE
feat(remake): add package

### DIFF
--- a/packages/remake/brioche.lock
+++ b/packages/remake/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/Trepan-Debuggers/remake/releases/download/remake-4.3+dbg-1.6/remake-4.3+dbg-1.6.tar.gz": {
+      "type": "sha256",
+      "value": "f6a0c6179cd92524ad5dd04787477c0cd45afb5822d977be93d083b810647b87"
+    }
+  }
+}

--- a/packages/remake/project.bri
+++ b/packages/remake/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+
+export const project = {
+  name: "remake",
+  version: "4.3+dbg-1.6",
+  repository: "https://github.com/Trepan-Debuggers/remake",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/remake-${project.version}/remake-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function remake(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/remake"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    remake --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(remake)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `GNU Make ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^remake-(?<version>.+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `remake`
- **Website / repository:** `https://github.com/Trepan-Debuggers/remake`
- **Repology URL:** `https://repology.org/project/remake/versions`
- **Short description:** `GNU Make with comprehensible tracing and a debugger`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1080214
[1080214] GNU Make 4.3+dbg-1.6
[1080214] Built for aarch64-unknown-linux-gnu
[1080214] Copyright (C) 1988-2020 Free Software Foundation, Inc.
[1080214] Copyright (C) 2015, 2017 Rocky Bernstein.
[1080214] License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
[1080214] This is free software: you are free to change and redistribute it.
[1080214] There is NO WARRANTY, to the extent permitted by law.
Process 1080214 ran in 0.02s
Build finished, completed 1 job in 2.66s
Result: 9571f5d9fac9916ff3acdb12168fe9c4d10ddf639c2cc988d557a916efd53029
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1080301
Process 1080301 ran in 0.03s
Build finished, completed 1 job in 2.96s
Running brioche-run
{
  "name": "remake",
  "version": "4.3+dbg-1.6",
  "repository": "https://github.com/Trepan-Debuggers/remake"
}
```

</p>
</details>

## Implementation notes / special instructions

None.