### PR TITLE
feat(console_bridge): add package

### DIFF
--- a/packages/console_bridge/brioche.lock
+++ b/packages/console_bridge/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/ros/console_bridge.git": {
+      "1.0.2": "0828d846f2d4940b4e2b5075c6c724991d0cd308"
+    }
+  }
+}

--- a/packages/console_bridge/project.bri
+++ b/packages/console_bridge/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "console_bridge",
+  version: "1.0.2",
+  repository: "https://github.com/ros/console_bridge",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: project.version,
+});
+
+export default function consoleBridge(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTING: "OFF",
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion console_bridge | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, consoleBridge)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `console_bridge`
- **Website / repository:** `https://github.com/ros/console_bridge`
- **Repology URL:** `https://repology.org/project/console_bridge/versions`
- **Short description:** `A ROS-independent logging utility for C++ that provides severity-level message logging (DEBUG, INFO, WARN, ERROR)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.01s
Result: ced054e67be617fcbdbb0ca09ea39eb380f90b63aa98f9351b5897ca0f597e3e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.92s
Running brioche-run
{
  "name": "console_bridge",
  "version": "1.0.2",
  "repository": "https://github.com/ros/console_bridge"
}
```

</p>
</details>

## Implementation notes / special instructions

None.