### PR TITLE
feat(kubectl_cnpg): add package

### DIFF
--- a/packages/kubectl_cnpg/brioche.lock
+++ b/packages/kubectl_cnpg/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/cloudnative-pg/cloudnative-pg/@v/v1.29.1.info": {
+      "type": "sha256",
+      "value": "cb9f733d35250d1d1a8ecd7ff22ed4e96f2030892949e8db7e7b209da605549b"
+    },
+    "https://proxy.golang.org/github.com/cloudnative-pg/cloudnative-pg/@v/v1.29.1.zip": {
+      "type": "sha256",
+      "value": "3cb1014ee8746f605b9a29466b924a3514077ca99ed6be1a17119e61a1c846b6"
+    }
+  }
+}

--- a/packages/kubectl_cnpg/project.bri
+++ b/packages/kubectl_cnpg/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "kubectl_cnpg",
+  version: "1.29.1",
+  extra: {
+    moduleName: "github.com/cloudnative-pg/cloudnative-pg",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function kubectlCnpg(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/pkg/versions.buildVersion=${project.version}`,
+        "-X",
+        `${project.extra.moduleName}/pkg/versions.buildCommit=${manifest.origin.hash}`,
+        "-X",
+        `${project.extra.moduleName}/pkg/versions.buildDate=${manifest.time}`,
+      ],
+    },
+    path: "./cmd/kubectl-cnpg",
+    runnable: "bin/kubectl-cnpg",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    kubectl-cnpg version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(kubectlCnpg)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}

--- a/packages/shellcheck/project.bri
+++ b/packages/shellcheck/project.bri
@@ -50,7 +50,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const expected = `version: ${project.version}`;
   std.assert(
     result.includes(expected),
-    `expected '${expected}' in output, got '${result}'`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;

--- a/packages/tofu_ls/project.bri
+++ b/packages/tofu_ls/project.bri
@@ -38,7 +38,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const expected = project.version;
   std.assert(
     result.startsWith(expected),
-    `expected '${expected}' in output, got '${result}'`,
+    `expected '${expected}', got '${result}'`,
   );
 
   return script;


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `kubectl_cnpg`
- **Website / repository:** `https://github.com/cloudnative-pg/cloudnative-pg`
- **Repology URL:** `https://repology.org/project/kubectl-cnpg/versions`
- **Short description:** `kubectl plugin that extends kubectl to manage CloudNativePG clusters`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.00s
Result: d5e2e544a4de3dbadd3e90e415ceeb3aa4c827d04f533e259b914a8c440ef198
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.17s
Running brioche-run
{
  "name": "kubectl_cnpg",
  "version": "1.29.1",
  "extra": {
    "moduleName": "github.com/cloudnative-pg/cloudnative-pg"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.