### PR TITLE
feat(conftest): add package

### DIFF
--- a/packages/conftest/brioche.lock
+++ b/packages/conftest/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/open-policy-agent/conftest/@v/v0.68.2.zip": {
+      "type": "sha256",
+      "value": "76f7335b9c2398a0c56895a957a088b69fa2cf3d3fbce12b209cf7ae55ce3072"
+    }
+  }
+}

--- a/packages/conftest/project.bri
+++ b/packages/conftest/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "conftest",
+  version: "0.68.2",
+  extra: {
+    moduleName: "github.com/open-policy-agent/conftest",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function conftest(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/internal/version.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/conftest",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    conftest --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(conftest)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Conftest: ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `conftest`
- **Website / repository:** `https://github.com/open-policy-agent/conftest`
- **Repology URL:** `https://repology.org/project/conftest/versions`
- **Short description:** `Test structured configuration data using Open Policy Agent`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.74s
Result: 1d6636b946988ef1d5ece6f50a954207f9266ef5296190013d26a0ec7947b157
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.10s
Running brioche-run
{
  "name": "conftest",
  "version": "0.68.2",
  "extra": {
    "moduleName": "github.com/open-policy-agent/conftest"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.