### PR TITLE
feat(libshout): add package

### DIFF
--- a/packages/libshout/brioche.lock
+++ b/packages/libshout/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.xiph.org/releases/libshout/libshout-2.4.6.tar.gz": {
+      "type": "sha256",
+      "value": "39cbd4f0efdfddc9755d88217e47f8f2d7108fa767f9d58a2ba26a16d8f7c910"
+    }
+  }
+}

--- a/packages/libshout/project.bri
+++ b/packages/libshout/project.bri
@@ -1,0 +1,79 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import openssl from "openssl";
+import libogg from "libogg";
+import libvorbis from "libvorbis";
+import libtheora from "libtheora";
+import speex from "speex";
+
+export const project = {
+  name: "libshout",
+  version: "2.4.6",
+  repository: "https://github.com/xiph/Icecast-libshout",
+};
+
+const source = Brioche.download(
+  `https://downloads.xiph.org/releases/libshout/libshout-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libshout(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-openssl \\
+      --with-ogg \\
+      --with-vorbis \\
+      --with-theora \\
+      --with-speex
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, openssl, libogg, libvorbis, libtheora, speex)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/shout"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion shout | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libshout)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://downloads.xiph.org/releases/libshout/
+      | lines
+      | where ($it | str contains 'libshout-') and ($it | str contains '.tar.gz')
+      | parse --regex '<a href="libshout-(?<version>[\\d.]+)\\.tar\\.gz"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libshout`
- **Website / repository:** `https://github.com/xiph/Icecast-libshout`
- **Repology URL:** `https://repology.org/project/libshout/versions`
- **Short description:** `Library for communicating with and sending audio data to an Icecast streaming server`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 484577
[484577] 2.4.6
Process 484577 ran in 0.02s
Build finished, completed 1 job in 3.16s
Result: 1044f92cc2f01951b8a623214e7ac3255d3fa72144676bb83845600617bfcb51
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.55s
Running brioche-run
{
  "name": "libshout",
  "version": "2.4.6",
  "repository": "https://github.com/xiph/Icecast-libshout"
}
```

</p>
</details>

## Implementation notes / special instructions

None.