### PR TITLE
feat(imagemagick): add package

### DIFF
--- a/packages/imagemagick/brioche.lock
+++ b/packages/imagemagick/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://imagemagick.org/archive/releases/ImageMagick-7.1.2-21.tar.xz": {
+      "type": "sha256",
+      "value": "56450bf5d65b63abb09568abb2c40b493ab913418f92df135ed661471da0eb0d"
+    }
+  }
+}

--- a/packages/imagemagick/project.bri
+++ b/packages/imagemagick/project.bri
@@ -1,0 +1,158 @@
+import * as std from "std";
+import aom from "aom";
+import brotli from "brotli";
+import dav1d from "dav1d";
+import fontconfig from "fontconfig";
+import freetype from "freetype";
+import glib from "glib";
+import lcms2 from "lcms2";
+import libde265 from "libde265";
+import libdeflate from "libdeflate";
+import libheif from "libheif";
+import libjpegTurbo from "libjpeg_turbo";
+import liblqr from "liblqr";
+import libpng from "libpng";
+import libtiff from "libtiff";
+import libvmaf from "libvmaf";
+import libwebp from "libwebp";
+import libxml2 from "libxml2";
+import lerc from "lerc";
+import openjpeg from "openjpeg";
+import pcre2 from "pcre2";
+import x265 from "x265";
+
+export const project = {
+  name: "imagemagick",
+  version: "7.1.2-21",
+  repository: "https://github.com/ImageMagick/ImageMagick",
+};
+
+const source = Brioche.download(
+  `https://imagemagick.org/archive/releases/ImageMagick-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function imagemagick(): std.Recipe<std.Directory> {
+  return (
+    std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --without-x \\
+      --disable-docs
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+      .workDir(source)
+      .dependencies(
+        std.toolchain,
+        aom,
+        brotli,
+        dav1d,
+        fontconfig,
+        freetype,
+        glib,
+        lcms2,
+        libde265,
+        libdeflate,
+        libheif,
+        libjpegTurbo,
+        liblqr,
+        libpng,
+        libtiff,
+        libvmaf,
+        libwebp,
+        libxml2,
+        lerc,
+        openjpeg,
+        pcre2,
+        x265,
+      )
+      .toDirectory()
+      .pipe(std.libtoolSanitizeDependencies)
+      .pipe(std.pkgConfigMakePathsRelative)
+      .pipe((recipe) =>
+        std.setEnv(recipe, {
+          CPATH: { append: [{ path: "include" }] },
+          LIBRARY_PATH: { append: [{ path: "lib" }] },
+          PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        }),
+      )
+      // Relocate the binary to libexec to free bin/magick for the wrapper added next
+      .pipe((recipe) =>
+        recipe
+          .insert("libexec/magick", recipe.get("bin/magick"))
+          .remove("bin/magick"),
+      )
+      .pipe((recipe) => {
+        // The binary can't locate its config directory at runtime,
+        // so the wrapper exports MAGICK_CONFIGURE_PATH for it
+        let result = std.addRunnable(recipe, "bin/magick", {
+          command: { relativePath: "libexec/magick" },
+          env: {
+            MAGICK_CONFIGURE_PATH: {
+              fallback: { relativePath: "etc/ImageMagick-7" },
+            },
+          },
+        });
+
+        // ImageMagick 7 dispatches legacy commands via argv[0], which the
+        // wrapper can't carry through a symlink; replace each symlink with
+        // its own wrapper that invokes magick with the legacy name prepended
+        const legacyCommands = [
+          "animate",
+          "compare",
+          "composite",
+          "conjure",
+          "convert",
+          "display",
+          "identify",
+          "import",
+          "magick-script",
+          "mogrify",
+          "montage",
+          "stream",
+        ];
+        for (const name of legacyCommands) {
+          result = result.remove(`bin/${name}`);
+          result = std.addRunnable(result, `bin/${name}`, {
+            command: { relativePath: "libexec/magick" },
+            args: [name],
+            env: {
+              MAGICK_CONFIGURE_PATH: {
+                fallback: { relativePath: "etc/ImageMagick-7" },
+              },
+            },
+          });
+        }
+        return result;
+      })
+      .pipe((recipe) => std.withRunnableLink(recipe, "bin/magick"))
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    magick --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(imagemagick)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ImageMagick ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^(?<version>\d+\.\d+\.\d+-\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `imagemagick`
- **Website / repository:** `https://github.com/ImageMagick/ImageMagick`
- **Repology URL:** `https://repology.org/project/imagemagick/versions`
- **Short description:** ImageMagick is a free, open-source software suite for creating, editing, converting, and composing bitmap images, supporting a wide range of image formats.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 1354041 in 1.49s
Launched process 1354041
[1354041] Version: ImageMagick 7.1.2-21 Q16-HDRI aarch64 23940 https://imagemagick.org
[1354041] Copyright: (C) 1999 ImageMagick Studio LLC
[1354041] License: https://imagemagick.org/license/
[1354041] Features: Cipher DPC HDRI OpenMP(4.5)
[1354041] Delegates (built-in): bzlib fontconfig freetype heic jng jp2 jpeg lcms lqr lzma png tiff webp xml zlib zstd
[1354041] Compiler: gcc (13.2)
Process 1354041 ran in 0.09s
Build finished, completed 1 job in 20.30s
Result: a336dd261e00c97f2fbefb7176ecf6d2c1dd1e985fe134ed274d438582ec2115
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.40s
Running brioche-run
{
  "name": "imagemagick",
  "version": "7.1.2-21",
  "repository": "https://github.com/ImageMagick/ImageMagick"
}
```

</p>
</details>

## Implementation notes / special instructions

None.