### PR TITLE
feat(opencore_amr): add package

### DIFF
--- a/packages/opencore_amr/brioche.lock
+++ b/packages/opencore_amr/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.6.tar.gz": {
+      "type": "sha256",
+      "value": "483eb4061088e2b34b358e47540b5d495a96cd468e361050fae615b1809dc4a1"
+    }
+  }
+}

--- a/packages/opencore_amr/project.bri
+++ b/packages/opencore_amr/project.bri
@@ -1,0 +1,68 @@
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "opencore_amr",
+  version: "0.1.6",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function opencoreAmr(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared \\
+      --enable-static
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion opencore-amrnb | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, opencoreAmr)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/opencore-amr/files/opencore-amr
+      | lines
+      | where ($it | str contains 'href="/projects/opencore-amr/files/opencore-amr/')
+      | parse --regex '<a href="/projects/opencore-amr/files/opencore-amr/(?:opencore-amr-)?(?<version>\\d[\\d.]*\\d)'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `opencore_amr`
- **Website / repository:** `https://sourceforge.net/projects/opencore-amr/`
- **Repology URL:** `https://repology.org/project/opencore-amr/versions`
- **Short description:** `OpenCORE Adaptive Multi Rate (AMR) speech codec library implementation (AMR-NB and AMR-WB)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 526787
[526787] 0.1.6
Process 526787 ran in 0.01s
Build finished, completed 1 job in 1.43s
Result: f5d32cf720e88f6c82320c28e7f16b78498d8b5d1c629df0f3072d65397b0079
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 526889
Process 526889 ran in 0.04s
Build finished, completed 1 job in 3.29s
Running brioche-run
{
  "name": "opencore_amr",
  "version": "0.1.6"
}
```

</p>
</details>

## Implementation notes / special instructions

None.