### PR TITLE
feat(otfcc): add package

### DIFF
--- a/packages/otfcc/brioche.lock
+++ b/packages/otfcc/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/caryll/otfcc/archive/refs/tags/v0.10.4.tar.gz": {
+      "type": "sha256",
+      "value": "d9c74825ddac700eb429de31de7cb0a249636f47c6a4cc64eaa102a40966cf00"
+    }
+  }
+}

--- a/packages/otfcc/project.bri
+++ b/packages/otfcc/project.bri
@@ -1,0 +1,70 @@
+import * as std from "std";
+import premake from "premake";
+
+export const project = {
+  name: "otfcc",
+  version: "0.10.4",
+  repository: "https://github.com/caryll/otfcc",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // StaticRuntime was removed in modern premake5, and the toolchain gcc
+    // is built with --disable-multilib so -m64/-m32 flags are unavailable
+    std.runBash`
+      sed -i \\
+        -e 's/flags { "StaticRuntime" }/-- flags { "StaticRuntime" }/' \\
+        -e 's/platforms { "x64", "x86" }/-- platforms { "x64", "x86" }/' \\
+        -e '/filter "platforms:x86"/,/filter {}/d' \\
+        -e '/filter "platforms:x64"/,/filter {}/d' \\
+        "$BRIOCHE_OUTPUT/premake5.lua"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function otfcc(): std.Recipe<std.Directory> {
+  return std.runBash`
+    premake5 gmake
+    cd build/gmake
+    make config=release -j "$(nproc)"
+    cd ../..
+
+    # Manual installation
+    cp bin/release-/otfccdump "$BRIOCHE_OUTPUT/bin/"
+    cp bin/release-/otfccbuild "$BRIOCHE_OUTPUT/bin/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, premake)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/otfccdump"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    otfccdump --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(otfcc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `This is otfccdump, version ${project.version}.`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `otfcc`
- **Website / repository:** `https://github.com/caryll/otfcc`
- **Repology URL:** `https://repology.org/project/otfcc/versions`
- **Short description:** `Optimized OpenType builder and inspector that dumps fonts to JSON and back`

## Related issue(s) or discussion(s)

Depends on #3794 (premake package).

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.45s
Result: 0cdbb6d6455196712c7fc51ab8239a816674a468d88ea21486a92686d38ecff4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Running brioche-run
{
  "name": "otfcc",
  "version": "0.10.4",
  "repository": "https://github.com/caryll/otfcc"
}
```

</p>
</details>

## Implementation notes / special instructions

None.