### PR TITLE
feat(libreplaygain): add package

### DIFF
--- a/packages/avfs/project.bri
+++ b/packages/avfs/project.bri
@@ -8,7 +8,6 @@ import * as std from "std";
 export const project = {
   name: "avfs",
   version: "1.3.0",
-  repository: "https://sourceforge.net/projects/avf",
 };
 
 const source = Brioche.download(

--- a/packages/giflib/project.bri
+++ b/packages/giflib/project.bri
@@ -4,7 +4,6 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "giflib",
   version: "5.2.2",
-  repository: "https://sourceforge.net/projects/giflib",
 };
 
 const source = Brioche.download(

--- a/packages/libreplaygain/brioche.lock
+++ b/packages/libreplaygain/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://files.musepack.net/source/libreplaygain_r475.tar.gz": {
+      "type": "sha256",
+      "value": "8258bf785547ac2cda43bb195e07522f0a3682f55abe97753c974609ec232482"
+    }
+  }
+}

--- a/packages/libreplaygain/project.bri
+++ b/packages/libreplaygain/project.bri
@@ -1,0 +1,88 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "libreplaygain",
+  version: "r475",
+};
+
+const source = Brioche.download(
+  `https://files.musepack.net/source/libreplaygain_${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Add missing header installation
+    std.runBash`
+      sed -i '/install(TARGETS/a\\install(DIRECTORY \${libreplaygain_SOURCE_DIR}/include/replaygain DESTINATION include)' "$BRIOCHE_OUTPUT/src/CMakeLists.txt"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function libreplaygain(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <replaygain/gain_analysis.h>
+
+      int main(void)
+      {
+          int result = gain_init_analysis(44100);
+          printf("%d", result);
+          return 0;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -lreplaygain -lm -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, libreplaygain)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "1";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.musepack.net/index.php?pg=src
+      | lines
+      | where ($it | str contains 'libreplaygain')
+      | parse --regex 'libreplaygain[._-](?<version>r\\d+)\\.t'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}

--- a/packages/xlslib/project.bri
+++ b/packages/xlslib/project.bri
@@ -4,7 +4,6 @@ import { nushellRunnable, type NushellRunnable } from "nushell";
 export const project = {
   name: "xlslib",
   version: "2.5.0",
-  repository: "https://sourceforge.net/projects/xlslib",
 };
 
 const source = std.castToDirectory(


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libreplaygain`
- **Website / repository:** `https://www.musepack.net/`
- **Repology URL:** `https://repology.org/project/libreplaygain/versions`
- **Short description:** `Library to implement the ReplayGain standard for audio`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.16s
Result: 434956d6017ce7690b60a61ba74d87b4303a9f10dd2a09aa7d52d5e37ffd8ff8
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 6.55s
Running brioche-run
{
  "name": "libreplaygain",
  "version": "r475"
}
```

</p>
</details>

## Implementation notes / special instructions

None.