### PR TITLE
feat(faad2): add package

### DIFF
--- a/packages/faad2/brioche.lock
+++ b/packages/faad2/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/knik0/faad2.git": {
+      "2.11.2": "673a22a3c7c33e96e2ff7aae7c4d2bc190dfbf92"
+    }
+  }
+}

--- a/packages/faad2/project.bri
+++ b/packages/faad2/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "faad2",
+  version: "2.11.2",
+  repository: "https://github.com/knik0/faad2",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: project.version,
+});
+
+export default function faad2(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    runnable: "bin/faad",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion faad2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, faad2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `faad2`
- **Website / repository:** `https://github.com/knik0/faad2`
- **Repology URL:** `https://repology.org/project/faad2/versions`
- **Short description:** `Freeware Advanced Audio (AAC) Decoder (MPEG-2 and MPEG-4 AAC decoder library and CLI frontend)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.80s
Result: 81c009a52a56f31b01df17b949e0212af0e97415dd5694240308a3e9a96da80e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 5.50s
Running brioche-run
{
  "name": "faad2",
  "version": "2.11.2",
  "repository": "https://github.com/knik0/faad2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.