### PR TITLE
feat(libnfs): add package

### DIFF
--- a/packages/libnfs/brioche.lock
+++ b/packages/libnfs/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/sahlberg/libnfs.git": {
+      "libnfs-6.0.2": "18c5c73ee88bb7dc8da0d55dc95164bb77e49dc6"
+    }
+  }
+}

--- a/packages/libnfs/project.bri
+++ b/packages/libnfs/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+import gnutls from "gnutls";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libnfs",
+  version: "6.0.2",
+  repository: "https://github.com/sahlberg/libnfs.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `libnfs-${project.version}`,
+});
+
+export default function libnfs(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, gnutls],
+    set: {
+      ENABLE_TESTS: "OFF",
+      ENABLE_EXAMPLES: "OFF",
+      ENABLE_UTILS: "OFF",
+      ENABLE_DOCUMENTATION: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the pkg-config
+  // modversion is used to verify the correct installation
+  const script = std.runBash`
+    pkg-config --modversion libnfs | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnfs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^libnfs-(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libnfs`
- **Website / repository:** `https://github.com/sahlberg/libnfs`
- **Repology URL:** `https://repology.org/project/libnfs/versions`
- **Short description:** `Client library for accessing NFS shares over a network`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.34s
Result: b6735a925ac70771a534c97c8bb83ba9c500849f988996773f8f4917ff28146e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.99s
Running brioche-run
{
  "name": "libnfs",
  "version": "6.0.2",
  "repository": "https://github.com/sahlberg/libnfs.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.