### PR TITLE
feat(gnutls): add package

### DIFF
--- a/packages/gnutls/brioche.lock
+++ b/packages/gnutls/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.13.tar.xz": {
+      "type": "sha256",
+      "value": "ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
+    }
+  }
+}

--- a/packages/gnutls/project.bri
+++ b/packages/gnutls/project.bri
@@ -1,0 +1,81 @@
+import * as std from "std";
+import libiconv from "libiconv";
+import libidn2 from "libidn2";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import nettle from "nettle";
+import p11Kit from "p11_kit";
+
+export const project = {
+  name: "gnutls",
+  version: "3.8.13",
+  repository: "https://gitlab.com/gnutls/gnutls",
+  extra: {
+    majorVersion: "3",
+    minorVersion: "8",
+  },
+};
+
+// Ensure the major version number matches the version
+std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+// Ensure the minor version number matches the version
+std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+
+const source = Brioche.download(
+  `https://www.gnupg.org/ftp/gcrypt/gnutls/v${project.extra.majorVersion}.${project.extra.minorVersion}/gnutls-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function gnutls(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --without-tpm \\
+      --without-tpm2 \\
+      --disable-doc \\
+      --disable-tests
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      nettle,
+      libtasn1,
+      libidn2,
+      libiconv,
+      libunistring,
+      p11Kit,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion gnutls | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gnutls)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gnutls`
- **Website / repository:** `https://gitlab.com/gnutls/gnutls`
- **Repology URL:** `https://repology.org/project/gnutls/versions`
- **Short description:** GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Prepared process 1499143 in 1.81s
Launched process 1499143
[1499143] 3.8.13
Process 1499143 ran in 0.17s
Build finished, completed 1 job in 6.48s
Result: b86cdbd5644fa264fcbf589c3a2bd81df921348c3dd64bc0fac18ddbd5018e95
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1499236
Process 1499236 ran in 0.03s
Build finished, completed 1 job in 8.64s
Running brioche-run
{
  "name": "gnutls",
  "version": "3.8.13",
  "repository": "https://gitlab.com/gnutls/gnutls",
  "extra": {
    "majorVersion": "3",
    "minorVersion": "8"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.