### PR TITLE
feat(libmikmod): add package

### DIFF
--- a/packages/libmikmod/brioche.lock
+++ b/packages/libmikmod/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sezero/mikmod": {
+      "libmikmod-3.3.13": "b25f6ee25bdfc05d21b6e7f1f6a72eb15fa1ebb2"
+    }
+  }
+}

--- a/packages/libmikmod/project.bri
+++ b/packages/libmikmod/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import alsaLib from "alsa_lib";
+import { cmakeBuild } from "cmake";
+import pulseaudio from "pulseaudio";
+
+export const project = {
+  name: "libmikmod",
+  version: "3.3.13",
+  repository: "https://github.com/sezero/mikmod",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `libmikmod-${project.version}`,
+});
+
+export default function libmikmod(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    path: "libmikmod",
+    dependencies: [std.toolchain, alsaLib, pulseaudio],
+    set: {
+      ENABLE_SHARED: "ON",
+      ENABLE_STATIC: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libmikmod | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libmikmod)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^libmikmod-(?<version>.+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libmikmod`
- **Website / repository:** `https://github.com/sezero/mikmod`
- **Repology URL:** `https://repology.org/project/libmikmod/versions`
- **Short description:** `Portable sound library for playing module music files (MOD, S3M, IT, XM, etc.)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1139353
[1139353] 3.3.13
Process 1139353 ran in 0.12s
Build finished, completed 1 job in 11.13s
Result: 521deebef6601956037d70ffc1990885b400469f0a5998aad78ca8c49fd89e9b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1140121
Process 1140121 ran in 0.05s
Build finished, completed 1 job in 13.61s
Running brioche-run
{
  "name": "libmikmod",
  "version": "3.3.13",
  "repository": "https://github.com/sezero/mikmod"
}
```

</p>
</details>

## Implementation notes / special instructions

None.