### PR TITLE
feat(safeint): add package

### DIFF
--- a/packages/safeint/brioche.lock
+++ b/packages/safeint/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28a.tar.gz": {
+      "type": "sha256",
+      "value": "9e652d065a3cef80623287d5dc61edcf6a95ddab38a9dfeb34f155261fc9cef7"
+    }
+  }
+}

--- a/packages/safeint/project.bri
+++ b/packages/safeint/project.bri
@@ -1,0 +1,79 @@
+import * as std from "std";
+
+export const project = {
+  name: "safeint",
+  version: "3.0.28a",
+  repository: "https://github.com/dcleblanc/SafeInt",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function safeint(): std.Recipe<std.Directory> {
+  return std.runBash`
+    cp SafeInt.hpp safe_math.h safe_math_impl.h "$BRIOCHE_OUTPUT/include/"
+  `
+    .workDir(source)
+    .outputScaffold(
+      std.directory({
+        include: std.directory(),
+      }),
+    )
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.cpp": std.file(std.indoc`
+      #include <SafeInt.hpp>
+      #include <cstdlib>
+      #include <iostream>
+
+      int main()
+      {
+          int result;
+          if (!SafeDivide(10, 0, result)) {
+              std::cout << "ok";
+          }
+
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    g++ main.cpp -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, safeint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    // Upstream reset versioning from 3.X.Y back to 3.0.X[letter]? in 2021,
+    // so restrict to that format to avoid picking older version schema
+    matchTag: /^(?<version>3\.0\.\d+[a-z]?)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `safeint`
- **Website / repository:** `https://github.com/dcleblanc/SafeInt`
- **Repology URL:** `https://repology.org/project/safeint/versions`
- **Short description:** `Header-only C++ class library for managing integer overflows`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 971498
[971498] ok
Process 971498 ran in 2.44s
Build finished, completed 1 job in 6.31s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.03s
Running brioche-run
{
  "name": "safeint",
  "version": "3.0.28a",
  "repository": "https://github.com/dcleblanc/SafeInt"
}
```

</p>
</details>

## Implementation notes / special instructions

None.