### PR TITLE
feat(syncthing): add package

### DIFF
--- a/packages/fastly/project.bri
+++ b/packages/fastly/project.bri
@@ -24,7 +24,7 @@ export default function fastly(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `github.com/fastly/cli/pkg/revision.AppVersion=v${project.version}`,
+        `github.com/fastly/cli/pkg/revision.AppVersion=${project.version}`,
         "-X",
         "github.com/fastly/cli/pkg/revision.Environment=release",
       ],
@@ -43,7 +43,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
   const result = (await script.read()).trim();
 
-  const expected = `Fastly CLI version v${project.version}`;
+  const expected = `Fastly CLI version ${project.version}`;
   std.assert(
     result.includes(expected),
     `expected '${expected}', got '${result}'`,

--- a/packages/hysteria/project.bri
+++ b/packages/hysteria/project.bri
@@ -26,7 +26,7 @@ export default function hysteria(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `github.com/apernet/hysteria/app/v2/cmd.appVersion=v${project.version}`,
+        `github.com/apernet/hysteria/app/v2/cmd.appVersion=${project.version}`,
         "-X",
         `github.com/apernet/hysteria/app/v2/cmd.appType=release`,
         "-X",
@@ -52,7 +52,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `v${project.version}`;
+  const expected = project.version;
   std.assert(
     result.includes(expected),
     `expected '${expected}', got '${result}'`,

--- a/packages/kubescape/project.bri
+++ b/packages/kubescape/project.bri
@@ -18,7 +18,7 @@ export default function kubescape(): std.Recipe<std.Directory> {
   return goBuild({
     source,
     buildParams: {
-      ldflags: ["-s", "-w", "-X", `main.version=v${project.version}`],
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
     },
     runnable: "bin/kubescape",
   });
@@ -34,7 +34,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
   const result = (await script.read()).trim();
 
   // Check that the result contains the expected version
-  const expected = `Your current version is: v${project.version}`;
+  const expected = `Your current version is: ${project.version}`;
   std.assert(
     result.includes(expected),
     `expected '${expected}', got '${result}'`,

--- a/packages/syncthing/brioche.lock
+++ b/packages/syncthing/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/syncthing/syncthing/@v/v1.30.0.info": {
+      "type": "sha256",
+      "value": "0e1c21d0272fa60b33e8718988251da563b3dc73dac7bbb98baa75db9c61f053"
+    },
+    "https://proxy.golang.org/github.com/syncthing/syncthing/@v/v1.30.0.zip": {
+      "type": "sha256",
+      "value": "0711e0002e15fcf3004593ce6777fb2ca909c892cb56e9cc6f612a8a15e42398"
+    }
+  }
+}

--- a/packages/syncthing/project.bri
+++ b/packages/syncthing/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "syncthing",
+  version: "1.30.0",
+  extra: {
+    moduleName: "github.com/syncthing/syncthing",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function syncthing(): std.Recipe<std.Directory> {
+  // The build system expects a Unix timestamp for the Stamp variable
+  const stamp = Math.floor(Date.parse(manifest.time) / 1000).toString();
+
+  return goBuild({
+    source,
+    env: {
+      GOFLAGS: "-tags=noassets",
+    },
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/syncthing/syncthing/lib/build.Version=v${project.version}`,
+        "-X",
+        `github.com/syncthing/syncthing/lib/build.Stamp=${stamp}`,
+        "-X",
+        `github.com/syncthing/syncthing/lib/build.User=brioche`,
+        "-X",
+        `github.com/syncthing/syncthing/lib/build.Host=brioche`,
+      ],
+    },
+    path: "./cmd/syncthing",
+    runnable: "bin/syncthing",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    syncthing --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(syncthing)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `syncthing v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}

--- a/packages/yoke/project.bri
+++ b/packages/yoke/project.bri
@@ -31,7 +31,7 @@ export default function yoke(): std.Recipe<std.Directory> {
         "-s",
         "-w",
         "-X",
-        `${project.extra.moduleName}/internal.buildVersion=v${project.version}`,
+        `${project.extra.moduleName}/internal.buildVersion=${project.version}`,
       ],
     },
     path: "./cmd/yoke",


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `syncthing`
- **Website / repository:** `https://github.com/syncthing/syncthing`
- **Repology URL:** `https://repology.org/project/syncthing/versions`
- **Short description:** `Open-source continuous file synchronization application`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
syncthing v1.30.0 "Gold Grasshopper" (go1.26.2 linux-arm64) brioche@brioche 2025-06-20 09:17:23 UTC
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "syncthing",
  "version": "1.30.0",
  "repository": "https://github.com/syncthing/syncthing",
  "extra": {
    "moduleName": "github.com/syncthing/syncthing"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

The build uses the `noassets` build tag to skip the embedded web GUI assets, which normally require `go generate` to produce. This is the standard approach used by distributions. Version information is injected via ldflags into four variables in `lib/build`: `Version`, `Stamp` (Unix timestamp from the Go module manifest), `User`, and `Host`.