### PR TITLE
fix: resolve eslint 9 issues

### DIFF
--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -193,7 +193,8 @@ export function process(options: ProcessOptions): Process {
             await v.briocheSerialize(),
           ]),
         ),
-        Promise.all(dependencies.map(async (dep) => dep.briocheSerialize())),
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        Promise.all(dependencies.map((dep) => dep.briocheSerialize())),
       ]);
 
       return {
@@ -435,7 +436,8 @@ export class ProcessTemplate {
   briocheSerialize(): Promise<runtime.ProcessTemplate> {
     this.#serialized ??= (async () => {
       const components = await Promise.all(
-        this.components.map(async (component) =>
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        this.components.map((component) =>
           typeof component === "function" ? component() : component,
         ),
       );

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -430,6 +430,9 @@ export class ProcessTemplate {
   #serialized: Promise<runtime.ProcessTemplate> | undefined;
 
   constructor(...components: ProcessTemplateLike[]) {
+    // NOTE: Needed to silence warnings for ESLint in Brioche v0.1.7
+    // and earlier.
+    // eslint-disable-next-line
     this.components = components;
   }
 

--- a/packages/std/core/recipes/process.bri
+++ b/packages/std/core/recipes/process.bri
@@ -193,7 +193,7 @@ export function process(options: ProcessOptions): Process {
             await v.briocheSerialize(),
           ]),
         ),
-        Promise.all(dependencies.map((dep) => dep.briocheSerialize())),
+        Promise.all(dependencies.map(async (dep) => dep.briocheSerialize())),
       ]);
 
       return {
@@ -429,14 +429,13 @@ export class ProcessTemplate {
   #serialized: Promise<runtime.ProcessTemplate> | undefined;
 
   constructor(...components: ProcessTemplateLike[]) {
-    /* eslint-disable-next-line */
     this.components = components;
   }
 
   briocheSerialize(): Promise<runtime.ProcessTemplate> {
     this.#serialized ??= (async () => {
       const components = await Promise.all(
-        this.components.map((component) =>
+        this.components.map(async (component) =>
           typeof component === "function" ? component() : component,
         ),
       );

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -43,18 +43,16 @@ export function createProxy<T extends Artifact>(
   let serialized: Promise<runtime.ProxyRecipe> | undefined;
 
   const serializeProxy = async (): Promise<runtime.ProxyRecipe> => {
-    if (serialized === undefined) {
-      serialized = (async () => {
-        const recipeValue =
-          typeof recipe === "function" ? await recipe() : await recipe;
-        const serializedRecipe = await recipeValue.briocheSerialize();
-        const proxy = await runtime.createProxy(serializedRecipe);
-        return {
-          ...proxy,
-          meta: serializedRecipe.meta,
-        };
-      })();
-    }
+    serialized ??= (async () => {
+      const recipeValue =
+        typeof recipe === "function" ? await recipe() : await recipe;
+      const serializedRecipe = await recipeValue.briocheSerialize();
+      const proxy = await runtime.createProxy(serializedRecipe);
+      return {
+        ...proxy,
+        meta: serializedRecipe.meta,
+      };
+    })();
 
     return await serialized;
   };

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -25,7 +25,13 @@ export function autopack(
 
   const variableArgs: std.ProcessTemplateLike[] = Object.entries(
     variables,
-  ).flatMap(([name, value]) => ["--var", std.tpl`${name}=path:${value.value}`]);
+  ).flatMap(([name, value]) => {
+    switch (value.type) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      case "path":
+        return ["--var", std.tpl`${name}=path:${value.value}`];
+    }
+  });
 
   return std
     .process({

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -25,12 +25,7 @@ export function autopack(
 
   const variableArgs: std.ProcessTemplateLike[] = Object.entries(
     variables,
-  ).flatMap(([name, value]) => {
-    switch (value.type) {
-      case "path":
-        return ["--var", std.tpl`${name}=path:${value.value}`];
-    }
-  });
+  ).flatMap(([name, value]) => ["--var", std.tpl`${name}=path:${value.value}`]);
 
   return std
     .process({

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -342,7 +342,13 @@ function autopack(
 
   const variableArgs: std.ProcessTemplateLike[] = Object.entries(
     variables,
-  ).flatMap(([name, value]) => ["--var", std.tpl`${name}=path:${value.value}`]);
+  ).flatMap(([name, value]) => {
+    switch (value.type) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      case "path":
+        return ["--var", std.tpl`${name}=path:${value.value}`];
+    }
+  });
 
   return std
     .process({

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -342,12 +342,7 @@ function autopack(
 
   const variableArgs: std.ProcessTemplateLike[] = Object.entries(
     variables,
-  ).flatMap(([name, value]) => {
-    switch (value.type) {
-      case "path":
-        return ["--var", std.tpl`${name}=path:${value.value}`];
-    }
-  });
+  ).flatMap(([name, value]) => ["--var", std.tpl`${name}=path:${value.value}`]);
 
   return std
     .process({


### PR DESCRIPTION
Companion PR of https://github.com/brioche-dev/brioche/pull/452.

This PR resolves the following lints detected by ESLint 9:

```
[Warning] file:///tmp/brioche-packages/packages/std/toolchain/native/index.bri:347:12
Unnecessary conditional, comparison is always true, since `"path" === "path"` is true.

[Warning] file:///tmp/brioche-packages/packages/std/extra/autopack.bri:30:12
Unnecessary conditional, comparison is always true, since `"path" === "path"` is true.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/process.bri:196:21
Unexpected iterable of non-Promise (non-"Thenable") values passed to promise aggregator.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/process.bri:432:5
Unused eslint-disable directive (no problems were reported).

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/process.bri:439:9
Unexpected iterable of non-Promise (non-"Thenable") values passed to promise aggregator.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/proxy.bri:46:5
Prefer using nullish coalescing operator (`??=`) instead of an assignment expression, as it is simpler to read.
```