### PR TITLE
feat(luajit): add package

### DIFF
--- a/packages/luajit/brioche.lock
+++ b/packages/luajit/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/luajit/project.bri
+++ b/packages/luajit/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "luajit",
+  version: "2.1.1774896198",
+  repository: "https://github.com/LuaJIT/LuaJIT",
+  extra: {
+    // No recent tags or releases published, pin to the latest commit on the v2.1 branch.
+    gitRef: "18b087cd2cd4ddc4a79782bf155383a689d5093d",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+})
+  // Bake the commit timestamp into `.relver`
+  .insert(".relver", std.file(project.version.replace(/^\d+\.\d+\./, "")));
+
+export default function luajit(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/luajit"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    luajit -v | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(luajit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `LuaJIT ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let response = http get https://api.github.com/repos/LuaJIT/LuaJIT/commits/v2.1
+    let gitRef = $response.sha
+    let timestamp = $response.commit.committer.date
+      | into datetime
+      | format date "%s"
+    let version = $"2.1.($timestamp)"
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}

--- a/packages/luajit/project.bri
+++ b/packages/luajit/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "luajit",
+  version: "2.1.1780076327",
+  repository: "https://github.com/LuaJIT/LuaJIT",
+  extra: {
+    // No recent tags or releases published, pin to the latest commit on the v2.1 branch.
+    gitRef: "b925b3e3fc6771171602323b45fbe9fb8fc90369",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+})
+  // Bake the commit timestamp into `.relver`
+  .insert(".relver", std.file(project.version.replace(/^\d+\.\d+\./, "")));
+
+export default function luajit(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/luajit"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    luajit -v | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(luajit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `LuaJIT ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let response = http get https://api.github.com/repos/LuaJIT/LuaJIT/commits/v2.1
+    let gitRef = $response.sha
+    let timestamp = $response.commit.committer.date
+      | into datetime
+      | format date "%s"
+    let version = $"2.1.($timestamp)"
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `luajit`
- **Website / repository:** `https://luajit.org` / `https://github.com/LuaJIT/LuaJIT`
- **Repology URL:** `https://repology.org/project/luajit/versions`
- **Short description:** `A Just-In-Time Compiler (JIT) for the Lua programming language.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/luajit^test
Launched process 1208805
[1208805] LuaJIT 2.1.1774896198 -- Copyright (C) 2005-2026 Mike Pall. https://luajit.org/
Process 1208805 ran in 0.01s
Build finished, completed 1 job in 1.97s
Result: cdaaa24518221902e71980de9c1aa1a90784a503ab34b31726a1adf01076ea92
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/luajit^liveUpdate
Build finished, completed 1 job in 15.38s
Running brioche-run
{
  "name": "luajit",
  "version": "2.1.1774896198",
  "repository": "https://github.com/LuaJIT/LuaJIT",
  "extra": {
    "gitRef": "18b087cd2cd4ddc4a79782bf155383a689d5093d"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

LuaJIT uses a rolling-release model with no formal tags since 2017 (`v2.1.0-beta3`). The recipe pins to a specific commit on the `v2.1` branch (matching the approach used by Homebrew and Nixpkgs) and uses `2.1.<commit_unix_timestamp>` as the version.