### PR TITLE
feat(http_server): add package

### DIFF
--- a/packages/http_server/brioche.lock
+++ b/packages/http_server/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/http_server/project.bri
+++ b/packages/http_server/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "http_server",
+  version: "14.1.1",
+  extra: {
+    packageName: "http-server",
+  },
+};
+
+export default function httpServer(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/http-server"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    http-server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(httpServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `http_server`
- **Website / repository:** `https://github.com/http-party/http-server`
- **Repology URL:** `https://repology.org/project/http-server/versions`
- **Short description:** `A simple, zero-configuration, command-line HTTP server`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.34s
Result: ffbfb22c5e82e5cf08325a37e8caa78c47276e614cf3e72463a1a1d79edef5a1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "http_server",
  "version": "14.1.1",
  "extra": {
    "packageName": "http-server"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.