### PR TITLE
feat(premake): add package

### DIFF
--- a/packages/premake/brioche.lock
+++ b/packages/premake/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/premake/premake-core/archive/refs/tags/v5.0.0-beta8.tar.gz": {
+      "type": "sha256",
+      "value": "2a55195fd2b27e5aa3de8ff6d22cdb127232a86f801d06e7f673d30a0eba09ac"
+    }
+  }
+}

--- a/packages/premake/project.bri
+++ b/packages/premake/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+
+export const project = {
+  name: "premake",
+  version: "5.0.0-beta8",
+  repository: "https://github.com/premake/premake-core",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  // Build reads git-tags.txt as fallback when git metadata is unavailable
+  .insert("git-tags.txt", std.file(`v${project.version}`));
+
+export default function premake(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -f Bootstrap.mak linux
+
+    # Manual installation
+    cp bin/release/premake5 "$BRIOCHE_OUTPUT/bin/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/premake5"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    premake5 --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(premake())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `premake5 (Premake Build Script Generator) ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    includePrerelease: true,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `premake`
- **Website / repository:** `https://github.com/premake/premake-core`
- **Repology URL:** `https://repology.org/project/premake/versions`
- **Short description:** `A build script generator that produces project files for Visual Studio, GNU Make, Xcode, and more using Lua-based configuration scripts`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.64s
Result: 89e5491c20d18f85327bf3c85e916d2cd8c7dde64b2ae4ccbd24f7253b332527
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.21s
Running brioche-run
{
  "name": "premake",
  "version": "5.0.0-beta8",
  "repository": "https://github.com/premake/premake-core"
}
```

</p>
</details>

## Implementation notes / special instructions

None.