### PR TITLE
feat(howard_hinnant_date): add package

### DIFF
--- a/packages/howard_hinnant_date/brioche.lock
+++ b/packages/howard_hinnant_date/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/HowardHinnant/date.git": {
+      "v3.0.4": "f94b8f36c6180be0021876c4a397a054fe50c6f2"
+    }
+  }
+}

--- a/packages/howard_hinnant_date/project.bri
+++ b/packages/howard_hinnant_date/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "howard_hinnant_date",
+  version: "3.0.4",
+  repository: "https://github.com/HowardHinnant/date.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function howardHinnantDate(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TZ_LIB: "ON",
+      USE_SYSTEM_TZ_DB: "ON",
+      ENABLE_DATE_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "CMakeLists.txt": std.file(std.indoc`
+      cmake_minimum_required(VERSION 4.0)
+      project(QueryVersion)
+
+      find_package(date REQUIRED CONFIG)
+      message(STATUS "date version: \${date_VERSION}")
+    `),
+  });
+
+  const script = std.runBash`
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, cmake, howardHinnantDate)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `date version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `howard_hinnant_date`
- **Website / repository:** `https://github.com/HowardHinnant/date`
- **Repology URL:** `https://repology.org/project/howard-hinnant-date/versions`
- **Short description:** A C++ date and time library extending the C++11/14/17 `<chrono>` header, with full IANA timezone database support.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 943821 in 1.13s
Launched process 943821
[943821] -- The C compiler identification is GNU 13.2.0
[943821] -- The CXX compiler identification is GNU 13.2.0
[943821] -- Detecting C compiler ABI info
[943821] -- Detecting C compiler ABI info - done
[943821] -- Check for working C compiler: /home/brioche-runner-7bd4c3a4c1d4e0265d2b0e0b46327a2fe3497bfefab2f0dce3126ead783bfba8/.local/share/brioche/locals/3de8a25da2baf35ceeb53381b2c5adb419869da4d4272de97576d2dba8d4d788/bin/cc - skipped
[943821] -- Detecting C compile features
[943821] -- Detecting C compile features - done
[943821] -- Detecting CXX compiler ABI info
[943821] -- Detecting CXX compiler ABI info - done
[943821] -- Check for working CXX compiler: /home/brioche-runner-7bd4c3a4c1d4e0265d2b0e0b46327a2fe3497bfefab2f0dce3126ead783bfba8/.local/share/brioche/locals/3de8a25da2baf35ceeb53381b2c5adb419869da4d4272de97576d2dba8d4d788/bin/c++ - skipped
[943821] -- Detecting CXX compile features
[943821] -- Detecting CXX compile features - done
[943821] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
[943821] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
[943821] -- Found Threads: TRUE
[943821] -- date version: 3.0.4
[943821] -- Configuring done (2.2s)
[943821] -- Generating done (0.0s)
[943821] -- Build files have been written to: /home/brioche-runner-7bd4c3a4c1d4e0265d2b0e0b46327a2fe3497bfefab2f0dce3126ead783bfba8/work/tmp
Process 943821 ran in 2.31s
Build finished, completed 1 job in 10.42s
Result: 5e6f4b85cb32e7b9381669d40a8abbd00da012a7a8331535dd38ccf946a7492a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Fetching artifact from cache
Fetching artifact from cache
Fetching artifact from cache
Fetched 0 B for artifact from cache in 0.01s
Fetching artifact from cache
Fetched 0 B for artifact from cache in 0.02s
Fetching artifact from cache
Fetched 0 B for artifact from cache in 0.06s
Launched process 944024
Process 944024 ran in 0.12s
Fetching artifact from cache
Fetched 0 B for artifact from cache in 0.05s
Fetched 13.0 MiB for artifact from cache in 4.92s
Fetched 13.4 MiB for artifact from cache in 17.46s
Build finished, completed 7 jobs in 28.89s
Running brioche-run
{
  "name": "howard_hinnant_date",
  "version": "3.0.4",
  "repository": "https://github.com/HowardHinnant/date.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.