### PR TITLE
feat(nufmt): add package

### DIFF
--- a/packages/nufmt/brioche.lock
+++ b/packages/nufmt/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nushell/nufmt.git": {
+      "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d": "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d"
+    }
+  }
+}

--- a/packages/nufmt/brioche.lock
+++ b/packages/nufmt/brioche.lock
@@ -1,8 +1,3 @@
 {
-  "dependencies": {},
-  "git_refs": {
-    "https://github.com/nushell/nufmt.git": {
-      "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d": "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d"
-    }
-  }
+  "dependencies": {}
 }

--- a/packages/nufmt/project.bri
+++ b/packages/nufmt/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "nufmt",
+  version: "0.1.0",
+  repository: "https://github.com/nushell/nufmt.git",
+  extra: {
+    // No tags or releases published yet, pin to the latest commit.
+    gitRef: "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+});
+
+export default function nufmt(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/nufmt",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    nufmt --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nufmt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `nufmt ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let gitRef = ^git ls-remote ${project.repository} refs/heads/main
+      | lines
+      | parse --regex '(?<hash>[0-9a-f]+)\\s+'
+      | get 0.hash
+
+    let version = http get --raw $"https://raw.githubusercontent.com/nushell/nufmt/($gitRef)/Cargo.toml"
+      | lines
+      | where ($it | str starts-with 'version = ')
+      | first
+      | parse --regex 'version = "(?<version>[^"]+)"'
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}

--- a/packages/nufmt/project.bri
+++ b/packages/nufmt/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "nufmt",
+  version: "0.1.4",
+  repository: "https://github.com/nushell/nufmt.git",
+  extra: {
+    // No tags or releases published yet, pin to the latest commit.
+    gitRef: "a24c2b1bc7f573b1a8b2c4a453e989407a4d29c8",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+});
+
+export default function nufmt(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/nufmt",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    nufmt --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nufmt)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `nufmt ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let gitRef = ^git ls-remote ${project.repository} refs/heads/main
+      | lines
+      | parse --regex '(?<hash>[0-9a-f]+)\\s+'
+      | get 0.hash
+
+    let version = http get --raw $"https://raw.githubusercontent.com/nushell/nufmt/($gitRef)/Cargo.toml"
+      | lines
+      | where ($it | str starts-with 'version = ')
+      | first
+      | parse --regex 'version = "(?<version>[^"]+)"'
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `nufmt`
- **Website / repository:** `https://github.com/nushell/nufmt`
- **Repology URL:** `https://repology.org/project/nufmt/versions`
- **Short description:** `A code formatter for Nushell.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ cargo run -- build /tmp/brioche-packages/packages/nufmt^test
   Compiling brioche-core v0.1.7 (/workspaces/brioche/crates/brioche-core)
   Compiling brioche v0.1.7 (/workspaces/brioche/crates/brioche)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.03s
     Running `target/debug/brioche build '/tmp/brioche-packages/packages/nufmt^test'`
Build finished, completed 1 job in 4.64s
Result: bcea2857cada7fa8ec8c66f3bbc9d29b93c7ea33fa84812a558fbc60472ebd9b
90926  | nufmt 0.1.0
 0.03s  Process 90926
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
 0.04s  Process 739632
 1.50s  Cache     100% Fetch artifact: 2.1 MiB
 0.16s  Unarchive 100% Unarchive: 2.1 MiB
Build finished, completed 3 jobs in 13.74s
Running brioche-run
{
  "name": "nufmt",
  "version": "0.1.0",
  "repository": "https://github.com/nushell/nufmt.git",
  "extra": {
    "gitRef": "4a9e384cb13a3bf5e7a0094d7e4e21868b4f9c1d"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.