### PR TITLE
Enable GCC NLS support

### DIFF
--- a/packages/ortp/brioche.lock
+++ b/packages/ortp/brioche.lock
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "git_refs": {
-    "https://gitlab.linphone.org/BC/public/ortp.git": {
+    "https://github.com/BelledonneCommunications/ortp.git": {
       "5.4.97": "298490d88d7e531631a69fde96b4856272feb378"
     }
   }

--- a/packages/ortp/project.bri
+++ b/packages/ortp/project.bri
@@ -5,7 +5,9 @@ import bctoolbox from "bctoolbox";
 export const project = {
   name: "ortp",
   version: "5.4.97",
-  repository: "https://gitlab.linphone.org/BC/public/ortp.git",
+  // Use the GitHub mirror instead of the official GitLab repository,
+  // the later seems to have network issues.
+  repository: "https://github.com/BelledonneCommunications/ortp.git",
 };
 
 const source = Brioche.gitCheckout({
@@ -53,8 +55,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGitlabTags({
-    gitlabUrl: "https://gitlab.linphone.org",
-    project,
-  });
+  return std.liveUpdateFromGithubTags({ project });
 }

--- a/packages/std/toolchain/native/gcc.bri
+++ b/packages/std/toolchain/native/gcc.bri
@@ -53,7 +53,6 @@ export default std.memo((): std.Recipe<std.Directory> => {
     }),
   );
 
-  // TODO: Enable NLS
   let gcc = std
     .process({
       command: std.tpl`${stage2}/bin/bash`,
@@ -70,7 +69,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
             --enable-languages=c,c++ \\
             --enable-default-pie \\
             --enable-default-ssp \\
-            --disable-nls \\
+            --enable-nls \\
             --disable-multilib \\
             --disable-bootstrap \\
             --disable-fixincludes \\
@@ -93,6 +92,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       ],
       env: {
         PATH: std.tpl`${buildSysroot}/bin:${stage2}/bin`,
+        GCONV_PATH: std.tpl`${buildSysroot}/lib/gconv`,
         CPPFLAGS: std.tpl`-I${zlib}/include -I${gmp}/include -I${mpfr}/include -I${mpc}/include -isystem ${stage2}/usr/lib/gcc/${platformInfo.arch}-lfs-linux-gnu/13.2.0/include -isystem ${buildSysroot}/include -isystem ${buildSysroot}/usr/include`,
         LDFLAGS: std.tpl`-L${zlib}/lib -L${gmp}/lib -L${mpfr}/lib -L${mpc}/lib -L${buildSysroot}/lib -L${buildSysroot}/lib64 -lm --sysroot=${buildSysroot}`,
         buildSysroot,

--- a/packages/std/toolchain/native/gettext.bri
+++ b/packages/std/toolchain/native/gettext.bri
@@ -1,5 +1,6 @@
 import * as std from "/core";
 import stage2 from "/toolchain/stage2";
+import glibc from "./glibc.bri";
 
 export default std.memo((): std.Recipe<std.Directory> => {
   const source = Brioche.download(
@@ -27,6 +28,7 @@ export default std.memo((): std.Recipe<std.Directory> => {
       env: {
         source,
         PATH: std.tpl`${stage2}/bin`,
+        GCONV_PATH: std.tpl`${glibc}/lib/gconv`,
       },
       workDir: source,
     })

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -245,6 +245,9 @@ export const toolchain = std.memo(
       ZLIB_ROOT: { fallback: { path: "." } },
       LIBLZMA_ROOT: { fallback: { path: "." } },
 
+      // glibc gconv modules for charset conversion (used by msgfmt, iconv, etc.)
+      GCONV_PATH: { fallback: { path: "lib/gconv" } },
+
       // Bison data dir
       BISON_PKGDATADIR: { fallback: { path: "share/bison" } },
 

--- a/packages/xkeyboard_config/project.bri
+++ b/packages/xkeyboard_config/project.bri
@@ -20,9 +20,6 @@ export default function xkeyboardConfig(): std.Recipe<std.Directory> {
   return mesonBuild({
     source,
     dependencies: [std.toolchain, ninja, python],
-    set: {
-      nls: "false",
-    },
   }).pipe((recipe) =>
     std.setEnv(recipe, {
       PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },


### PR DESCRIPTION
This PR enables Native Language Support (NLS) in the native GCC toolchain. Enabling NLS surfaced a latent bug: the native `gettext` was being built without `iconv()` support, breaking `msgfmt` for any package with non-UTF-8 `.po` files.

**During GCC toolchain build** (after flipping `--disable-nls` to `--enable-nls`):

```
msgfmt -o de.mo ../../../../libstdc++-v3/po/de.po
msgfmt: Cannot convert from "ISO-8859-1" to "UTF-8". msgfmt relies on iconv(). This version was built without iconv().
make[4]: *** [Makefile:564: de.mo] Error 1
```

**During `xkeyboard_config` build** (same root cause):

```
FAILED: [code=1] po/af/LC_MESSAGES/xkeyboard-config-2.mo
.../bin/msgfmt -o po/af/LC_MESSAGES/xkeyboard-config-2.mo ../po/af.po
.../bin/msgfmt: Cannot convert from "ISO-8859-1" to "UTF-8". msgfmt relies on iconv(). This version was built without iconv().
```

To be reviewed commit per commit:

- cccb304a: Root cause fix. Set `GCONV_PATH` during gettext's build so `configure` detects a working `iconv()` and `msgfmt` gets compiled with iconv support baked in.
- 86bb7486: Resolves the TODO: switch `--disable-nls` to `--enable-nls` and set `GCONV_PATH` so `msgfmt` can find gconv modules when compiling GCC's `.po` translation files.
- 943c614f: Expose `GCONV_PATH` via the toolchain's `setEnv` as a fallback, so downstream packages invoking `msgfmt` (meson's NLS handling, autotools, etc.) get charset conversion support automatically.
- cdbe7565: Drop the `nls: "false"` workaround now that the toolchain fix makes it unnecessary.

**Warning**: it will rebuild almost every recipe.