### PR TITLE
feat(usrsctp): add package

### DIFF
--- a/packages/usrsctp/brioche.lock
+++ b/packages/usrsctp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sctplab/usrsctp.git": {
+      "0.9.5.0": "07f871bda23943c43c9e74cc54f25130459de830"
+    }
+  }
+}

--- a/packages/usrsctp/project.bri
+++ b/packages/usrsctp/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "usrsctp",
+  version: "0.9.5.0",
+  repository: "https://github.com/sctplab/usrsctp.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function usrsctp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      sctp_build_programs: "OFF",
+      sctp_debug: "OFF",
+      sctp_build_shared_lib: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion usrsctp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, usrsctp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^(?<version>\d+\.\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `usrsctp`
- **Website / repository:** `https://github.com/sctplab/usrsctp`
- **Repology URL:** `https://repology.org/project/usrsctp/versions`
- **Short description:** A portable SCTP userland stack supporting FreeBSD, OpenBSD, Linux, Mac OS X and Windows.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 483933
[483933] 0.9.5.0
Process 483933 ran in 0.03s
Build finished, completed 1 job in 2.65s
Result: bd583473bbfb38945fb41619e0bc18cc5888013a5bb6307dac2df19a1373ac10
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.79s
Running brioche-run
{
  "name": "usrsctp",
  "version": "0.9.5.0",
  "repository": "https://github.com/sctplab/usrsctp.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.