### PR TITLE
feat(libcuefile): add package

### DIFF
--- a/packages/libcuefile/brioche.lock
+++ b/packages/libcuefile/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://files.musepack.net/source/libcuefile_r475.tar.gz": {
+      "type": "sha256",
+      "value": "b681ca6772b3f64010d24de57361faecf426ee6182f5969fcf29b3f649133fe7"
+    }
+  }
+}

--- a/packages/libcuefile/project.bri
+++ b/packages/libcuefile/project.bri
@@ -1,0 +1,87 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "libcuefile",
+  version: "r475",
+};
+
+const source = Brioche.download(
+  `https://files.musepack.net/source/libcuefile_${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Add missing header installation
+    std.runBash`
+      sed -i '/install(TARGETS/a\\install(DIRECTORY \${libcuefile_SOURCE_DIR}/include/cuetools DESTINATION include)' "$BRIOCHE_OUTPUT/src/CMakeLists.txt"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function libcuefile(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <cuetools/cuefile.h>
+
+      int main(void)
+      {
+          printf("ok");
+          return 0;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -lcuefile -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, libcuefile)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://www.musepack.net/index.php?pg=src
+      | lines
+      | where ($it | str contains 'libcuefile')
+      | parse --regex 'libcuefile[._-](?<version>r\\d+)\\.t'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libcuefile`
- **Website / repository:** `https://www.musepack.net/`
- **Repology URL:** `https://repology.org/project/libcuefile/versions`
- **Short description:** Library to work with CUE sheet and TOC files (from the Musepack project)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.85s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.66s
Running brioche-run
{
  "name": "libcuefile",
  "version": "r475"
}
```

</p>
</details>

## Implementation notes / special instructions

None.