### PR TITLE
feat(libcaca): add package

### DIFF
--- a/packages/libcaca/brioche.lock
+++ b/packages/libcaca/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/cacalabs/libcaca/commit/00d5a26a131b2b91cead7588881fb4b41b6d9392.patch": {
+      "type": "sha256",
+      "value": "2b6ae97055989ae0dc336c6d474a760c9e06a7f9899518ab6cd759e7c5927502"
+    },
+    "https://github.com/cacalabs/libcaca/releases/download/v0.99.beta20/libcaca-0.99.beta20.tar.gz": {
+      "type": "sha256",
+      "value": "8ad74babc63bf665b0b2378d95b4da65b7493c11bd9f3ac600517085b0c4acf2"
+    }
+  }
+}

--- a/packages/libcaca/project.bri
+++ b/packages/libcaca/project.bri
@@ -1,0 +1,82 @@
+import imlib2 from "imlib2";
+import libx11 from "libx11";
+import * as std from "std";
+import xorgproto from "xorgproto";
+
+export const project = {
+  name: "libcaca",
+  version: "0.99.beta20",
+  repository: "https://github.com/cacalabs/libcaca",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libcaca-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Redefine `_caca_alloc2d` locally in `common-image.c` so `img2txt` and
+    // `cacaview` build without pulling the internal symbol from libcaca.
+    // https://github.com/cacalabs/libcaca/issues/59#issuecomment-3453490297
+    std.applyPatch({
+      source,
+      patch: Brioche.download(
+        `${project.repository}/commit/00d5a26a131b2b91cead7588881fb4b41b6d9392.patch`,
+      ),
+      strip: 1,
+    }),
+  );
+
+export default function libcaca(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-static \\
+      --disable-java \\
+      --disable-cxx \\
+      --disable-csharp \\
+      --disable-python \\
+      --disable-ruby \\
+      --disable-doc \\
+      --disable-slang \\
+      --disable-x11 \\
+      --disable-gl
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, imlib2, libx11, xorgproto)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion caca | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libcaca)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^v(?<version>\d+\.\d+\.\w+\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libcaca`
- **Website / repository:** `https://github.com/cacalabs/libcaca`
- **Repology URL:** `https://repology.org/project/libcaca/versions`
- **Short description:** Colour ASCII art library with text graphics rendering and image-to-text conversion.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/libcaca^test
Build finished, completed (no new jobs) in 8m21s
Result: a709a9683123712e9f24a6a3a2273b511ef0a3c5f967c475893f2fbb15799318
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/libcaca^liveUpdate
Build finished, completed (no new jobs) in 1m51s
Running brioche-run
{
  "name": "libcaca",
  "version": "0.99.beta20",
  "repository": "https://github.com/cacalabs/libcaca"
}
```

</p>
</details>

## Implementation notes / special instructions

None.