### PR TITLE
feat(better_commits): add package

### DIFF
--- a/packages/better_commits/brioche.lock
+++ b/packages/better_commits/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/better_commits/project.bri
+++ b/packages/better_commits/project.bri
@@ -1,0 +1,41 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "better_commits",
+  version: "1.23.0",
+  extra: {
+    packageName: "better-commits",
+  },
+};
+
+export default function betterCommits(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/better-commits"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ls
+    better-commits --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(betterCommits)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Better Commits v${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `better_commits`
- **Website / repository:** `https://github.com/Everduin94/better-commits`
- **Repology URL:** `https://repology.org/project/better-commits/versions`
- **Short description:** `CLI tool for creating commits that follow the conventional commits specification.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.88s
Result: e32317681899d383ce61838329b432633246255b118265d41039fe0245bb74e8
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "better_commits",
  "version": "1.23.0",
  "extra": {
    "packageName": "better-commits"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.