### PR TITLE
feat(fdk_aac): add package

### DIFF
--- a/packages/fdk_aac/brioche.lock
+++ b/packages/fdk_aac/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-2.0.3.tar.gz": {
+      "type": "sha256",
+      "value": "829b6b89eef382409cda6857fd82af84fabb63417b08ede9ea7a553f811cb79e"
+    }
+  }
+}

--- a/packages/fdk_aac/project.bri
+++ b/packages/fdk_aac/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+
+export const project = {
+  name: "fdk_aac",
+  version: "2.0.3",
+  repository: "https://github.com/mstorsjo/fdk-aac",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function fdkAac(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared \\
+      --enable-static
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion fdk-aac | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, fdkAac)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `fdk_aac`
- **Website / repository:** `https://github.com/mstorsjo/fdk-aac`
- **Repology URL:** `https://repology.org/project/fdk-aac/versions`
- **Short description:** A standalone library of the Fraunhofer FDK AAC code from Android, providing AAC audio encoding and decoding.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 483515
[483515] 2.0.3
Process 483515 ran in 0.01s
Build finished, completed 1 job in 1.63s
Result: b0b4ebe971341fb3b2df67e4a952c095039dd9967e27276768bbf6e66f15420a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.37s
Running brioche-run
{
  "name": "fdk_aac",
  "version": "2.0.3",
  "repository": "https://github.com/mstorsjo/fdk-aac"
}
```

</p>
</details>

## Implementation notes / special instructions

None.