### PR TITLE
feat(git_codereview): add package

### DIFF
--- a/packages/git_codereview/brioche.lock
+++ b/packages/git_codereview/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/golang.org/x/review/@v/v1.20.0.zip": {
+      "type": "sha256",
+      "value": "215f7bccf9dd2ab0d829b0a95f72d70be765304ba265121c29d635bd5442ce98"
+    }
+  }
+}

--- a/packages/git_codereview/project.bri
+++ b/packages/git_codereview/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "git_codereview",
+  version: "1.20.0",
+  extra: {
+    moduleName: "golang.org/x/review",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function gitCodereview(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./git-codereview",
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/git-codereview",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    git-codereview help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gitCodereview)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `git_codereview`
- **Website / repository:** `https://pkg.go.dev/golang.org/x/review/git-codereview`
- **Repology URL:** `https://repology.org/project/git-codereview/versions`
- **Short description:** `Git-codereview manages the code review process for Git changes using a Gerrit server.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 1564770
[1564770] Usage: git-codereview <command> [-n] [-v]
[1564770] 
[1564770] Git-codereview is a git helper command for managing pending commits
[1564770] against an upstream server, typically a Gerrit server.
[1564770] 
[1564770] The -n flag prints commands that would make changes but does not run them.
[1564770] The -v flag prints those commands as they run.
[1564770] 
[1564770] Available commands:
[1564770] 
[1564770] 	branchpoint
[1564770] 	change [name]
[1564770] 	change NNNN[/PP]
[1564770] 	gofmt [-l]
[1564770] 	help
[1564770] 	hooks
[1564770] 	mail [-r reviewer,...] [-cc mail,...] [options] [commit]
[1564770] 	pending [-c] [-g] [-l] [-s]
[1564770] 	rebase-work
[1564770] 	reword [commit...]
[1564770] 	submit [-i | commit...]
[1564770] 	sync
[1564770] 	sync-branch [-continue]
[1564770] 
[1564770] See https://pkg.go.dev/golang.org/x/review/git-codereview
[1564770] for the full details of each command.
Process 1564770 ran in 0.03s
Build finished, completed 1 job in 1.55s
Result: f3852e02a4f193c0f83d41719720b46908cd3f2ee3313b964088bd12e07a57f0
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.84s
Running brioche-run
{
  "name": "git_codereview",
  "version": "1.20.0",
  "extra": {
    "moduleName": "golang.org/x/review"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.