### PR TITLE
feat(libunibreak): add package

### DIFF
--- a/packages/libunibreak/brioche.lock
+++ b/packages/libunibreak/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/adah1972/libunibreak/releases/download/libunibreak_7_0/libunibreak-7.0.tar.gz": {
+      "type": "sha256",
+      "value": "8c9a6e121736cd0d5c890ae3ae96f3f4010a19aa040f1dbded833a62a87717d3"
+    }
+  }
+}

--- a/packages/libunibreak/project.bri
+++ b/packages/libunibreak/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+
+export const project = {
+  name: "libunibreak",
+  version: "7.0",
+  repository: "https://github.com/adah1972/libunibreak",
+  extra: {
+    versionUnderscore: "7_0",
+  },
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/libunibreak_${project.extra.versionUnderscore}/libunibreak-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libunibreak(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libunibreak | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libunibreak)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^libunibreak_(?<version>\d+[._]\d+)$/,
+    normalizeVersion: true,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libunibreak`
- **Website / repository:** `https://github.com/adah1972/libunibreak`
- **Repology URL:** `https://repology.org/project/libunibreak/versions`
- **Short description:** `C library implementing the line breaking and word/grapheme breaking algorithms per Unicode Standard Annexes 14 and 29`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 445776
[445776] 7.0
Process 445776 ran in 0.04s
Build finished, completed 1 job in 1.51s
Result: 8691804952409cce536383a58eb4ae2d0c1cd1c8d77883836e41ca8e69e0d1b2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.52s
Running brioche-run
{
  "name": "libunibreak",
  "version": "7.0",
  "repository": "https://github.com/adah1972/libunibreak",
  "extra": {
    "versionUnderscore": "7_0"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.