### PR TITLE
feat(libcanberra): add package

### DIFF
--- a/packages/libcanberra/brioche.lock
+++ b/packages/libcanberra/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz": {
+      "type": "sha256",
+      "value": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+    }
+  }
+}

--- a/packages/libcanberra/project.bri
+++ b/packages/libcanberra/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libogg from "libogg";
+import libvorbis from "libvorbis";
+
+export const project = {
+  name: "libcanberra",
+  version: "0.30",
+};
+
+const source = Brioche.download(
+  `http://0pointer.de/lennart/projects/libcanberra/libcanberra-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libcanberra(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libogg, libvorbis)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libcanberra | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libcanberra)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get http://0pointer.de/lennart/projects/libcanberra/
+      | lines
+      | where ($it | str contains 'libcanberra-') and ($it | str contains '.tar.')
+      | parse --regex 'libcanberra-(?<version>[\\d.]+)\\.tar'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libcanberra`
- **Website / repository:** `http://0pointer.de/lennart/projects/libcanberra/`
- **Repology URL:** `https://repology.org/project/libcanberra/versions`
- **Short description:** `Implementation of the XDG Sound Theme and Name Specifications for generating event sounds on free desktops`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.27s
Result: 9a5b6b1e359c89dae83668e38ff6348e1bf4487d4f639550587a6815f25aac81
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.42s
Running brioche-run
{
  "name": "libcanberra",
  "version": "0.30"
}
```

</p>
</details>

## Implementation notes / special instructions

None.