### PR TITLE
feat(httpx): add package

### DIFF
--- a/packages/httpx/brioche.lock
+++ b/packages/httpx/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/projectdiscovery/httpx/@v/v1.9.0.zip": {
+      "type": "sha256",
+      "value": "05ab4b7acb6ea26f6afb2a4d46bfc1915982e2e8c5dae62d815e11533828bada"
+    }
+  }
+}

--- a/packages/httpx/project.bri
+++ b/packages/httpx/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "httpx",
+  version: "1.9.0",
+  extra: {
+    moduleName: "github.com/projectdiscovery/httpx",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function httpx(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    path: "./cmd/httpx",
+    runnable: "bin/httpx",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    httpx -version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httpx)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Current Version: v${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `httpx`
- **Website / repository:** `https://github.com/projectdiscovery/httpx`
- **Repology URL:** `https://repology.org/project/httpx/versions`
- **Short description:** `Fast and multi-purpose HTTP toolkit for running multiple probes and web reconnaissance`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.69s
Result: 7bb239ab30bab7c1ba8757b94b981a32ce1261b28b8137a40bf9765c619c301e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.33s
Running brioche-run
{
  "name": "httpx",
  "version": "1.9.0",
  "extra": {
    "moduleName": "github.com/projectdiscovery/httpx"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.