### PR TITLE
feat(pulseaudio): add package

### DIFF
--- a/packages/pulseaudio/brioche.lock
+++ b/packages/pulseaudio/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-17.0.tar.xz": {
+      "type": "sha256",
+      "value": "053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5"
+    }
+  }
+}

--- a/packages/pulseaudio/project.bri
+++ b/packages/pulseaudio/project.bri
@@ -1,0 +1,96 @@
+import * as std from "std";
+import alsaLib from "alsa_lib";
+import cmake from "cmake";
+import dbus from "dbus";
+import flac from "flac";
+import glib from "glib";
+import lame from "lame";
+import libcap from "libcap";
+import libogg from "libogg";
+import libsndfile from "libsndfile";
+import libvorbis from "libvorbis";
+import { mesonBuild } from "meson";
+import mpg123 from "mpg123";
+import ninja from "ninja";
+import openssl from "openssl";
+import opus from "opus";
+import orc from "orc";
+import pcre2 from "pcre2";
+import soxr from "soxr";
+import speexdsp from "speexdsp";
+
+export const project = {
+  name: "pulseaudio",
+  version: "17.0",
+  repository: "https://gitlab.freedesktop.org/pulseaudio/pulseaudio",
+};
+
+const source = Brioche.download(
+  `https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function pulseaudio(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      cmake,
+      ninja,
+      alsaLib,
+      dbus,
+      flac,
+      glib,
+      lame,
+      libcap,
+      libogg,
+      libsndfile,
+      libvorbis,
+      mpg123,
+      openssl,
+      opus,
+      orc,
+      pcre2,
+      soxr,
+      speexdsp,
+    ],
+    set: {
+      database: "simple",
+      doxygen: "false",
+      man: "false",
+      tests: "false",
+    },
+    runnable: "bin/pulseaudio",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libpulse | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, pulseaudio)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabTags({
+    gitlabUrl: "https://gitlab.freedesktop.org",
+    project,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pulseaudio`
- **Website / repository:** `https://gitlab.freedesktop.org/pulseaudio/pulseaudio`
- **Repology URL:** `https://repology.org/project/pulseaudio/versions`
- **Short description:** `PulseAudio sound server for POSIX operating systems`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 527276 in 1.09s
Launched process 527276
[527276] 17.0
Process 527276 ran in 0.04s
Build finished, completed 1 job in 5.67s
Result: 964eeac28c057dc6c319e1753b8025bd36863cc0095335109fb766917bc92663
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.31s
Running brioche-run
{
  "name": "pulseaudio",
  "version": "17.0",
  "repository": "https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
}
```

</p>
</details>

## Implementation notes / special instructions

None.