### PR TITLE
feat(gitea_runner): add package

### DIFF
--- a/packages/gitea_runner/brioche.lock
+++ b/packages/gitea_runner/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/gitea.com/gitea/runner/@v/v1.0.1.zip": {
+      "type": "sha256",
+      "value": "9737ab49f8e42551146dcb322f1c2da94107fe82358365840d267b74ff20334b"
+    }
+  }
+}

--- a/packages/gitea_runner/project.bri
+++ b/packages/gitea_runner/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "gitea_runner",
+  version: "1.0.1",
+  extra: {
+    moduleName: "gitea.com/gitea/runner",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function giteaRunner(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/internal/pkg/ver.version=${project.version}`,
+      ],
+    },
+    runnable: "bin/runner",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    runner --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(giteaRunner)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `gitea-runner version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gitea_runner`
- **Website / repository:** `https://gitea.com/gitea/runner`
- **Repology URL:** `https://repology.org/project/gitea-runner/versions`
- **Short description:** `Act runner for running Gitea Actions workflows`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1533478
[1533478] gitea-runner version 1.0.1
Process 1533478 ran in 0.03s
Build finished, completed 1 job in 1.60s
Result: 737c5449a8d4dd3a8cec93717b990972e475f781ea704af635bd6f436f04a27a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1533586
Process 1533586 ran in 0.03s
Build finished, completed 1 job in 5.74s
Running brioche-run
{
  "name": "gitea_runner",
  "version": "1.0.1",
  "repository": "https://gitea.com/gitea/runner",
  "extra": {
    "moduleName": "gitea.com/gitea/runner"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.