### PR TITLE
chore(openssl): reduce build time by avoiding building tests and docs

### DIFF
--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -18,7 +18,9 @@ export default function openssl(): std.Recipe<std.Directory> {
     ./config \\
       --prefix=/ \\
       --openssldir=/etc/ssl \\
-      --libdir=lib
+      --libdir=lib \\
+      no-tests \\
+      no-docs
     make -j "$(nproc)"
     make install DESTDIR="$BRIOCHE_OUTPUT"
   `


### PR DESCRIPTION
Today I lost a lot of times by building again and agin this package which was in the dependencies chain of another one. As for now, we are not making use of the tests, nor of the documentation. If one day, we do need that, we could revert this modification, until then let's disable both to reduce the build time of this recipe.