### PR TITLE
feat(cpu_features): add package

### DIFF
--- a/packages/cpu_features/brioche.lock
+++ b/packages/cpu_features/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/cpu_features.git": {
+      "v0.10.1": "d3b2440fcfc25fe8e6d0d4a85f06d68e98312f5b"
+    }
+  }
+}

--- a/packages/cpu_features/project.bri
+++ b/packages/cpu_features/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "cpu_features",
+  version: "0.10.1",
+  repository: "https://github.com/google/cpu_features.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cpuFeatures(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTING: "OFF",
+    },
+    runnable: "bin/list_cpu_features",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "CMakeLists.txt": std.file(std.indoc`
+      cmake_minimum_required(VERSION 4.0)
+      project(QueryVersion)
+
+      find_package(CpuFeatures REQUIRED CONFIG)
+      message(STATUS "CpuFeatures version: \${CpuFeatures_VERSION}")
+    `),
+  });
+
+  const script = std.runBash`
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, cmake, cpuFeatures)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `CpuFeatures version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cpu_features`
- **Website / repository:** `https://github.com/google/cpu_features`
- **Repology URL:** `https://repology.org/project/cpu_features/versions`
- **Short description:** `Cross-platform C library to retrieve CPU features (such as available instructions) at runtime`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: .../bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: .../bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CpuFeatures version: 0.10.1
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: .../tmp
Build finished, completed 1 job in 13.26s
Result: 2aa3032e06ff94d3931e787a737f47c4194ef5cfe9ea6d20563343553c37870a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 9.93s
Running brioche-run
{
  "name": "cpu_features",
  "version": "0.10.1",
  "repository": "https://github.com/google/cpu_features.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.