### PR TITLE
chore: resolve new lints from 'brioche check'

### DIFF
--- a/packages/smol_toml/date.bri
+++ b/packages/smol_toml/date.bri
@@ -74,11 +74,11 @@ export class TomlDate extends Date {
     }
   }
 
-  isDateTime() {
+  isDateTime(): boolean {
     return this.#hasDate && this.#hasTime;
   }
 
-  isLocal() {
+  isLocal(): boolean {
     return (
       !this.#hasDate ||
       !this.#hasTime ||
@@ -87,19 +87,19 @@ export class TomlDate extends Date {
     );
   }
 
-  isDate() {
+  isDate(): boolean {
     return this.#hasDate && !this.#hasTime;
   }
 
-  isTime() {
+  isTime(): boolean {
     return this.#hasTime && !this.#hasDate;
   }
 
-  isValid() {
+  isValid(): boolean {
     return this.#hasDate || this.#hasTime;
   }
 
-  override toISOString() {
+  override toISOString(): string {
     const iso = super.toISOString();
 
     // Local Date
@@ -124,26 +124,26 @@ export class TomlDate extends Date {
     return offsetDate.toISOString().slice(0, -1) + this.#offset;
   }
 
-  static wrapAsOffsetDateTime(jsDate: Date, offset = "Z") {
+  static wrapAsOffsetDateTime(jsDate: Date, offset = "Z"): TomlDate {
     const date = new TomlDate(jsDate);
     date.#offset = offset;
     return date;
   }
 
-  static wrapAsLocalDateTime(jsDate: Date) {
+  static wrapAsLocalDateTime(jsDate: Date): TomlDate {
     const date = new TomlDate(jsDate);
     date.#offset = null;
     return date;
   }
 
-  static wrapAsLocalDate(jsDate: Date) {
+  static wrapAsLocalDate(jsDate: Date): TomlDate {
     const date = new TomlDate(jsDate);
     date.#hasTime = false;
     date.#offset = null;
     return date;
   }
 
-  static wrapAsLocalTime(jsDate: Date) {
+  static wrapAsLocalTime(jsDate: Date): TomlDate {
     const date = new TomlDate(jsDate);
     date.#hasDate = false;
     date.#offset = null;

--- a/packages/smol_toml/stringify.bri
+++ b/packages/smol_toml/stringify.bri
@@ -163,7 +163,7 @@ function stringifyTable(obj: any, prefix = "") {
   return `${preamble}\n${tables}`.trim();
 }
 
-export function stringify(obj: any) {
+export function stringify(obj: unknown): string {
   if (extendedTypeOf(obj) !== "object") {
     throw new TypeError("stringify can only be called with an object");
   }

--- a/packages/smol_toml/util.bri
+++ b/packages/smol_toml/util.bri
@@ -37,13 +37,17 @@ export type TomlPrimitive =
   | { [key: string]: TomlPrimitive }
   | TomlPrimitive[];
 
-export function indexOfNewline(str: string, start = 0, end = str.length) {
+export function indexOfNewline(
+  str: string,
+  start = 0,
+  end = str.length,
+): number {
   let idx = str.indexOf("\n", start);
   if (str[idx - 1] === "\r") idx--;
   return idx <= end ? idx : -1;
 }
 
-export function skipComment(str: string, ptr: number) {
+export function skipComment(str: string, ptr: number): number {
   for (let i = ptr; i < str.length; i++) {
     const c = str[i] as string;
     if (c === "\n") return i;
@@ -88,7 +92,7 @@ export function skipUntil(
   sep: string,
   end?: string,
   banNewLines: boolean = false,
-) {
+): number {
   if (end == null || end === "") {
     ptr = indexOfNewline(str, ptr);
     return ptr < 0 ? str.length : ptr;
@@ -116,7 +120,7 @@ export function skipUntil(
   });
 }
 
-export function getStringEnd(str: string, seek: number) {
+export function getStringEnd(str: string, seek: number): number {
   const first = str[seek] as string;
   const target =
     first === str[seek + 1] && str[seek + 1] === str[seek + 2]

--- a/packages/std/core/recipes/proxy.bri
+++ b/packages/std/core/recipes/proxy.bri
@@ -42,7 +42,7 @@ export function createProxy<T extends Artifact>(
 ): Recipe<T> {
   let serialized: Promise<runtime.ProxyRecipe> | undefined;
 
-  const serializeProxy = async (): Promise<runtime.ProxyRecipe> => {
+  async function serializeProxy(): Promise<runtime.ProxyRecipe> {
     serialized ??= (async () => {
       const recipeValue =
         typeof recipe === "function" ? await recipe() : await recipe;
@@ -55,7 +55,7 @@ export function createProxy<T extends Artifact>(
     })();
 
     return await serialized;
-  };
+  }
 
   return createRecipe(["file", "directory", "symlink"] as ArtifactType<T>[], {
     sourceDepth: 1,

--- a/packages/std/extra/autopack.bri
+++ b/packages/std/extra/autopack.bri
@@ -212,17 +212,17 @@ export function buildAutopackConfig(
   const variables: Record<string, AutopackConfigVariable> = {};
 
   let variableIndex = 0;
-  const addVar = (variable: {
+  function addVar(variable: {
     name?: string;
     value: std.RecipeLike;
-  }): TemplateVariable => {
+  }): TemplateVariable {
     const name = variable.name ?? `var${variableIndex++}`;
     std.assert(!(name in variables), `duplicate variable name ${name}`);
     variables[name] = { type: "path", value: variable.value };
     return { variable: name };
-  };
+  }
 
-  const buildEnvValue = (value: EnvValue): EnvValueTemplateValue => {
+  function buildEnvValue(value: EnvValue): EnvValueTemplateValue {
     if (typeof value === "object" && "relativePath" in value) {
       return {
         components: [
@@ -265,7 +265,7 @@ export function buildAutopackConfig(
         ),
       };
     }
-  };
+  }
 
   const dynamicBinaryPackedExecutable = addVar({
     name: "dynamicBinaryPackedExecutable",


### PR DESCRIPTION
Companion PR of https://github.com/brioche-dev/brioche/pull/465.

This PR resolves the following lints from a nightly version of `brioche check` linter:

```
/workspaces/brioche (main) $ cargo run -- check /tmp/brioche-packages/packages/*
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.29s
     Running `target/debug/brioche check /tmp/brioche-packages/packages/3cpio /tmp/brioche-packages/packages/64tass /tmp/brioche-packages/packages/6tunnel /tmp/brioche-packages/packages/aardvark_dns /tmp/brioche-packages/packages/acl /tmp/brioche-packages/packages/acme_redirect /tmp/brioche-packages/packages/act /tmp/brioche-packages/packages/action_validator /tmp/brioche-packages/packages/actionlint /tmp/brioche-packages/packages/addlicense /tmp/brioche-packages/packages/aerleon /tmp/brioche-packages/packages/afio /tmp/brioche-packages/packages/aften /tmp/brioche-packages/packages/age /tmp/brioche-packages/packages/age_plugin_tpm /tmp/brioche-packages/packages/age_plugin_yubikey /tmp/brioche-packages/packages/aicommit2 /tmp/brioche-packages/packages/aks_mcp_server /tmp/brioche-packages/packages/aliyun_cli /tmp/brioche-packages/packages/alsa_lib /tmp/brioche-packages/packages/amber /tmp/brioche-packages/packages/aom /tmp/brioche-packages/packages/apko /tmp/brioche-packages/packages/arduino_cli /tmp/brioche-packages/packages/argocd /tmp/brioche-packages/packages/argparse /tmp/brioche-packages/packages/asc /tmp/brioche-packages/packages/asciinema /tmp/brioche-packages/packages/asdf /tmp/brioche-packages/packages/asmfmt /tmp/brioche-packages/packages/ast_grep /tmp/brioche-packages/packages/atomic_queue /tmp/brioche-packages/packages/attempt_cli /tmp/brioche-packages/packages/audit /tmp/brioche-packages/packages/autoconf_archive /tmp/brioche-packages/packages/autoprefixer /tmp/brioche-packages/packages/avahi /tmp/brioche-packages/packages/avbroot /tmp/brioche-packages/packages/avfs /tmp/brioche-packages/packages/aws_c_auth /tmp/brioche-packages/packages/aws_c_cal /tmp/brioche-packages/packages/aws_c_common /tmp/brioche-packages/packages/aws_c_compression /tmp/brioche-packages/packages/aws_c_event_stream /tmp/brioche-packages/packages/aws_c_http /tmp/brioche-packages/packages/aws_c_io /tmp/brioche-packages/packages/aws_c_mqtt /tmp/brioche-packages/packages/aws_c_s3 /tmp/brioche-packages/packages/aws_c_sdkutils /tmp/brioche-packages/packages/aws_cdk /tmp/brioche-packages/packages/aws_checksums /tmp/brioche-packages/packages/aws_cli /tmp/brioche-packages/packages/aws_crt_cpp /tmp/brioche-packages/packages/aws_iam_authenticator /tmp/brioche-packages/packages/aws_sdk_cpp /tmp/brioche-packages/packages/azcopy /tmp/brioche-packages/packages/bacon /tmp/brioche-packages/packages/bacon_ls /tmp/brioche-packages/packages/bash_language_server /tmp/brioche-packages/packages/bat /tmp/brioche-packages/packages/bctoolbox /tmp/brioche-packages/packages/beancount_language_server /tmp/brioche-packages/packages/berkeley_db /tmp/brioche-packages/packages/better_commits /tmp/brioche-packages/packages/bgpdump /tmp/brioche-packages/packages/binaryen /tmp/brioche-packages/packages/binsider /tmp/brioche-packages/packages/biome /tmp/brioche-packages/packages/bkmr /tmp/brioche-packages/packages/blake3 /tmp/brioche-packages/packages/boehm_gc /tmp/brioche-packages/packages/boost /tmp/brioche-packages/packages/bosh_cli /tmp/brioche-packages/packages/brook /tmp/brioche-packages/packages/broot /tmp/brioche-packages/packages/brotli /tmp/brioche-packages/packages/bubblewrap /tmp/brioche-packages/packages/bugstalker /tmp/brioche-packages/packages/build2 /tmp/brioche-packages/packages/bullet /tmp/brioche-packages/packages/byacc /tmp/brioche-packages/packages/c2rust /tmp/brioche-packages/packages/c_ares /tmp/brioche-packages/packages/c_blosc /tmp/brioche-packages/packages/c_blosc2 /tmp/brioche-packages/packages/ca_certificates /tmp/brioche-packages/packages/cabal_install /tmp/brioche-packages/packages/caddy /tmp/brioche-packages/packages/cadical /tmp/brioche-packages/packages/cairo /tmp/brioche-packages/packages/caligula /tmp/brioche-packages/packages/carapace /tmp/brioche-packages/packages/cargo_about /tmp/brioche-packages/packages/cargo_audit /tmp/brioche-packages/packages/cargo_binstall /tmp/brioche-packages/packages/cargo_binutils /tmp/brioche-packages/packages/cargo_bisect_rustc /tmp/brioche-packages/packages/cargo_bloat /tmp/brioche-packages/packages/cargo_c /tmp/brioche-packages/packages/cargo_chef /tmp/brioche-packages/packages/cargo_deny /tmp/brioche-packages/packages/cargo_dist /tmp/brioche-packages/packages/cargo_edit /tmp/brioche-packages/packages/cargo_expand /tmp/brioche-packages/packages/cargo_flamegraph /tmp/brioche-packages/packages/cargo_fuzz /tmp/brioche-packages/packages/cargo_generate /tmp/brioche-packages/packages/cargo_hack /tmp/brioche-packages/packages/cargo_insta /tmp/brioche-packages/packages/cargo_leptos /tmp/brioche-packages/packages/cargo_llvm_cov /tmp/brioche-packages/packages/cargo_llvm_lines /tmp/brioche-packages/packages/cargo_machete /tmp/brioche-packages/packages/cargo_make /tmp/brioche-packages/packages/cargo_minimal_versions /tmp/brioche-packages/packages/cargo_msrv /tmp/brioche-packages/packages/cargo_mutants /tmp/brioche-packages/packages/cargo_nextest /tmp/brioche-packages/packages/cargo_no_dev_deps /tmp/brioche-packages/packages/cargo_outdated /tmp/brioche-packages/packages/cargo_quickinstall /tmp/brioche-packages/packages/cargo_readme /tmp/brioche-packages/packages/cargo_release /tmp/brioche-packages/packages/cargo_shear /tmp/brioche-packages/packages/cargo_smart_release /tmp/brioche-packages/packages/cargo_sort /tmp/brioche-packages/packages/cargo_spellcheck /tmp/brioche-packages/packages/cargo_tarpaulin /tmp/brioche-packages/packages/cargo_udeps /tmp/brioche-packages/packages/cargo_update /tmp/brioche-packages/packages/cargo_zigbuild /tmp/brioche-packages/packages/cbindgen /tmp/brioche-packages/packages/ccusage /tmp/brioche-packages/packages/cdebug /tmp/brioche-packages/packages/centrifugo /tmp/brioche-packages/packages/cereal /tmp/brioche-packages/packages/cf_terraforming /tmp/brioche-packages/packages/cfitsio /tmp/brioche-packages/packages/cgal /tmp/brioche-packages/packages/cglm /tmp/brioche-packages/packages/chezmoi /tmp/brioche-packages/packages/cilium_cli /tmp/brioche-packages/packages/ck_search /tmp/brioche-packages/packages/claude_code /tmp/brioche-packages/packages/cli11 /tmp/brioche-packages/packages/cliproxyapi /tmp/brioche-packages/packages/clive /tmp/brioche-packages/packages/clorinde /tmp/brioche-packages/packages/cloud_nuke /tmp/brioche-packages/packages/clzip /tmp/brioche-packages/packages/cmake /tmp/brioche-packages/packages/cmctl /tmp/brioche-packages/packages/cntr /tmp/brioche-packages/packages/codebook /tmp/brioche-packages/packages/codex /tmp/brioche-packages/packages/commitlint /tmp/brioche-packages/packages/comrak /tmp/brioche-packages/packages/conftest /tmp/brioche-packages/packages/console_bridge /tmp/brioche-packages/packages/copilot_language_server /tmp/brioche-packages/packages/coredns /tmp/brioche-packages/packages/corrosion /tmp/brioche-packages/packages/cosign /tmp/brioche-packages/packages/coturn /tmp/brioche-packages/packages/cpio /tmp/brioche-packages/packages/cpp_httplib /tmp/brioche-packages/packages/cppcheck /tmp/brioche-packages/packages/cpptoml /tmp/brioche-packages/packages/cpu_features /tmp/brioche-packages/packages/cspell /tmp/brioche-packages/packages/cubejs_cli /tmp/brioche-packages/packages/cups /tmp/brioche-packages/packages/curl /tmp/brioche-packages/packages/cyrus_sasl /tmp/brioche-packages/packages/cython /tmp/brioche-packages/packages/dagger /tmp/brioche-packages/packages/dart /tmp/brioche-packages/packages/dasel /tmp/brioche-packages/packages/databricks_cli /tmp/brioche-packages/packages/datafusion_cli /tmp/brioche-packages/packages/dav1d /tmp/brioche-packages/packages/dbmate /tmp/brioche-packages/packages/dbus /tmp/brioche-packages/packages/dclint /tmp/brioche-packages/packages/deark /tmp/brioche-packages/packages/delta /tmp/brioche-packages/packages/delve /tmp/brioche-packages/packages/deno /tmp/brioche-packages/packages/dependabot /tmp/brioche-packages/packages/depot /tmp/brioche-packages/packages/difftastic /tmp/brioche-packages/packages/dioxus_cli /tmp/brioche-packages/packages/directx_headers /tmp/brioche-packages/packages/docbook /tmp/brioche-packages/packages/docbook_xsl /tmp/brioche-packages/packages/docker_buildx /tmp/brioche-packages/packages/docker_compose /tmp/brioche-packages/packages/docutils /tmp/brioche-packages/packages/dolt /tmp/brioche-packages/packages/dot_language_server /tmp/brioche-packages/packages/double_conversion /tmp/brioche-packages/packages/doxygen /tmp/brioche-packages/packages/dprint /tmp/brioche-packages/packages/draco /tmp/brioche-packages/packages/dsvpn /tmp/brioche-packages/packages/duckdb /tmp/brioche-packages/packages/duktape /tmp/brioche-packages/packages/dumbpipe /tmp/brioche-packages/packages/dust /tmp/brioche-packages/packages/dysk /tmp/brioche-packages/packages/eask_cli /tmp/brioche-packages/packages/ecl /tmp/brioche-packages/packages/editline /tmp/brioche-packages/packages/eigen /tmp/brioche-packages/packages/eks_node_viewer /tmp/brioche-packages/packages/elfio /tmp/brioche-packages/packages/elfutils /tmp/brioche-packages/packages/emmylua_check /tmp/brioche-packages/packages/epsilon /tmp/brioche-packages/packages/erlang /tmp/brioche-packages/packages/esbuild /tmp/brioche-packages/packages/eslint /tmp/brioche-packages/packages/expat /tmp/brioche-packages/packages/eza /tmp/brioche-packages/packages/faac /tmp/brioche-packages/packages/faad2 /tmp/brioche-packages/packages/fabio /tmp/brioche-packages/packages/fabric_ai /tmp/brioche-packages/packages/fast_float /tmp/brioche-packages/packages/fastly /tmp/brioche-packages/packages/fd /tmp/brioche-packages/packages/fdk_aac /tmp/brioche-packages/packages/fence /tmp/brioche-packages/packages/fftw /tmp/brioche-packages/packages/file /tmp/brioche-packages/packages/filebrowser /tmp/brioche-packages/packages/fio /tmp/brioche-packages/packages/fizz /tmp/brioche-packages/packages/flac /tmp/brioche-packages/packages/flatbuffers /tmp/brioche-packages/packages/flint /tmp/brioche-packages/packages/fluidsynth /tmp/brioche-packages/packages/fmt /tmp/brioche-packages/packages/fnox /tmp/brioche-packages/packages/folly /tmp/brioche-packages/packages/font_iosevka /tmp/brioche-packages/packages/font_util /tmp/brioche-packages/packages/fontconfig /tmp/brioche-packages/packages/fonttools /tmp/brioche-packages/packages/forgejo_cli /tmp/brioche-packages/packages/forgejo_runner /tmp/brioche-packages/packages/fping /tmp/brioche-packages/packages/freealut /tmp/brioche-packages/packages/freeglut /tmp/brioche-packages/packages/freeimage /tmp/brioche-packages/packages/freetype /tmp/brioche-packages/packages/freexl /tmp/brioche-packages/packages/fresh_editor /tmp/brioche-packages/packages/fribidi /tmp/brioche-packages/packages/functionalplus /tmp/brioche-packages/packages/fx /tmp/brioche-packages/packages/fypp /tmp/brioche-packages/packages/fzf /tmp/brioche-packages/packages/game_music_emu /tmp/brioche-packages/packages/gd /tmp/brioche-packages/packages/gdbm /tmp/brioche-packages/packages/gemini_cli /tmp/brioche-packages/packages/gengetopt /tmp/brioche-packages/packages/geos /tmp/brioche-packages/packages/gersemi /tmp/brioche-packages/packages/gettext /tmp/brioche-packages/packages/gflags /tmp/brioche-packages/packages/gfold /tmp/brioche-packages/packages/ghc /tmp/brioche-packages/packages/giflib /tmp/brioche-packages/packages/git /tmp/brioche-packages/packages/git_cliff /tmp/brioche-packages/packages/git_codereview /tmp/brioche-packages/packages/git_grab /tmp/brioche-packages/packages/git_spice /tmp/brioche-packages/packages/gitea_mcp_server /tmp/brioche-packages/packages/gitea_runner /tmp/brioche-packages/packages/github_cli /tmp/brioche-packages/packages/github_copilot_cli /tmp/brioche-packages/packages/github_mcp_server /tmp/brioche-packages/packages/gitlab_runner /tmp/brioche-packages/packages/gitlogue /tmp/brioche-packages/packages/gitnr /tmp/brioche-packages/packages/gitui /tmp/brioche-packages/packages/glab /tmp/brioche-packages/packages/glaze /tmp/brioche-packages/packages/gleam /tmp/brioche-packages/packages/glib /tmp/brioche-packages/packages/glm /tmp/brioche-packages/packages/glog /tmp/brioche-packages/packages/glslang /tmp/brioche-packages/packages/glu /tmp/brioche-packages/packages/gmp /tmp/brioche-packages/packages/gnutls /tmp/brioche-packages/packages/go /tmp/brioche-packages/packages/go_md2man /tmp/brioche-packages/packages/go_mockery /tmp/brioche-packages/packages/go_security_tracker /tmp/brioche-packages/packages/go_size_analyzer /tmp/brioche-packages/packages/go_task /tmp/brioche-packages/packages/gobject_introspection /tmp/brioche-packages/packages/golangci_lint /tmp/brioche-packages/packages/gopls /tmp/brioche-packages/packages/goreleaser /tmp/brioche-packages/packages/gosec /tmp/brioche-packages/packages/gost /tmp/brioche-packages/packages/gperf /tmp/brioche-packages/packages/graphite2 /tmp/brioche-packages/packages/graphql_client_cli /tmp/brioche-packages/packages/grcov /tmp/brioche-packages/packages/grokj2k /tmp/brioche-packages/packages/gron /tmp/brioche-packages/packages/gsettings_desktop_schemas /tmp/brioche-packages/packages/gsl /tmp/brioche-packages/packages/gtest /tmp/brioche-packages/packages/gum /tmp/brioche-packages/packages/harbor_cli /tmp/brioche-packages/packages/harfbuzz /tmp/brioche-packages/packages/harper /tmp/brioche-packages/packages/harsh /tmp/brioche-packages/packages/hath_rust /tmp/brioche-packages/packages/hcloud /tmp/brioche-packages/packages/hdf5 /tmp/brioche-packages/packages/headscale /tmp/brioche-packages/packages/helix /tmp/brioche-packages/packages/hello_world /tmp/brioche-packages/packages/helm /tmp/brioche-packages/packages/helm_docs /tmp/brioche-packages/packages/helmfile /tmp/brioche-packages/packages/helmify /tmp/brioche-packages/packages/help2man /tmp/brioche-packages/packages/hicolor_icon_theme /tmp/brioche-packages/packages/highs /tmp/brioche-packages/packages/highway /tmp/brioche-packages/packages/hl /tmp/brioche-packages/packages/howard_hinnant_date /tmp/brioche-packages/packages/htmlhint /tmp/brioche-packages/packages/htop /tmp/brioche-packages/packages/httm /tmp/brioche-packages/packages/http_prompt /tmp/brioche-packages/packages/http_server /tmp/brioche-packages/packages/httpie /tmp/brioche-packages/packages/httping /tmp/brioche-packages/packages/httpx /tmp/brioche-packages/packages/hugo /tmp/brioche-packages/packages/hunspell /tmp/brioche-packages/packages/hwloc /tmp/brioche-packages/packages/hyperfine /tmp/brioche-packages/packages/hysteria /tmp/brioche-packages/packages/iamlive /tmp/brioche-packages/packages/icu /tmp/brioche-packages/packages/igrep /tmp/brioche-packages/packages/imagemagick /tmp/brioche-packages/packages/imake /tmp/brioche-packages/packages/imapgoose /tmp/brioche-packages/packages/imath /tmp/brioche-packages/packages/imessage_exporter /tmp/brioche-packages/packages/imlib2 /tmp/brioche-packages/packages/impala /tmp/brioche-packages/packages/infisical /tmp/brioche-packages/packages/inframap /tmp/brioche-packages/packages/inih /tmp/brioche-packages/packages/iniparser /tmp/brioche-packages/packages/iperf3 /tmp/brioche-packages/packages/ipget /tmp/brioche-packages/packages/ipsw /tmp/brioche-packages/packages/ironclaw /tmp/brioche-packages/packages/isl /tmp/brioche-packages/packages/iso_codes /tmp/brioche-packages/packages/istioctl /tmp/brioche-packages/packages/itstool /tmp/brioche-packages/packages/jansson /tmp/brioche-packages/packages/jaq /tmp/brioche-packages/packages/jarl /tmp/brioche-packages/packages/jasper /tmp/brioche-packages/packages/jbig2dec /tmp/brioche-packages/packages/jd /tmp/brioche-packages/packages/jemalloc /tmp/brioche-packages/packages/jjui /tmp/brioche-packages/packages/joshuto /tmp/brioche-packages/packages/jq /tmp/brioche-packages/packages/jq_lsp /tmp/brioche-packages/packages/json_c /tmp/brioche-packages/packages/json_spirit /tmp/brioche-packages/packages/jsoncpp /tmp/brioche-packages/packages/jujutsu /tmp/brioche-packages/packages/jumppad /tmp/brioche-packages/packages/just /tmp/brioche-packages/packages/jvgrep /tmp/brioche-packages/packages/jwt_cli /tmp/brioche-packages/packages/k9s /tmp/brioche-packages/packages/kakoune /tmp/brioche-packages/packages/karmadactl /tmp/brioche-packages/packages/keep_sorted /tmp/brioche-packages/packages/kmod /tmp/brioche-packages/packages/kor /tmp/brioche-packages/packages/krb5 /tmp/brioche-packages/packages/krr /tmp/brioche-packages/packages/ksh /tmp/brioche-packages/packages/kubectl_cnpg /tmp/brioche-packages/packages/kubectl_view_allocations /tmp/brioche-packages/packages/kubent /tmp/brioche-packages/packages/kubescape /tmp/brioche-packages/packages/kubetail /tmp/brioche-packages/packages/kubie /tmp/brioche-packages/packages/ladybug /tmp/brioche-packages/packages/lame /tmp/brioche-packages/packages/lasso /tmp/brioche-packages/packages/lazygit /tmp/brioche-packages/packages/lcms2 /tmp/brioche-packages/packages/leetcode_cli /tmp/brioche-packages/packages/lefthook /tmp/brioche-packages/packages/leptonica /tmp/brioche-packages/packages/lerc /tmp/brioche-packages/packages/leveldb /tmp/brioche-packages/packages/lf /tmp/brioche-packages/packages/libaec /tmp/brioche-packages/packages/libaio /tmp/brioche-packages/packages/libapparmor /tmp/brioche-packages/packages/libarchive /tmp/brioche-packages/packages/libassuan /tmp/brioche-packages/packages/libatomic_ops /tmp/brioche-packages/packages/libavif /tmp/brioche-packages/packages/libb2 /tmp/brioche-packages/packages/libb64 /tmp/brioche-packages/packages/libbsd /tmp/brioche-packages/packages/libcaca /tmp/brioche-packages/packages/libcacard /tmp/brioche-packages/packages/libcanberra /tmp/brioche-packages/packages/libcap /tmp/brioche-packages/packages/libcap_ng /tmp/brioche-packages/packages/libcaption /tmp/brioche-packages/packages/libcbor /tmp/brioche-packages/packages/libclc /tmp/brioche-packages/packages/libcoap /tmp/brioche-packages/packages/libcuefile /tmp/brioche-packages/packages/libcyaml /tmp/brioche-packages/packages/libdaemon /tmp/brioche-packages/packages/libdatrie /tmp/brioche-packages/packages/libde265 /tmp/brioche-packages/packages/libdeflate /tmp/brioche-packages/packages/libdnet /tmp/brioche-packages/packages/libdrm /tmp/brioche-packages/packages/libebur128 /tmp/brioche-packages/packages/libedit /tmp/brioche-packages/packages/libepoxy /tmp/brioche-packages/packages/libev /tmp/brioche-packages/packages/libevent /tmp/brioche-packages/packages/libfabric /tmp/brioche-packages/packages/libfaketime /tmp/brioche-packages/packages/libffi /tmp/brioche-packages/packages/libfontenc /tmp/brioche-packages/packages/libfs /tmp/brioche-packages/packages/libfuse /tmp/brioche-packages/packages/libfyaml /tmp/brioche-packages/packages/libgcrypt /tmp/brioche-packages/packages/libgeotiff /tmp/brioche-packages/packages/libgit2 /tmp/brioche-packages/packages/libgpg_error /tmp/brioche-packages/packages/libgsf /tmp/brioche-packages/packages/libheif /tmp/brioche-packages/packages/libice /tmp/brioche-packages/packages/libiconv /tmp/brioche-packages/packages/libid3tag /tmp/brioche-packages/packages/libidn /tmp/brioche-packages/packages/libidn2 /tmp/brioche-packages/packages/libimagequant /tmp/brioche-packages/packages/libint /tmp/brioche-packages/packages/libiptcdata /tmp/brioche-packages/packages/libjpeg /tmp/brioche-packages/packages/libjpeg_turbo /tmp/brioche-packages/packages/libjxl /tmp/brioche-packages/packages/libkml /tmp/brioche-packages/packages/libks /tmp/brioche-packages/packages/libksba /tmp/brioche-packages/packages/liblc3 /tmp/brioche-packages/packages/liblockfile /tmp/brioche-packages/packages/liblqr /tmp/brioche-packages/packages/libmd /tmp/brioche-packages/packages/libmicrohttpd /tmp/brioche-packages/packages/libmikmod /tmp/brioche-packages/packages/libmongocrypt /tmp/brioche-packages/packages/libmpc /tmp/brioche-packages/packages/libmpdclient /tmp/brioche-packages/packages/libmysofa /tmp/brioche-packages/packages/libnet /tmp/brioche-packages/packages/libnfs /tmp/brioche-packages/packages/libnl /tmp/brioche-packages/packages/libnova /tmp/brioche-packages/packages/libnpupnp /tmp/brioche-packages/packages/libogg /tmp/brioche-packages/packages/libpcap /tmp/brioche-packages/packages/libpciaccess /tmp/brioche-packages/packages/libpipeline /tmp/brioche-packages/packages/libpng /tmp/brioche-packages/packages/libpoly /tmp/brioche-packages/packages/libpsl /tmp/brioche-packages/packages/libraw /tmp/brioche-packages/packages/librdkafka /tmp/brioche-packages/packages/libreplaygain /tmp/brioche-packages/packages/librttopo /tmp/brioche-packages/packages/libsamplerate /tmp/brioche-packages/packages/libsass /tmp/brioche-packages/packages/libseccomp /tmp/brioche-packages/packages/libselinux /tmp/brioche-packages/packages/libsemanage /tmp/brioche-packages/packages/libsepol /tmp/brioche-packages/packages/libshout /tmp/brioche-packages/packages/libsm /tmp/brioche-packages/packages/libsndfile /tmp/brioche-packages/packages/libsodium /tmp/brioche-packages/packages/libspatialite /tmp/brioche-packages/packages/libsrtp /tmp/brioche-packages/packages/libssh /tmp/brioche-packages/packages/libssh2 /tmp/brioche-packages/packages/libtasn1 /tmp/brioche-packages/packages/libthai /tmp/brioche-packages/packages/libtheora /tmp/brioche-packages/packages/libtiff /tmp/brioche-packages/packages/libtirpc /tmp/brioche-packages/packages/libtommath /tmp/brioche-packages/packages/libtrace /tmp/brioche-packages/packages/libudev_zero /tmp/brioche-packages/packages/libudfread /tmp/brioche-packages/packages/libunibreak /tmp/brioche-packages/packages/libunistring /tmp/brioche-packages/packages/libunwind /tmp/brioche-packages/packages/libupnp /tmp/brioche-packages/packages/libupnpp /tmp/brioche-packages/packages/liburing /tmp/brioche-packages/packages/libusb /tmp/brioche-packages/packages/libva /tmp/brioche-packages/packages/libvmaf /tmp/brioche-packages/packages/libvorbis /tmp/brioche-packages/packages/libvpx /tmp/brioche-packages/packages/libwandder /tmp/brioche-packages/packages/libwebp /tmp/brioche-packages/packages/libx11 /tmp/brioche-packages/packages/libxau /tmp/brioche-packages/packages/libxaw /tmp/brioche-packages/packages/libxaw3d /tmp/brioche-packages/packages/libxc /tmp/brioche-packages/packages/libxcb /tmp/brioche-packages/packages/libxcomposite /tmp/brioche-packages/packages/libxcrypt /tmp/brioche-packages/packages/libxcursor /tmp/brioche-packages/packages/libxcvt /tmp/brioche-packages/packages/libxdamage /tmp/brioche-packages/packages/libxdmcp /tmp/brioche-packages/packages/libxext /tmp/brioche-packages/packages/libxfixes /tmp/brioche-packages/packages/libxfont2 /tmp/brioche-packages/packages/libxft /tmp/brioche-packages/packages/libxi /tmp/brioche-packages/packages/libxinerama /tmp/brioche-packages/packages/libxkbcommon /tmp/brioche-packages/packages/libxkbfile /tmp/brioche-packages/packages/libxml2 /tmp/brioche-packages/packages/libxmp /tmp/brioche-packages/packages/libxmu /tmp/brioche-packages/packages/libxpm /tmp/brioche-packages/packages/libxpresent /tmp/brioche-packages/packages/libxrandr /tmp/brioche-packages/packages/libxrender /tmp/brioche-packages/packages/libxres /tmp/brioche-packages/packages/libxscrnsaver /tmp/brioche-packages/packages/libxshmfence /tmp/brioche-packages/packages/libxslt /tmp/brioche-packages/packages/libxt /tmp/brioche-packages/packages/libxtst /tmp/brioche-packages/packages/libxv /tmp/brioche-packages/packages/libxvmc /tmp/brioche-packages/packages/libxxf86dga /tmp/brioche-packages/packages/libxxf86vm /tmp/brioche-packages/packages/libyaml /tmp/brioche-packages/packages/libyuv /tmp/brioche-packages/packages/libzip /tmp/brioche-packages/packages/limine /tmp/brioche-packages/packages/lint_staged /tmp/brioche-packages/packages/lintspec /tmp/brioche-packages/packages/linux /tmp/brioche-packages/packages/linux_pam /tmp/brioche-packages/packages/lisette /tmp/brioche-packages/packages/lksctp_tools /tmp/brioche-packages/packages/lla /tmp/brioche-packages/packages/llmfit /tmp/brioche-packages/packages/llvm /tmp/brioche-packages/packages/llvm_lit /tmp/brioche-packages/packages/lm_sensors /tmp/brioche-packages/packages/lrzip /tmp/brioche-packages/packages/lua /tmp/brioche-packages/packages/luau /tmp/brioche-packages/packages/luau_lsp /tmp/brioche-packages/packages/lurk /tmp/brioche-packages/packages/lz4 /tmp/brioche-packages/packages/lzip /tmp/brioche-packages/packages/lziprecover /tmp/brioche-packages/packages/lzlib /tmp/brioche-packages/packages/lzo /tmp/brioche-packages/packages/lzop /tmp/brioche-packages/packages/magic_enum /tmp/brioche-packages/packages/mailpit /tmp/brioche-packages/packages/marisa /tmp/brioche-packages/packages/markdown_oxide /tmp/brioche-packages/packages/markdownlint_cli /tmp/brioche-packages/packages/markdownlint_cli2 /tmp/brioche-packages/packages/mcap /tmp/brioche-packages/packages/mcp_server_kubernetes /tmp/brioche-packages/packages/md4c /tmp/brioche-packages/packages/mdbook /tmp/brioche-packages/packages/meilisearch /tmp/brioche-packages/packages/melange /tmp/brioche-packages/packages/mergiraf /tmp/brioche-packages/packages/mesa /tmp/brioche-packages/packages/mesheryctl /tmp/brioche-packages/packages/meson /tmp/brioche-packages/packages/microsoft_gsl /tmp/brioche-packages/packages/mikmod /tmp/brioche-packages/packages/mimalloc /tmp/brioche-packages/packages/miniflux /tmp/brioche-packages/packages/minisat /tmp/brioche-packages/packages/miniserve /tmp/brioche-packages/packages/minizip /tmp/brioche-packages/packages/minizip_ng /tmp/brioche-packages/packages/mise /tmp/brioche-packages/packages/mitmproxy /tmp/brioche-packages/packages/mollysocket /tmp/brioche-packages/packages/mongo_c_driver /tmp/brioche-packages/packages/mongo_cxx_driver /tmp/brioche-packages/packages/monit /tmp/brioche-packages/packages/monocle /tmp/brioche-packages/packages/moor /tmp/brioche-packages/packages/moreutils /tmp/brioche-packages/packages/mpdecimal /tmp/brioche-packages/packages/mpfr /tmp/brioche-packages/packages/mpg123 /tmp/brioche-packages/packages/mq /tmp/brioche-packages/packages/mtools /tmp/brioche-packages/packages/mummer /tmp/brioche-packages/packages/munge /tmp/brioche-packages/packages/mutagen /tmp/brioche-packages/packages/mvfst /tmp/brioche-packages/packages/n8n_mcp /tmp/brioche-packages/packages/nasm /tmp/brioche-packages/packages/navidrome /tmp/brioche-packages/packages/nbytes /tmp/brioche-packages/packages/ncbi_vdb /tmp/brioche-packages/packages/ncps /tmp/brioche-packages/packages/ncurses /tmp/brioche-packages/packages/net_tools /tmp/brioche-packages/packages/netbird /tmp/brioche-packages/packages/netcdf /tmp/brioche-packages/packages/nettle /tmp/brioche-packages/packages/newrelic_cli /tmp/brioche-packages/packages/nexttrace /tmp/brioche-packages/packages/nextvi /tmp/brioche-packages/packages/nghttp2 /tmp/brioche-packages/packages/nghttp3 /tmp/brioche-packages/packages/nginx /tmp/brioche-packages/packages/ngt /tmp/brioche-packages/packages/ngtcp2 /tmp/brioche-packages/packages/nickel /tmp/brioche-packages/packages/ninja /tmp/brioche-packages/packages/nix_init /tmp/brioche-packages/packages/nlohmann_json /tmp/brioche-packages/packages/nlohmann_json_schema_validator /tmp/brioche-packages/packages/nodejs /tmp/brioche-packages/packages/noti /tmp/brioche-packages/packages/npq /tmp/brioche-packages/packages/npth /tmp/brioche-packages/packages/nspr /tmp/brioche-packages/packages/nss /tmp/brioche-packages/packages/numactl /tmp/brioche-packages/packages/numcpp /tmp/brioche-packages/packages/numdiff /tmp/brioche-packages/packages/numpy /tmp/brioche-packages/packages/nushell /tmp/brioche-packages/packages/nuspell /tmp/brioche-packages/packages/nvm /tmp/brioche-packages/packages/ocaml /tmp/brioche-packages/packages/oh_my_posh /tmp/brioche-packages/packages/oha /tmp/brioche-packages/packages/onednn /tmp/brioche-packages/packages/oniguruma /tmp/brioche-packages/packages/open_policy_agent /tmp/brioche-packages/packages/openal_soft /tmp/brioche-packages/packages/openapv /tmp/brioche-packages/packages/openblas /tmp/brioche-packages/packages/opencore_amr /tmp/brioche-packages/packages/openexr /tmp/brioche-packages/packages/openjpeg /tmp/brioche-packages/packages/openjph /tmp/brioche-packages/packages/openmp /tmp/brioche-packages/packages/openmpi /tmp/brioche-packages/packages/openslp /tmp/brioche-packages/packages/openssl /tmp/brioche-packages/packages/opentofu /tmp/brioche-packages/packages/opus /tmp/brioche-packages/packages/opusfile /tmp/brioche-packages/packages/orc /tmp/brioche-packages/packages/ortp /tmp/brioche-packages/packages/oterm /tmp/brioche-packages/packages/otfcc /tmp/brioche-packages/packages/ov /tmp/brioche-packages/packages/ovh_ttyrec /tmp/brioche-packages/packages/oxfmt /tmp/brioche-packages/packages/oxlint /tmp/brioche-packages/packages/p11_kit /tmp/brioche-packages/packages/pack /tmp/brioche-packages/packages/packer /tmp/brioche-packages/packages/pappl /tmp/brioche-packages/packages/parallel_hashmap /tmp/brioche-packages/packages/parlay /tmp/brioche-packages/packages/parqeye /tmp/brioche-packages/packages/parquet_tools /tmp/brioche-packages/packages/patch /tmp/brioche-packages/packages/pcre /tmp/brioche-packages/packages/pcre2 /tmp/brioche-packages/packages/pcsc_lite /tmp/brioche-packages/packages/pdfrip /tmp/brioche-packages/packages/pdlzip /tmp/brioche-packages/packages/perl /tmp/brioche-packages/packages/php /tmp/brioche-packages/packages/physfs /tmp/brioche-packages/packages/pinact /tmp/brioche-packages/packages/pinentry /tmp/brioche-packages/packages/pingme /tmp/brioche-packages/packages/pipewire /tmp/brioche-packages/packages/pixman /tmp/brioche-packages/packages/plocate /tmp/brioche-packages/packages/plzip /tmp/brioche-packages/packages/pmix /tmp/brioche-packages/packages/pngcrush /tmp/brioche-packages/packages/pngnq /tmp/brioche-packages/packages/pnpm /tmp/brioche-packages/packages/pocketbase /tmp/brioche-packages/packages/poco /tmp/brioche-packages/packages/podlet /tmp/brioche-packages/packages/poetry /tmp/brioche-packages/packages/popeye /tmp/brioche-packages/packages/popt /tmp/brioche-packages/packages/portaudio /tmp/brioche-packages/packages/poselib /tmp/brioche-packages/packages/postgresql /tmp/brioche-packages/packages/prek /tmp/brioche-packages/packages/premake /tmp/brioche-packages/packages/prettier /tmp/brioche-packages/packages/process_compose /tmp/brioche-packages/packages/proj /tmp/brioche-packages/packages/promptfoo /tmp/brioche-packages/packages/proot /tmp/brioche-packages/packages/prrte /tmp/brioche-packages/packages/pstack /tmp/brioche-packages/packages/pugixml /tmp/brioche-packages/packages/pulseaudio /tmp/brioche-packages/packages/pulumi /tmp/brioche-packages/packages/pv /tmp/brioche-packages/packages/pvetui /tmp/brioche-packages/packages/pycparser /tmp/brioche-packages/packages/pyrefly /tmp/brioche-packages/packages/python /tmp/brioche-packages/packages/qhull /tmp/brioche-packages/packages/qsv /tmp/brioche-packages/packages/ragel /tmp/brioche-packages/packages/railway /tmp/brioche-packages/packages/range_v3 /tmp/brioche-packages/packages/rapidjson /tmp/brioche-packages/packages/rav1e /tmp/brioche-packages/packages/rbspy /tmp/brioche-packages/packages/rclone /tmp/brioche-packages/packages/rdma_core /tmp/brioche-packages/packages/re2c /tmp/brioche-packages/packages/readline /tmp/brioche-packages/packages/redis /tmp/brioche-packages/packages/redocly /tmp/brioche-packages/packages/redumper /tmp/brioche-packages/packages/remake /tmp/brioche-packages/packages/renovate /tmp/brioche-packages/packages/reproc /tmp/brioche-packages/packages/resterm /tmp/brioche-packages/packages/restic /tmp/brioche-packages/packages/restish /tmp/brioche-packages/packages/rip2 /tmp/brioche-packages/packages/ripgrep /tmp/brioche-packages/packages/rnr /tmp/brioche-packages/packages/robotframework /tmp/brioche-packages/packages/rosa /tmp/brioche-packages/packages/rpcsvc_proto /tmp/brioche-packages/packages/rpm_sequoia /tmp/brioche-packages/packages/rqlite /tmp/brioche-packages/packages/rsync /tmp/brioche-packages/packages/ruff /tmp/brioche-packages/packages/rulesync /tmp/brioche-packages/packages/rumdl /tmp/brioche-packages/packages/rust /tmp/brioche-packages/packages/rust_analyzer /tmp/brioche-packages/packages/rust_bindgen /tmp/brioche-packages/packages/rustic /tmp/brioche-packages/packages/rustnet /tmp/brioche-packages/packages/rv /tmp/brioche-packages/packages/s2argv_execs /tmp/brioche-packages/packages/s2n /tmp/brioche-packages/packages/safeint /tmp/brioche-packages/packages/sass /tmp/brioche-packages/packages/sassc /tmp/brioche-packages/packages/sccache /tmp/brioche-packages/packages/scdoc /tmp/brioche-packages/packages/scmpuff /tmp/brioche-packages/packages/sdl12_compat /tmp/brioche-packages/packages/sdl2 /tmp/brioche-packages/packages/sdl2_gfx /tmp/brioche-packages/packages/sdl2_image /tmp/brioche-packages/packages/sdl2_mixer /tmp/brioche-packages/packages/sdl2_net /tmp/brioche-packages/packages/sdl2_sound /tmp/brioche-packages/packages/sdl2_ttf /tmp/brioche-packages/packages/sdl3 /tmp/brioche-packages/packages/sdl3_image /tmp/brioche-packages/packages/sdl3_mixer /tmp/brioche-packages/packages/sdl3_ttf /tmp/brioche-packages/packages/seaweedfs /tmp/brioche-packages/packages/selene /tmp/brioche-packages/packages/sendme /tmp/brioche-packages/packages/sesh /tmp/brioche-packages/packages/sfcgal /tmp/brioche-packages/packages/sfml /tmp/brioche-packages/packages/shaderc /tmp/brioche-packages/packages/shadowsocks_rust /tmp/brioche-packages/packages/shared_mime_info /tmp/brioche-packages/packages/shellcheck /tmp/brioche-packages/packages/shfmt /tmp/brioche-packages/packages/simdjson /tmp/brioche-packages/packages/sipp /tmp/brioche-packages/packages/skim /tmp/brioche-packages/packages/slackdump /tmp/brioche-packages/packages/slang /tmp/brioche-packages/packages/smol_toml /tmp/brioche-packages/packages/snappy /tmp/brioche-packages/packages/snazy /tmp/brioche-packages/packages/socat /tmp/brioche-packages/packages/softhsm /tmp/brioche-packages/packages/soxr /tmp/brioche-packages/packages/spdlog /tmp/brioche-packages/packages/speex /tmp/brioche-packages/packages/speexdsp /tmp/brioche-packages/packages/spicedb /tmp/brioche-packages/packages/spirv_cross /tmp/brioche-packages/packages/spirv_headers /tmp/brioche-packages/packages/spirv_llvm_translator /tmp/brioche-packages/packages/spirv_tools /tmp/brioche-packages/packages/sqlcipher /tmp/brioche-packages/packages/sqlite /tmp/brioche-packages/packages/sqlx_cli /tmp/brioche-packages/packages/sqruff /tmp/brioche-packages/packages/sratoolkit /tmp/brioche-packages/packages/srt /tmp/brioche-packages/packages/starship /tmp/brioche-packages/packages/std /tmp/brioche-packages/packages/steampipe /tmp/brioche-packages/packages/stormlib /tmp/brioche-packages/packages/strace /tmp/brioche-packages/packages/stripe_cli /tmp/brioche-packages/packages/stylelint /tmp/brioche-packages/packages/superseedr /tmp/brioche-packages/packages/svt_av1 /tmp/brioche-packages/packages/svt_vp9 /tmp/brioche-packages/packages/swc /tmp/brioche-packages/packages/swig /tmp/brioche-packages/packages/syft /tmp/brioche-packages/packages/symfony_cli /tmp/brioche-packages/packages/syncthing /tmp/brioche-packages/packages/systemfd /tmp/brioche-packages/packages/taglib /tmp/brioche-packages/packages/tailspin /tmp/brioche-packages/packages/tailwindcss /tmp/brioche-packages/packages/talhelper /tmp/brioche-packages/packages/talloc /tmp/brioche-packages/packages/talm /tmp/brioche-packages/packages/tbls /tmp/brioche-packages/packages/tcl /tmp/brioche-packages/packages/tcpdump /tmp/brioche-packages/packages/tcsh /tmp/brioche-packages/packages/television /tmp/brioche-packages/packages/tenv /tmp/brioche-packages/packages/terraform /tmp/brioche-packages/packages/terraform_docs /tmp/brioche-packages/packages/terraform_ls /tmp/brioche-packages/packages/terraform_mcp_server /tmp/brioche-packages/packages/terragrunt /tmp/brioche-packages/packages/texlab /tmp/brioche-packages/packages/tflint /tmp/brioche-packages/packages/tfswitch /tmp/brioche-packages/packages/thrift /tmp/brioche-packages/packages/tiledb /tmp/brioche-packages/packages/tinycbor /tmp/brioche-packages/packages/tinyxml2 /tmp/brioche-packages/packages/tl_expected /tmp/brioche-packages/packages/tldx /tmp/brioche-packages/packages/tllist /tmp/brioche-packages/packages/tmux /tmp/brioche-packages/packages/tofrodos /tmp/brioche-packages/packages/tofu_ls /tmp/brioche-packages/packages/tokei /tmp/brioche-packages/packages/tokio_console /tmp/brioche-packages/packages/tombi /tmp/brioche-packages/packages/toml11 /tmp/brioche-packages/packages/topgrade /tmp/brioche-packages/packages/topiary /tmp/brioche-packages/packages/traefik /tmp/brioche-packages/packages/tree_sitter /tmp/brioche-packages/packages/treemd /tmp/brioche-packages/packages/trivy /tmp/brioche-packages/packages/trunk /tmp/brioche-packages/packages/tscli /tmp/brioche-packages/packages/ttdl /tmp/brioche-packages/packages/ttfautohint /tmp/brioche-packages/packages/ttyrec /tmp/brioche-packages/packages/tuios /tmp/brioche-packages/packages/ty /tmp/brioche-packages/packages/typer /tmp/brioche-packages/packages/typst /tmp/brioche-packages/packages/tzdata /tmp/brioche-packages/packages/uchardet /tmp/brioche-packages/packages/umka_lang /tmp/brioche-packages/packages/unbound /tmp/brioche-packages/packages/unibilium /tmp/brioche-packages/packages/unixodbc /tmp/brioche-packages/packages/unzip /tmp/brioche-packages/packages/urdfdom_headers /tmp/brioche-packages/packages/uriparser /tmp/brioche-packages/packages/urx /tmp/brioche-packages/packages/usage /tmp/brioche-packages/packages/usrsctp /tmp/brioche-packages/packages/utf8proc /tmp/brioche-packages/packages/uthash /tmp/brioche-packages/packages/util_macros /tmp/brioche-packages/packages/uutils_coreutils /tmp/brioche-packages/packages/uuu /tmp/brioche-packages/packages/uv /tmp/brioche-packages/packages/vacuum /tmp/brioche-packages/packages/valgrind /tmp/brioche-packages/packages/valijson /tmp/brioche-packages/packages/valkey /tmp/brioche-packages/packages/vault_unseal /tmp/brioche-packages/packages/vdeplug4 /tmp/brioche-packages/packages/vegeta /tmp/brioche-packages/packages/velero /tmp/brioche-packages/packages/vespa_cli /tmp/brioche-packages/packages/vet /tmp/brioche-packages/packages/vfox /tmp/brioche-packages/packages/vgt /tmp/brioche-packages/packages/victoriametrics /tmp/brioche-packages/packages/vidstab /tmp/brioche-packages/packages/vite /tmp/brioche-packages/packages/viu /tmp/brioche-packages/packages/volta /tmp/brioche-packages/packages/vtcode /tmp/brioche-packages/packages/vulkan_extensionlayer /tmp/brioche-packages/packages/vulkan_headers /tmp/brioche-packages/packages/vulkan_loader /tmp/brioche-packages/packages/vulkan_profiles /tmp/brioche-packages/packages/vulkan_tools /tmp/brioche-packages/packages/vulkan_utility_libraries /tmp/brioche-packages/packages/vulkan_volk /tmp/brioche-packages/packages/wabt /tmp/brioche-packages/packages/wakatime_cli /tmp/brioche-packages/packages/wandio /tmp/brioche-packages/packages/wasm_bindgen_cli /tmp/brioche-packages/packages/wasm_language_tools /tmp/brioche-packages/packages/wasm_pack /tmp/brioche-packages/packages/wasm_server_runner /tmp/brioche-packages/packages/wasm_tools /tmp/brioche-packages/packages/wasmtime /tmp/brioche-packages/packages/watchexec /tmp/brioche-packages/packages/wavpack /tmp/brioche-packages/packages/wayback /tmp/brioche-packages/packages/wayland /tmp/brioche-packages/packages/wayland_protocols /tmp/brioche-packages/packages/weaviate /tmp/brioche-packages/packages/webpack_cli /tmp/brioche-packages/packages/wget /tmp/brioche-packages/packages/wireguard_go /tmp/brioche-packages/packages/wireman /tmp/brioche-packages/packages/witr /tmp/brioche-packages/packages/wolfssl /tmp/brioche-packages/packages/wrangler /tmp/brioche-packages/packages/x264 /tmp/brioche-packages/packages/x265 /tmp/brioche-packages/packages/xauth /tmp/brioche-packages/packages/xcaddy /tmp/brioche-packages/packages/xcb_proto /tmp/brioche-packages/packages/xcb_util /tmp/brioche-packages/packages/xcb_util_cursor /tmp/brioche-packages/packages/xcb_util_errors /tmp/brioche-packages/packages/xcb_util_image /tmp/brioche-packages/packages/xcb_util_keysyms /tmp/brioche-packages/packages/xcb_util_renderutil /tmp/brioche-packages/packages/xcb_util_wm /tmp/brioche-packages/packages/xerces_c /tmp/brioche-packages/packages/xh /tmp/brioche-packages/packages/xk6 /tmp/brioche-packages/packages/xkeyboard_config /tmp/brioche-packages/packages/xlslib /tmp/brioche-packages/packages/xmlsec /tmp/brioche-packages/packages/xmlto /tmp/brioche-packages/packages/xorgproto /tmp/brioche-packages/packages/xplr /tmp/brioche-packages/packages/xsimd /tmp/brioche-packages/packages/xsv /tmp/brioche-packages/packages/xtrans /tmp/brioche-packages/packages/xvidcore /tmp/brioche-packages/packages/xxhash /tmp/brioche-packages/packages/xz /tmp/brioche-packages/packages/yajl /tmp/brioche-packages/packages/yaml_cpp /tmp/brioche-packages/packages/yaml_language_server /tmp/brioche-packages/packages/yasm /tmp/brioche-packages/packages/yazi /tmp/brioche-packages/packages/yoke /tmp/brioche-packages/packages/yyjson /tmp/brioche-packages/packages/z3 /tmp/brioche-packages/packages/zellij /tmp/brioche-packages/packages/zenith /tmp/brioche-packages/packages/zerofs /tmp/brioche-packages/packages/zimg /tmp/brioche-packages/packages/zizmor /tmp/brioche-packages/packages/zlib /tmp/brioche-packages/packages/zlib_ng /tmp/brioche-packages/packages/zoxide /tmp/brioche-packages/packages/zsign /tmp/brioche-packages/packages/zstd /tmp/brioche-packages/packages/zuban /tmp/brioche-packages/packages/zx /tmp/brioche-packages/packages/zziplib`
[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:77:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:81:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:90:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:94:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:98:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:102:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:127:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:133:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:139:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/date.bri:146:3
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/std/extra/autopack.bri:215:9
Expected a function declaration.

[Warning] file:///tmp/brioche-packages/packages/std/extra/autopack.bri:225:9
Expected a function declaration.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/util.bri:40:8
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/util.bri:46:8
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/util.bri:85:8
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/util.bri:119:8
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/stringify.bri:166:8
Missing return type on function.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/stringify.bri:166:27
Argument 'obj' should be typed with a non-any type.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/proxy.bri:45:9
Expected a function declaration.
```