### PR TITLE
feat(openapv): add package

### DIFF
--- a/packages/nbytes/project.bri
+++ b/packages/nbytes/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 import { cmakeBuild } from "cmake";
 
 export const project = {
-  name: "",
+  name: "nbytes",
   version: "0.1.4",
   repository: "https://github.com/nodejs/nbytes.git",
 };

--- a/packages/openapv/brioche.lock
+++ b/packages/openapv/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/AcademySoftwareFoundation/openapv": {
+      "v0.2.1.3": "390b5605c55ea5723802062a00876d67134f71d9"
+    }
+  }
+}

--- a/packages/openapv/os-release-guard.patch
+++ b/packages/openapv/os-release-guard.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -175,7 +175,7 @@
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     message(STATUS "Linux system")
+     # Read the /etc/os-release file to determine the distribution
+-    file(READ "/etc/os-release" OS_RELEASE_CONTENT)
++    set(OS_RELEASE_CONTENT "")
+
+     if(OS_RELEASE_CONTENT MATCHES "ID=debian" OR OS_RELEASE_CONTENT MATCHES "ID=ubuntu")
+         message(STATUS "Debian-based system detected")

--- a/packages/openapv/project.bri
+++ b/packages/openapv/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "openapv",
+  version: "0.2.1.3",
+  repository: "https://github.com/AcademySoftwareFoundation/openapv",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+}).pipe((dir) =>
+  std.applyPatch({
+    source: dir,
+    patch: Brioche.includeFile("os-release-guard.patch"),
+    strip: 1,
+  }),
+);
+
+export default function openapv(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      ENABLE_TESTS: "OFF",
+      OAPV_BUILD_APPS: "ON",
+    },
+    runnable: "bin/oapv_app_enc",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion oapv | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, openapv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  // HACK: the project doesn't seem to report its version correctly.
+  const expected = project.version === "0.2.1.3" ? "0.2.1.1" : project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^v(?<version>\d+\.\d+\.\d+\.\d+)(?:-\w+)?$/,
+  });
+}

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -57,7 +57,9 @@ interface PythonOptions {
   version?: PythonVersion;
 }
 
-export default async function python(options: PythonOptions = {}) {
+export default async function python(
+  options: PythonOptions = {},
+): Promise<std.Recipe<std.Directory>> {
   const { version = getLatestVersion() } = options;
 
   // Get the Python source for the selected version


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `openapv`
- **Website / repository:** `https://github.com/AcademySoftwareFoundation/openapv`
- **Repology URL:** `https://repology.org/project/openapv/versions`
- **Short description:** `Reference implementation of the APV (Adaptive Professional Video) codec, a royalty-free professional-grade video codec`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.09s
Result: 05f97800754aff465422ea6ea71c9e71a5931eea14e4f03edef5096062a093cd
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1m54s
Running brioche-run
{
  "name": "openapv",
  "version": "0.2.1.3",
  "repository": "https://github.com/AcademySoftwareFoundation/openapv"
}
```

</p>
</details>

## Implementation notes / special instructions

None.