### PR TITLE
feat(srt): add package

### DIFF
--- a/packages/srt/brioche.lock
+++ b/packages/srt/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Haivision/srt.git": {
+      "v1.5.4": "a8c6b65520f814c5bd8f801be48c33ceece7c4a6"
+    }
+  }
+}

--- a/packages/srt/project.bri
+++ b/packages/srt/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import openssl from "openssl";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "srt",
+  version: "1.5.4",
+  repository: "https://github.com/Haivision/srt",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: `v${project.version}`,
+});
+
+export default function srt(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, openssl],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      ENABLE_APPS: "ON",
+      ENABLE_TESTING: "OFF",
+      ENABLE_UNITTESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion srt | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, srt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `srt`
- **Website / repository:** `https://github.com/Haivision/srt`
- **Repology URL:** `https://repology.org/project/srt/versions`
- **Short description:** `Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the internet.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 484152
[484152] 1.5.4
Process 484152 ran in 0.02s
Build finished, completed 1 job in 2.65s
Result: f15abcc4d150214c697ed89fc601febe272cdbcd1ac20abf87c818249aebe994
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.60s
Running brioche-run
{
  "name": "srt",
  "version": "1.5.4",
  "repository": "https://github.com/Haivision/srt"
}
```

</p>
</details>

## Implementation notes / special instructions

None.