### PR TITLE
feat(liblc3): add package

### DIFF
--- a/packages/liblc3/brioche.lock
+++ b/packages/liblc3/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/google/liblc3/archive/refs/tags/v1.1.3.tar.gz": {
+      "type": "sha256",
+      "value": "276752ff54ce6a77d54ec133397b9d7e71f90caf3d9afa32d8b0e891b8ecb8af"
+    }
+  }
+}

--- a/packages/liblc3/project.bri
+++ b/packages/liblc3/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "liblc3",
+  version: "1.1.3",
+  repository: "https://github.com/google/liblc3",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function liblc3(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      tools: "true",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lc3 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, liblc3)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `liblc3`
- **Website / repository:** `https://github.com/google/liblc3`
- **Repology URL:** `https://repology.org/project/liblc3/versions`
- **Short description:** `LC3 (Low Complexity Communication Codec) audio codec library from Google, specified by the Bluetooth SIG for LE Audio`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.85s
Result: 12bac94445cf0841f415a0da808f366f25756547a6ba4be590fb1b35aa6272c3
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.24s
Running brioche-run
{
  "name": "liblc3",
  "version": "1.1.3",
  "repository": "https://github.com/google/liblc3"
}
```

</p>
</details>

## Implementation notes / special instructions

None.