### PR TITLE
feat(urdfdom_headers): add package

### DIFF
--- a/packages/urdfdom_headers/brioche.lock
+++ b/packages/urdfdom_headers/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/ros/urdfdom_headers.git": {
+      "2.1.1": "ee0b58cf461eca22a408cb32f0b35d7d7e85d196"
+    }
+  }
+}

--- a/packages/urdfdom_headers/project.bri
+++ b/packages/urdfdom_headers/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "urdfdom_headers",
+  version: "2.1.1",
+  repository: "https://github.com/ros/urdfdom_headers.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function urdfdomHeaders(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion urdfdom_headers | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, urdfdomHeaders)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `urdfdom_headers`
- **Website / repository:** `https://github.com/ros/urdfdom_headers`
- **Repology URL:** `https://repology.org/project/urdfdom_headers/versions`
- **Short description:** `C++ headers providing core data structures for the Unified Robot Description Format (URDF)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.96s
Result: 5cddc986e2da4392415c5e543e3723f050c5633ef1c5ef4441d1891421d9017f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.88s
Running brioche-run
{
  "name": "urdfdom_headers",
  "version": "2.1.1",
  "repository": "https://github.com/ros/urdfdom_headers.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.