### PR TITLE
feat(libcaption): add package

### DIFF
--- a/packages/libcaption/brioche.lock
+++ b/packages/libcaption/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/szatmary/libcaption.git": {
+      "v0.8": "e8b6261090eb3f2012427cc6b151c923f82453db"
+    }
+  }
+}

--- a/packages/libcaption/project.bri
+++ b/packages/libcaption/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libcaption",
+  version: "0.8",
+  repository: "https://github.com/szatmary/libcaption",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: `v${project.version}`,
+  options: {
+    submodules: true,
+  },
+});
+
+export default function libcaption(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_EXAMPLES: "OFF",
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <caption/caption.h>
+
+      int main(void)
+      {
+          caption_frame_t frame;
+          caption_frame_init(&frame);
+          printf("ok");
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -lcaption -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, libcaption)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libcaption`
- **Website / repository:** `https://github.com/szatmary/libcaption`
- **Repology URL:** `https://repology.org/project/libcaption/versions`
- **Short description:** `Free open-source CEA-608 / CEA-708 closed-caption encoder/decoder`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 144674
[144674] ok
Process 144674 ran in 0.12s
Build finished, completed 1 job in 2.77s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.73s
Running brioche-run
{
  "name": "libcaption",
  "version": "0.8",
  "repository": "https://github.com/szatmary/libcaption"
}
```

</p>
</details>

## Implementation notes / special instructions

None.