### PR TITLE
feat(imlib2): add package

### DIFF
--- a/packages/imlib2/brioche.lock
+++ b/packages/imlib2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.12.6/imlib2-1.12.6.tar.xz": {
+      "type": "sha256",
+      "value": "250f9752f69dc522e529a81aaa9395705f7fc312ff2453e5de59ac2ba1f2858f"
+    }
+  }
+}

--- a/packages/imlib2/project.bri
+++ b/packages/imlib2/project.bri
@@ -1,0 +1,102 @@
+import brotli from "brotli";
+import freetype from "freetype";
+import giflib from "giflib";
+import lerc from "lerc";
+import libdeflate from "libdeflate";
+import libjpegTurbo from "libjpeg_turbo";
+import libpng from "libpng";
+import libtiff from "libtiff";
+import libx11 from "libx11";
+import libxau from "libxau";
+import libxcb from "libxcb";
+import libxext from "libxext";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import xorgproto from "xorgproto";
+import * as std from "std";
+
+export const project = {
+  name: "imlib2",
+  version: "1.12.6",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/enlightenment/imlib2-src/${project.version}/imlib2-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function imlib2(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-amd64 \\
+      --without-heif \\
+      --without-id3 \\
+      --without-j2k \\
+      --without-jxl \\
+      --without-ps \\
+      --without-svg \\
+      --without-webp
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      brotli,
+      freetype,
+      giflib,
+      lerc,
+      libdeflate,
+      libjpegTurbo,
+      libpng,
+      libtiff,
+      libx11,
+      libxau,
+      libxcb,
+      libxext,
+      xorgproto,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion imlib2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, imlib2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/enlightenment/files/imlib2-src
+      | lines
+      | where ($it | str contains 'href="/projects/enlightenment/files/imlib2-src/')
+      | parse --regex '<a href="/projects/enlightenment/files/imlib2-src/(?<version>[\\d.]+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `imlib2`
- **Website / repository:** `https://sourceforge.net/projects/enlightenment/files/imlib2-src/`
- **Repology URL:** `https://repology.org/project/imlib2/versions`
- **Short description:** `Image loading, rendering, and manipulation library with X11 support`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.58s
Result: b41b17064b6d36de8b26ed6f5fd97b289897220a370c3ceef3d2e989aa754fc7
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.52s
Running brioche-run
{
  "name": "imlib2",
  "version": "1.12.6"
}
```

</p>
</details>

## Implementation notes / special instructions

None.