### PR TITLE
feat(ttfautohint): add package

### DIFF
--- a/packages/ttfautohint/brioche.lock
+++ b/packages/ttfautohint/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/freetype/ttfautohint/1.8.4/ttfautohint-1.8.4.tar.gz": {
+      "type": "sha256",
+      "value": "8a876117fa6ebfd2ffe1b3682a9a98c802c0f47189f57d3db4b99774206832e1"
+    }
+  }
+}

--- a/packages/ttfautohint/project.bri
+++ b/packages/ttfautohint/project.bri
@@ -1,0 +1,120 @@
+import brotli from "brotli";
+import cairo from "cairo";
+import cmake from "cmake";
+import fontconfig from "fontconfig";
+import freetype from "freetype";
+import glib from "glib";
+import graphite2 from "graphite2";
+import harfbuzz from "harfbuzz";
+import icu from "icu";
+import libffi from "libffi";
+import libpng from "libpng";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import libxrender from "libxrender";
+import lzo from "lzo";
+import ninja from "ninja";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import pcre2 from "pcre2";
+import pixman from "pixman";
+import python from "python";
+import * as std from "std";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "ttfautohint",
+  version: "1.8.4",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/freetype/ttfautohint/${project.version}/ttfautohint-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function ttfautohint(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --without-doc \\
+      --without-qt
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      freetype,
+      harfbuzz,
+      libpng,
+      // Transitive dependencies for freetype
+      brotli,
+      // Transitive dependencies for harfbuzz
+      cairo,
+      cmake,
+      fontconfig,
+      glib,
+      graphite2,
+      icu,
+      libffi,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      libxrender,
+      lzo,
+      ninja,
+      pcre2,
+      pixman,
+      python,
+      xorgproto,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ttfautohint"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ttfautohint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ttfautohint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ttfautohint ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/freetype/files/ttfautohint
+      | lines
+      | where ($it | str contains 'href="/projects/freetype/files/ttfautohint/') and (not ($it | str contains 'old-versions'))
+      | parse --regex '<a href="/projects/freetype/files/ttfautohint/(?<version>[\\d.]+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `ttfautohint`
- **Website / repository:** `https://freetype.org/ttfautohint/`
- **Repology URL:** `https://repology.org/project/ttfautohint/versions`
- **Short description:** `Free auto-hinter for TrueType fonts, built on FreeType's auto-hinting module`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 28.61s
Result: a5166b16ae0691b22417fa2a451e866f9964befffeb1fcdbd66f694cef2e0fb1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.73s
Running brioche-run
{
  "name": "ttfautohint",
  "version": "1.8.4"
}
```

</p>
</details>

## Implementation notes / special instructions

None.