### PR TITLE
feat(uuu): add package

### DIFF
--- a/packages/uuu/brioche.lock
+++ b/packages/uuu/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nxp-imx/mfgtools": {
+      "uuu_1.5.243": "bb04dcf48c7be428bd6d9b6d50b15c021bdd6495"
+    }
+  }
+}

--- a/packages/uuu/project.bri
+++ b/packages/uuu/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libusb from "libusb";
+import openssl from "openssl";
+import tinyxml2 from "tinyxml2";
+
+export const project = {
+  name: "uuu",
+  version: "1.5.243",
+  repository: "https://github.com/nxp-imx/mfgtools",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `uuu_${project.version}`,
+}).insert(".tarball-version", std.file(project.version));
+
+export default function uuu(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libusb, openssl, tinyxml2],
+    set: {
+      BUILD_DOC: "OFF",
+    },
+    runnable: "bin/uuu",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    uuu -h | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(uuu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `lib${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^uuu_(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `uuu`
- **Website / repository:** `https://github.com/nxp-imx/mfgtools`
- **Repology URL:** `https://repology.org/project/uuu/versions`
- **Short description:** `Universal Update Utility (UUU / mfgtools v3) for deploying images to Freescale/NXP i.MX chips`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/uuu^test
Build finished, completed (no new jobs) in 1.46s
Result: e1efc1f2edc08724902504817127b3de8d16fbcec63d6f446595911f9701f5f5
```

Test recipe output (`uuu -h`):

```
uuu (Universal Update Utility) for nxp imx chips -- lib1.5.243

uuu [-d -m -v -V -bmap -no-bmap] <bootloader|cmdlists|cmd>
...
```

Assertion: result includes `lib1.5.243` (passed).

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/uuu^liveUpdate
Launched process 1207374
Process 1207374 ran in 0.04s
Build finished, completed 1 job in 4.80s
Running brioche-run
{
  "name": "uuu",
  "version": "1.5.243",
  "repository": "https://github.com/nxp-imx/mfgtools"
}
```

</p>
</details>

## Implementation notes / special instructions

None.