### PR TITLE
feat(svt_av1): add package

### DIFF
--- a/packages/svt_av1/brioche.lock
+++ b/packages/svt_av1/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v4.1.0/SVT-AV1-v4.1.0.tar.bz2": {
+      "type": "sha256",
+      "value": "184162d3db3a4448882b17230413b4938ca252eef6b3c5e2f1236b2fcf497881"
+    }
+  }
+}

--- a/packages/svt_av1/project.bri
+++ b/packages/svt_av1/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import nasm from "nasm";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "svt_av1",
+  version: "4.1.0",
+  repository: "https://gitlab.com/AOMediaCodec/SVT-AV1",
+};
+
+const source = Brioche.download(
+  `${project.repository}/-/archive/v${project.version}/SVT-AV1-v${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function svtAv1(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, nasm],
+    set: {
+      BUILD_TESTING: "OFF",
+      BUILD_APPS: "ON",
+    },
+    runnable: "bin/SvtAv1EncApp",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion SvtAv1Enc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, svtAv1)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `svt_av1`
- **Website / repository:** `https://gitlab.com/AOMediaCodec/SVT-AV1`
- **Repology URL:** `https://repology.org/project/svt-av1/versions`
- **Short description:** `AV1-compliant encoder library core (Scalable Video Technology for AV1)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.72s
Result: 03528a775a15e6a9a3d1f84a29052733505bcb268defadcc0aa7c4aacafc1c0f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.24s
Running brioche-run
{
  "name": "svt_av1",
  "version": "4.1.0",
  "repository": "https://gitlab.com/AOMediaCodec/SVT-AV1"
}
```

</p>
</details>

## Implementation notes / special instructions

None.