### PR TITLE
feat(ladybug): add package

### DIFF
--- a/packages/ladybug/brioche.lock
+++ b/packages/ladybug/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/LadybugDB/ladybug.git": {
+      "v0.16.1": "90f1da397116a3e916bd40f3bbbca17e393102ee"
+    }
+  }
+}

--- a/packages/ladybug/project.bri
+++ b/packages/ladybug/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import python from "python";
+
+export const project = {
+  name: "ladybug",
+  version: "0.16.1",
+  repository: "https://github.com/LadybugDB/ladybug.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function ladybug(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, python],
+    set: {
+      BUILD_SHELL: "ON",
+      BUILD_TESTS: "OFF",
+      BUILD_BENCHMARK: "OFF",
+      BUILD_EXAMPLES: "OFF",
+    },
+    runnable: "bin/lbug",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    lbug --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ladybug)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Lbug ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `ladybug`
- **Website / repository:** `https://github.com/LadybugDB/ladybug`
- **Repology URL:** `https://repology.org/project/ladybug/versions`
- **Short description:** Embedded graph database built for query speed and scalability (formerly Kuzu), with Cypher query language

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 971340
[971340] Lbug 0.16.1
Process 971340 ran in 0.13s
Build finished, completed 1 job in 4.46s
Result: 70ff3bee80368ffd44068cf71878a197e1a6532211eddff8a25d22bfc8d6c7df
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.75s
Running brioche-run
{
  "name": "ladybug",
  "version": "0.16.1",
  "repository": "https://github.com/LadybugDB/ladybug.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.