### PR TITLE
feat(muparser): add package

### DIFF
--- a/packages/muparser/brioche.lock
+++ b/packages/muparser/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/beltoforion/muparser": {
+      "v2.3.5": "fbafd7f8774af2b53f4d2de07c57353fcfc09216"
+    }
+  }
+}

--- a/packages/muparser/project.bri
+++ b/packages/muparser/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "muparser",
+  version: "2.3.5",
+  repository: "https://github.com/beltoforion/muparser",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function muparser(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTING: "OFF",
+      ENABLE_SAMPLES: "OFF",
+      ENABLE_OPENMP: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion muparser | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, muparser)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `muparser`
- **Website / repository:** `https://github.com/beltoforion/muparser`
- **Repology URL:** `https://repology.org/project/muparser/versions`
- **Short description:** `Fast math expression parser library for C/C++ that evaluates mathematical expressions at runtime`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 148722
[148722] 2.3.5
Process 148722 ran in 0.04s
Build finished, completed 1 job in 2.63s
Result: 221b2008c1a6796401b15dd91274a67cd9a41a144c4996e1e127839ff4875c7e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.91s
Running brioche-run
{
  "name": "muparser",
  "version": "2.3.5",
  "repository": "https://github.com/beltoforion/muparser"
}
```

</p>
</details>

## Implementation notes / special instructions

None.