### PR TITLE
feat(numdiff): add package

### DIFF
--- a/packages/numdiff/brioche.lock
+++ b/packages/numdiff/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://download.savannah.gnu.org/releases/numdiff/numdiff-5.9.0.tar.gz": {
+      "type": "sha256",
+      "value": "87284a117944723eebbf077f857a0a114d818f8b5b54d289d59e73581194f5ef"
+    }
+  }
+}

--- a/packages/numdiff/project.bri
+++ b/packages/numdiff/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "numdiff",
+  version: "5.9.0",
+};
+
+const source = Brioche.download(
+  `https://download.savannah.gnu.org/releases/numdiff/numdiff-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function numdiff(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/numdiff"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ls
+    numdiff --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(numdiff)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `numdiff ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://download.savannah.nongnu.org/releases/numdiff/
+      | lines
+      | where ($it | str contains "numdiff-") and (not ($it | str contains ".sig")) and (not ($it | str contains "tests"))
+      | parse --regex '<a href="numdiff-(?<version>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `numdiff`
- **Website / repository:** `https://www.nongnu.org/numdiff/`
- **Repology URL:** `https://repology.org/project/numdiff/versions`
- **Short description:** Compares similar files line by line and field by field, ignoring small numeric differences or differing numeric formats.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1127718
[1127718] numdiff 5.9.0
[1127718] Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017  Ivano Primi <ivprimi@libero.it>
[1127718] License GPLv3+: GNU GPL version 3 or later,
[1127718] see <http://gnu.org/licenses/gpl.html>.
[1127718] This is free software: you are free to change and redistribute it.
[1127718] There is NO WARRANTY, to the extent permitted by law.
[1127718]
[1127718] The software has been linked against
[1127718] the GNU Multiple Precision Arithmetic Library,
[1127718] version number 6.3.0.
Process 1127718 ran in 0.02s
Build finished, completed 1 job in 2.60s
Result: 9ef96b59557685bf2805acb2ba177b305c1f9f5e2ad1be1f56788d68ef8cfdca
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1128824
Process 1128824 ran in 0.03s
Build finished, completed 1 job in 11.06s
Running brioche-run
{
  "name": "numdiff",
  "version": "5.9.0"
}
```

</p>
</details>

## Implementation notes / special instructions

None.