### PR TITLE
feat(faac): add package

### DIFF
--- a/packages/faac/brioche.lock
+++ b/packages/faac/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/knik0/faac": {
+      "faac-1.50": "79329efee51c9d3545bc4c7179b43a23fe350b6b"
+    }
+  }
+}

--- a/packages/faac/project.bri
+++ b/packages/faac/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "faac",
+  version: "1.50",
+  repository: "https://github.com/knik0/faac",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `faac-${project.version}`,
+});
+
+export default function faac(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    runnable: "bin/faac",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion faac | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, faac)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^faac-(?<version>\d+\.\d+(?:\.\d+)?)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `faac`
- **Website / repository:** `https://github.com/knik0/faac`
- **Repology URL:** `https://repology.org/project/faac/versions`
- **Short description:** `Freeware Advanced Audio Coder (FAAC) - an AAC audio encoder library and CLI tool`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.93s
Result: 84cb58cb6d5b38ed66c1ff486b42d48323d252bd9e5da4d752df92e7dd00819c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.78s
Running brioche-run
{
  "name": "faac",
  "version": "1.50",
  "repository": "https://github.com/knik0/faac"
}
```

</p>
</details>

## Implementation notes / special instructions

None.