### PR TITLE
feat(flatbuffers): add package

### DIFF
--- a/packages/flatbuffers/brioche.lock
+++ b/packages/flatbuffers/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/flatbuffers.git": {
+      "v25.12.19": "7e163021e59cca4f8e1e35a7c828b5c6b7915953"
+    }
+  }
+}

--- a/packages/flatbuffers/project.bri
+++ b/packages/flatbuffers/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "flatbuffers",
+  version: "25.12.19",
+  repository: "https://github.com/google/flatbuffers.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function flatbuffers(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      FLATBUFFERS_BUILD_TESTS: "OFF",
+      FLATBUFFERS_BUILD_SHAREDLIB: "ON",
+      CMAKE_POSITION_INDEPENDENT_CODE: "ON",
+    },
+    runnable: "bin/flatc",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    flatc --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(flatbuffers)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `flatc version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `flatbuffers`
- **Website / repository:** `https://github.com/google/flatbuffers`
- **Repology URL:** `https://repology.org/project/flatbuffers/versions`
- **Short description:** `Memory efficient serialization library and schema compiler (flatc) from Google.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 944404
[944404] flatc version 25.12.19
Process 944404 ran in 0.02s
Build finished, completed 1 job in 2.30s
Result: 77b03a21b3851a31d2fe4b002ec3cacb9d4bedb8e7a5b7267ac8e6d77eded8e4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 971728
Process 971728 ran in 0.02s
Build finished, completed 1 job in 4.36s
Running brioche-run
{
  "name": "flatbuffers",
  "version": "25.12.19",
  "repository": "https://github.com/google/flatbuffers.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.