### PR TITLE
feat(inih): add package

### DIFF
--- a/packages/inih/brioche.lock
+++ b/packages/inih/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/benhoyt/inih/archive/refs/tags/r62.tar.gz": {
+      "type": "sha256",
+      "value": "9c15fa751bb8093d042dae1b9f125eb45198c32c6704cd5481ccde460d4f8151"
+    }
+  }
+}

--- a/packages/inih/project.bri
+++ b/packages/inih/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "inih",
+  version: "62",
+  repository: "https://github.com/benhoyt/inih",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/r${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function inih(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      tests: "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion inih | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, inih)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^r(?<version>\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `inih`
- **Website / repository:** `https://github.com/benhoyt/inih`
- **Repology URL:** `https://repology.org/project/inih/versions`
- **Short description:** `Simple .INI file parser written in C, good for embedded systems`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.89s
Result: 57568e5a2edb45ab20f0126d18235f269ec03d62451d86bfcaff6a2aa6bc68e3
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.33s
Running brioche-run
{
  "name": "inih",
  "version": "62",
  "repository": "https://github.com/benhoyt/inih"
}
```

</p>
</details>

## Implementation notes / special instructions

None.