### PR TITLE
feat(spicedb): add package

### DIFF
--- a/packages/spicedb/brioche.lock
+++ b/packages/spicedb/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/authzed/spicedb/@v/v1.51.1.zip": {
+      "type": "sha256",
+      "value": "6929aef7cf7581864a3ca65da7e2498f19eb477525ee096522ef7bc4bae7a0d5"
+    }
+  }
+}

--- a/packages/spicedb/project.bri
+++ b/packages/spicedb/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "spicedb",
+  version: "1.51.1",
+  repository: "https://github.com/authzed/spicedb",
+  extra: {
+    moduleName: "github.com/authzed/spicedb",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function spicedb(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/spicedb",
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/jzelinskie/cobrautil/v2.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/spicedb",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    spicedb version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(spicedb)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `spicedb ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `spicedb`
- **Website / repository:** https://github.com/authzed/spicedb
- **Repology URL:** https://repology.org/project/spicedb/versions
- **Short description:** `Open source, Google Zanzibar-inspired database for scalably storing and querying fine-grained authorization data`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.64s
Result: 52e85bd73ed8cfeec84f63d737d632195ddc8be28e6c92bfb2e0a556d56e5347
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.17s
Running brioche-run
{
  "name": "spicedb",
  "version": "1.51.1",
  "repository": "https://github.com/authzed/spicedb",
  "extra": {
    "moduleName": "github.com/authzed/spicedb"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.