### PR TITLE
feat(libmpdclient): add package

### DIFF
--- a/packages/libmpdclient/brioche.lock
+++ b/packages/libmpdclient/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/MusicPlayerDaemon/libmpdclient/archive/refs/tags/v2.24.tar.gz": {
+      "type": "sha256",
+      "value": "b19ec4c10314f5b55e1bca2a34c299effbbb2f1f9b5113b331b7ba789f0c17d1"
+    }
+  }
+}

--- a/packages/libmpdclient/project.bri
+++ b/packages/libmpdclient/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "libmpdclient",
+  version: "2.24",
+  repository: "https://github.com/MusicPlayerDaemon/libmpdclient",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libmpdclient(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      documentation: "false",
+      test: "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libmpdclient | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libmpdclient)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libmpdclient`
- **Website / repository:** `https://github.com/MusicPlayerDaemon/libmpdclient`
- **Repology URL:** `https://repology.org/project/libmpdclient/versions`
- **Short description:** `A C library implementing the Music Player Daemon (MPD) protocol`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1512617
[1512617] 2.24
Process 1512617 ran in 0.02s
Build finished, completed 1 job in 2.01s
Result: d9cedb9accecd681d59a6707ac48d3b1044ad8c10894554aa24f61f5569234dd
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 13.06s
Running brioche-run
{
  "name": "libmpdclient",
  "version": "2.24",
  "repository": "https://github.com/MusicPlayerDaemon/libmpdclient"
}
```

</p>
</details>

## Implementation notes / special instructions

None.