### PR TITLE
feat(packer): add package

### DIFF
--- a/packages/packer/brioche.lock
+++ b/packages/packer/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/hashicorp/packer/@v/v1.15.3.info": {
+      "type": "sha256",
+      "value": "715c0c06b489a994d770a76d9de99b93544adc656fb59d2e36f7d2f4eee6c15b"
+    },
+    "https://proxy.golang.org/github.com/hashicorp/packer/@v/v1.15.3.zip": {
+      "type": "sha256",
+      "value": "f86c5ae15a666a87d21adf3328a90261583d5d14780b5cb52f5d72a223a80fbb"
+    }
+  }
+}

--- a/packages/packer/project.bri
+++ b/packages/packer/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "packer",
+  version: "1.15.3",
+  extra: {
+    moduleName: "github.com/hashicorp/packer",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function packer(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/version.GitCommit=${manifest.origin.hash}`,
+      ],
+    },
+    runnable: "bin/packer",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    packer --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(packer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Packer v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `packer`
- **Website / repository:** `https://github.com/hashicorp/packer`
- **Repology URL:** `https://repology.org/project/packer/versions`
- **Short description:** `Tool for creating identical machine images for multiple platforms from a single source configuration`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.01s
Result: 52b64b6e64847f359892307e22cbbd82e2314e7f2e2634041b68a311840da42a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 971179
Process 971179 ran in 0.03s
Build finished, completed 1 job in 4.39s
Running brioche-run
{
  "name": "packer",
  "version": "1.15.3",
  "extra": {
    "moduleName": "github.com/hashicorp/packer"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.