### PR TITLE
feat(victoriametrics): add package

### DIFF
--- a/packages/victoriametrics/brioche.lock
+++ b/packages/victoriametrics/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/VictoriaMetrics/VictoriaMetrics.git": {
+      "v1.140.0": "33d524bf137e5fe7054fcdafa2d5db5ed2400d9f"
+    }
+  }
+}

--- a/packages/victoriametrics/project.bri
+++ b/packages/victoriametrics/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "victoriametrics",
+  version: "1.140.0",
+  repository: "https://github.com/VictoriaMetrics/VictoriaMetrics.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function victoriaMetrics(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${project.version}`,
+      ],
+    },
+    path: "./app/victoria-metrics",
+    runnable: "bin/victoria-metrics",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    victoria-metrics --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(victoriaMetrics)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `victoriametrics`
- **Website / repository:** `https://github.com/VictoriaMetrics/VictoriaMetrics`
- **Repology URL:** `https://repology.org/project/victoriametrics/versions`
- **Short description:** `Fast, cost-effective monitoring solution and time series database`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.73s
Result: 60b8f099efae747ec50d10a4128394b5f5e2b10fc14cc102cf991a70c74251d1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.34s
Running brioche-run
{
  "name": "victoriametrics",
  "version": "1.140.0",
  "repository": "https://github.com/VictoriaMetrics/VictoriaMetrics.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.