### PR TITLE
feat(muparserx): add package

### DIFF
--- a/packages/muparserx/brioche.lock
+++ b/packages/muparserx/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/beltoforion/muparserx": {
+      "v4.0.12": "e1bdc2947e71ec8b30891749c1d807a3335ebd6d"
+    }
+  }
+}

--- a/packages/muparserx/project.bri
+++ b/packages/muparserx/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "muparserx",
+  version: "4.0.12",
+  repository: "https://github.com/beltoforion/muparserx",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function muparserx(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      BUILD_EXAMPLES: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion muparserx | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, muparserx)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `muparserx`
- **Website / repository:** `https://github.com/beltoforion/muparserx`
- **Repology URL:** `https://repology.org/project/muparserx/versions`
- **Short description:** `A C++ library for parsing expressions with strings, complex numbers, vectors, and matrices`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.40s
Result: 21984aafd668385ae13af69758eb409d882eedeec2811bd5d5a0f20958b59f36
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "muparserx",
  "version": "4.0.12",
  "repository": "https://github.com/beltoforion/muparserx"
}
```

</p>
</details>

## Implementation notes / special instructions

None.