### PR TITLE
feat(magic_enum): add package

### DIFF
--- a/packages/magic_enum/brioche.lock
+++ b/packages/magic_enum/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Neargye/magic_enum.git": {
+      "v0.9.8": "1384769c66bd16ec9bb1353f45fe8ec8ccc12dbd"
+    }
+  }
+}

--- a/packages/magic_enum/project.bri
+++ b/packages/magic_enum/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "magic_enum",
+  version: "0.9.8",
+  repository: "https://github.com/Neargye/magic_enum.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function magicEnum(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      MAGIC_ENUM_OPT_BUILD_EXAMPLES: "OFF",
+      MAGIC_ENUM_OPT_BUILD_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion magic_enum | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, magicEnum)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `magic_enum`
- **Website / repository:** `https://github.com/Neargye/magic_enum`
- **Repology URL:** `https://repology.org/project/magic-enum/versions`
- **Short description:** Header-only C++17 library providing static reflection for enums (to/from string, iteration) without macros or boilerplate.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 944805
[944805] 0.9.8
Process 944805 ran in 0.02s
Build finished, completed 1 job in 1.45s
Result: ab723956d6c5891ad5ac7e029bbede784ab1a09006636ec9cfbacdf200d0f8f4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 944910
Process 944910 ran in 0.01s
Build finished, completed 1 job in 3.34s
Running brioche-run
{
  "name": "magic_enum",
  "version": "0.9.8",
  "repository": "https://github.com/Neargye/magic_enum.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.