### PR TITLE
feat(64tass): add package

### DIFF
--- a/packages/64tass/brioche.lock
+++ b/packages/64tass/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/tass64/source/64tass-1.60.3243-src.zip": {
+      "type": "sha256",
+      "value": "9d83be3d23a2c55e085b7c7a7856c2f96080447ea120a6a8c21a217ed76427f0"
+    }
+  }
+}

--- a/packages/64tass/project.bri
+++ b/packages/64tass/project.bri
@@ -1,0 +1,59 @@
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "64tass",
+  version: "1.60.3243",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/tass64/source/64tass-${project.version}-src.zip`,
+)
+  .unarchive("zip")
+  .peel();
+
+export default function _64tass(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install-strip prefix=/ DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/64tass"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    64tass --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(_64tass)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/tass64/files/source/
+      | lines
+      | where ($it | str contains '64tass-')
+      | parse --regex '64tass-(?<version>[\\d.]+)-src\\.zip'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `64tass`
- **Website / repository:** `https://sourceforge.net/projects/tass64`
- **Repology URL:** `https://repology.org/project/64tass/versions`
- **Short description:** `Cross assembler for the 6502 and related microprocessors`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 62173
[62173] 64tass Turbo Assembler Macro V1.60.3243
Process 62173 ran in 0.01s
Build finished, completed 1 job in 1.68s
Result: f588f6d103932a0e5aa9ac700c431b08762e8b34c27a69fdc2c4decac29ff595
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1080734
Process 1080734 ran in 0.01s
Build finished, completed 1 job in 4.39s
Running brioche-run
{
  "name": "64tass",
  "version": "1.60.3243"
}
```

</p>
</details>

## Implementation notes / special instructions

None.