### PR TITLE
feat(kubescape): add package

### DIFF
--- a/packages/kubescape/brioche.lock
+++ b/packages/kubescape/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/kubescape/kubescape.git": {
+      "v4.0.6": "c36463cdcb4fbe2646e8ebc819059ef48eb752c1"
+    }
+  }
+}

--- a/packages/kubescape/project.bri
+++ b/packages/kubescape/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "kubescape",
+  version: "4.0.6",
+  repository: "https://github.com/kubescape/kubescape.git",
+};
+
+// Retrieve the source directly from the GitHub repository and not from the Go
+// proxy. Since, the one from Go proxy is not up to date.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function kubescape(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=v${project.version}`],
+    },
+    runnable: "bin/kubescape",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    kubescape version 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(kubescape)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Your current version is: v${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `kubescape`
- **Website / repository:** `https://github.com/kubescape/kubescape`
- **Repology URL:** `https://repology.org/project/kubescape/versions`
- **Short description:** `Open-source Kubernetes security platform for IDEs, CI/CD pipelines, and clusters (risk analysis, security, compliance, misconfiguration scanning)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 1070079 in 3.38s
Launched process 1070079
[1070079] Your current version is: v4.0.6
[1070079] Build commit: none
[1070079] Build date: unknown
[1070079] {"level":"info","ts":"2026-05-05T17:22:38Z","msg":"Received interrupt signal, exiting..."}
Process 1070079 ran in 0.41s
Build finished, completed 1 job in 6.54s
Result: 5abbd6025dc1a9ae1b101b4495f4779ef780541f02f7904bfd08c09569683335
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Fetching artifact from cache
Fetching artifact from cache
Fetching artifact from cache
Fetching artifact from cache
Fetching artifact from cache
Launched process 1070192
Process 1070192 ran in 0.08s
Fetched 5.6 MiB for artifact from cache in 2.71s
Fetched 12.9 MiB for artifact from cache in 5.35s
Fetched 13.0 MiB for artifact from cache in 8.31s
Fetched 13.4 MiB for artifact from cache in 12.83s
Fetched 56.5 MiB for artifact from cache in 35.13s
Fetched 107.9 MiB for artifact from cache in 1m 3s
Build finished, completed 7 jobs in 1m 8s
Running brioche-run
{
  "name": "kubescape",
  "version": "4.0.6",
  "repository": "https://github.com/kubescape/kubescape.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.