### PR TITLE
feat(liblockfile): add package

### DIFF
--- a/packages/liblockfile/brioche.lock
+++ b/packages/liblockfile/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/miquels/liblockfile": {
+      "v1.17": "9389848f70d5b1f242ffffe1ebf7865011f9026f"
+    }
+  }
+}

--- a/packages/liblockfile/project.bri
+++ b/packages/liblockfile/project.bri
@@ -1,0 +1,78 @@
+import * as std from "std";
+
+export const project = {
+  name: "liblockfile",
+  version: "1.17",
+  repository: "https://github.com/miquels/liblockfile",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+}).pipe((source) =>
+  // Drop -g root flags and guard empty @LDCONFIG@ substitution
+  std.runBash`
+    sed -i 's/-g root//g; s/-g $(MAILGROUP) -m 2755/-m 755/g' "$BRIOCHE_OUTPUT/Makefile.in"
+    sed -i 's/@LDCONFIG@/true/' "$BRIOCHE_OUTPUT/Makefile.in"
+  `
+    .dependencies(std.toolchain)
+    .outputScaffold(source)
+    .toDirectory(),
+);
+
+export default function liblockfile(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install_shared install_common DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <lockfile.h>
+
+      int main(void)
+      {
+          printf("ok");
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -llockfile -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, liblockfile)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `liblockfile`
- **Website / repository:** `https://github.com/miquels/liblockfile`
- **Repology URL:** `https://repology.org/project/liblockfile/versions`
- **Short description:** `NFS-safe locking library and dotlockfile CLI tool`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 143968
[143968] ok
Process 143968 ran in 0.07s
Build finished, completed 1 job in 1.43s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.22s
Running brioche-run
{
  "name": "liblockfile",
  "version": "1.17",
  "repository": "https://github.com/miquels/liblockfile"
}
```

</p>
</details>

## Implementation notes / special instructions

None.