### PR TITLE
feat(tofu_ls): add package

### DIFF
--- a/packages/tofu_ls/brioche.lock
+++ b/packages/tofu_ls/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/opentofu/tofu-ls/@v/v0.4.2.zip": {
+      "type": "sha256",
+      "value": "30c0573fb4b086ddc7ace4e41d7579616852fe242f6e88d85097eb9931c590c8"
+    }
+  }
+}

--- a/packages/tofu_ls/project.bri
+++ b/packages/tofu_ls/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "tofu_ls",
+  version: "0.4.2",
+  extra: {
+    moduleName: "github.com/opentofu/tofu-ls",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function tofuLs(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/tofu-ls",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    tofu-ls version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(tofuLs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}' in output, got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `tofu_ls`
- **Website / repository:** `https://github.com/opentofu/tofu-ls`
- **Repology URL:** `https://repology.org/project/tofu-ls/versions`
- **Short description:** `The official OpenTofu language server that provides IDE features to any LSP-compatible editor.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1519631
[1519631] 0.4.2
[1519631] platform: linux/arm64
[1519631] go: go1.26.2
[1519631] compiler: gc
Process 1519631 ran in 0.02s
Build finished, completed 1 job in 1.50s
Result: a080b85cd61b15b20e756674d4edf57c9b799a426f7e8bfc400f428f7f8002a0
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1519730
Process 1519730 ran in 0.01s
Build finished, completed 1 job in 3.85s
Running brioche-run
{
  "name": "tofu_ls",
  "version": "0.4.2",
  "repository": "https://github.com/opentofu/tofu-ls",
  "extra": {
    "moduleName": "github.com/opentofu/tofu-ls"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.