### PR TITLE
feat(pvetui): add package

### DIFF
--- a/packages/highs/project.bri
+++ b/packages/highs/project.bri
@@ -44,7 +44,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const expected = `HiGHS version ${project.version}`;
   std.assert(
     result.includes(expected),
-    `expected '${expected}' in '${result}'`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/munge/project.bri
+++ b/packages/munge/project.bri
@@ -53,7 +53,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const expectedVersion = `munge-${project.version}`;
   std.assert(
     result.startsWith(expectedVersion),
-    `expected '${expectedVersion}' in '${result}'`,
+    `expected '${expectedVersion}', got '${result}'`,
   );
 
   return script;

--- a/packages/pvetui/brioche.lock
+++ b/packages/pvetui/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/devnullvoid/pvetui/@v/v1.3.1.info": {
+      "type": "sha256",
+      "value": "2543e6b24d7a35bd5ec6fd12c9b3d94a3d689a721ebffb7299f5a056884192b4"
+    },
+    "https://proxy.golang.org/github.com/devnullvoid/pvetui/@v/v1.3.1.zip": {
+      "type": "sha256",
+      "value": "32ab1ec9bbff73e63fe178bb902b57e8b32cd7a8c65bd7b0cf815e37eace2616"
+    }
+  }
+}

--- a/packages/pvetui/project.bri
+++ b/packages/pvetui/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "pvetui",
+  version: "1.3.1",
+  extra: {
+    moduleName: "github.com/devnullvoid/pvetui",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function pvetui(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/pvetui",
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/internal/version.version=${project.version}`,
+        "-X",
+        `${project.extra.moduleName}/internal/version.commit=${manifest.origin.hash}`,
+        "-X",
+        `${project.extra.moduleName}/internal/version.buildDate=${manifest.time}`,
+      ],
+    },
+    runnable: "bin/pvetui",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pvetui --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pvetui)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `pvetui version v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pvetui`
- **Website / repository:** `https://github.com/devnullvoid/pvetui`
- **Repology URL:** `https://repology.org/project/pvetui/versions`
- **Short description:** `Terminal UI for managing Proxmox VE servers and clusters`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.66s
Result: 6c08fde79824d56a1313bd4d240a7553222caaf3e985cb5abd479df0bf8f86c0
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.48s
Running brioche-run
{
  "name": "pvetui",
  "version": "1.3.1",
  "extra": {
    "moduleName": "github.com/devnullvoid/pvetui"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.