### PR TITLE
feat(kakoune): add package

### DIFF
--- a/packages/kakoune/brioche.lock
+++ b/packages/kakoune/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/mawww/kakoune/releases/download/v2026.04.12/kakoune-2026.04.12.tar.bz2": {
+      "type": "sha256",
+      "value": "ce67adc8af7b20550463332c38e389cacfdd80f709e14b9940c127091aab0681"
+    }
+  }
+}

--- a/packages/kakoune/project.bri
+++ b/packages/kakoune/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+
+export const project = {
+  name: "kakoune",
+  version: "2026.04.12",
+  repository: "https://github.com/mawww/kakoune",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/kakoune-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function kakoune(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT" PREFIX=/
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/kak"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    kak -version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(kakoune())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Kakoune ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `kakoune`
- **Website / repository:** `https://github.com/mawww/kakoune`
- **Repology URL:** `https://repology.org/project/kakoune/versions`
- **Short description:** `A modern, vi-inspired code editor with support for multiple selections`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1555446
[1555446] Kakoune 2026.04.12
Process 1555446 ran in 0.02s
Build finished, completed 1 job in 3.18s
Result: 235a8ff476c13c87fa55a3d079e72422b577b40189385ac25aa99d95b38a7c5d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Launched process 1555530
Process 1555530 ran in 0.02s
Build finished, completed 1 job in 4.09s
Running brioche-run
{
  "name": "kakoune",
  "version": "2026.04.12",
  "repository": "https://github.com/mawww/kakoune"
}
```

</p>
</details>

## Implementation notes / special instructions

None.