### PR TITLE
feat(noti): add package

### DIFF
--- a/packages/noti/brioche.lock
+++ b/packages/noti/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/variadico/noti.git": {
+      "3.8.0": "1245c69097d5e910dd50a6b5e1086676634400a5"
+    }
+  }
+}

--- a/packages/noti/project.bri
+++ b/packages/noti/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "noti",
+  version: "3.8.0",
+  repository: "https://github.com/variadico/noti.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function noti(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/noti",
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/variadico/noti/internal/command.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/noti",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    noti --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(noti)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `noti version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `noti`
- **Website / repository:** `https://github.com/variadico/noti`
- **Repology URL:** `https://repology.org/project/noti/versions`
- **Short description:** `Monitor a process and trigger a notification`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.72s
Result: 382632a267cce6262040d54f27dacf1ab3fd2884a7222f5405a8a48ffea4f16d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "noti",
  "version": "3.8.0",
  "repository": "https://github.com/variadico/noti.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.