### PR TITLE
feat(http_prompt): add package

### DIFF
--- a/packages/http_prompt/brioche.lock
+++ b/packages/http_prompt/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/httpie/http-prompt": {
+      "v2.1.0": "7be6cfdbaac75a49ca01e46ab45b929934c51f18"
+    }
+  }
+}

--- a/packages/http_prompt/project.bri
+++ b/packages/http_prompt/project.bri
@@ -1,0 +1,68 @@
+import * as std from "std";
+import python, { getLatestVersion as getPythonVersion } from "python";
+import uv from "uv";
+
+export const project = {
+  name: "http_prompt",
+  version: "2.1.0",
+  repository: "https://github.com/httpie/http-prompt",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function httpPrompt(): std.Recipe<std.Directory> {
+  return std.runBash`
+    uv tool install .
+  `
+    .workDir(source)
+    .dependencies(python, uv)
+    .env({
+      UV_NO_MANAGED_PYTHON: "1",
+      UV_LINK_MODE: "copy",
+      UV_TOOL_DIR: std.outputPath,
+    })
+    .unsafe({ networking: true })
+    .toDirectory()
+    .pipe((recipe) => {
+      recipe = recipe.insert("brioche-run.d/python", python);
+
+      recipe = std.addRunnable(recipe, "bin/http-prompt", {
+        command: { relativePath: "brioche-run.d/python/bin/python" },
+        args: [{ relativePath: "http-prompt/bin/http-prompt" }],
+        env: {
+          PYTHONPATH: {
+            prepend: {
+              relativePath: `http-prompt/lib/python${getPythonVersion()}/site-packages`,
+            },
+            separator: ":",
+          },
+        },
+      });
+
+      return recipe;
+    })
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/http-prompt"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    http-prompt --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httpPrompt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `http_prompt`
- **Website / repository:** `https://github.com/httpie/http-prompt`
- **Repology URL:** `https://repology.org/project/http-prompt/versions`
- **Short description:** `An interactive command-line HTTP client featuring autocomplete and syntax highlighting, built on HTTPie and prompt_toolkit.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.99s
Result: b687b05c6adf851d65b347cde5cdcb0f54e7a6e68768989c158cd4dc57ddf46d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "http_prompt",
  "version": "2.1.0",
  "repository": "https://github.com/httpie/http-prompt"
}
```

</p>
</details>

## Implementation notes / special instructions

None.