### PR TITLE
feat(libcacard): add package

### DIFF
--- a/packages/libcacard/brioche.lock
+++ b/packages/libcacard/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://gitlab.freedesktop.org/spice/libcacard": {
+      "v2.8.2": "df2d3c05a250741632184c2cc66df247039a70d7"
+    }
+  }
+}

--- a/packages/libcacard/project.bri
+++ b/packages/libcacard/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import glib from "glib";
+import libffi from "libffi";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import nspr from "nspr";
+import nss from "nss";
+import pcre2 from "pcre2";
+import pcscLite from "pcsc_lite";
+
+export const project = {
+  name: "libcacard",
+  version: "2.8.2",
+  repository: "https://gitlab.freedesktop.org/spice/libcacard",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+})
+  // The upstream meson.build derives the version from git via
+  // `build-aux/git-version-gen`, which falls back to a `.tarball-version`
+  // file when there is no git history. Ship one so the configure step
+  // works against the plain archive checkout.
+  .insert(".tarball-version", std.file(`${project.version}\n`));
+
+export default function libcacard(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      ninja,
+      glib,
+      libffi,
+      nspr,
+      nss,
+      pcre2,
+      pcscLite,
+    ],
+    set: {
+      default_library: "both",
+      disable_tests: "true",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libcacard | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libcacard)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({
+    gitlabUrl: "https://gitlab.freedesktop.org",
+    project,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libcacard`
- **Website / repository:** `https://gitlab.freedesktop.org/spice/libcacard`
- **Repology URL:** `https://repology.org/project/libcacard/versions`
- **Short description:** CAC (Common Access Card) library that provides emulation of smart cards to a virtual card reader running in a guest virtual machine.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 736568
[736568] 2.8.2
Process 736568 ran in 0.03s
Build finished, completed 1 job in 4.53s
Result: 7e6df5ea215da8626f53a30d0fea00db63a4f5f3de50d68a0037cb667775d051
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 8.63s
Running brioche-run
{
  "name": "libcacard",
  "version": "2.8.2",
  "repository": "https://gitlab.freedesktop.org/spice/libcacard"
}
```

</p>
</details>

## Implementation notes / special instructions

None.