### PR TITLE
feat(pacparser): add package

### DIFF
--- a/packages/pacparser/brioche.lock
+++ b/packages/pacparser/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/manugarg/pacparser/archive/refs/tags/v1.5.1.tar.gz": {
+      "type": "sha256",
+      "value": "88dda1833b5c467ea61d0217fa58fbc7980f7c5a856ca2af325e6a110b1c081d"
+    }
+  }
+}

--- a/packages/pacparser/project.bri
+++ b/packages/pacparser/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+
+export const project = {
+  name: "pacparser",
+  version: "1.5.1",
+  repository: "https://github.com/manugarg/pacparser",
+};
+
+const source = Brioche.download(
+  `https://github.com/manugarg/pacparser/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function pacparser(): std.Recipe<std.Directory> {
+  return std.runBash`
+    cd src
+    make install \\
+      PREFIX="$BRIOCHE_OUTPUT" \\
+      NO_INTERNET=1 \\
+      VERSION="${project.version}" \\
+      SHELL="$(command -v bash)"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/pactester"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pactester -v | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pacparser)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pacparser`
- **Website / repository:** `https://github.com/manugarg/pacparser`
- **Repology URL:** `https://repology.org/project/pacparser/versions`
- **Short description:** `Library and tools to parse and test proxy auto-config (PAC) files`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.82s
Result: f98c325aaad192e14702c6ba58da6f7a38957d9d47b0b230cd51533e32ccfb3c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.90s
Running brioche-run
{
  "name": "pacparser",
  "version": "1.5.1",
  "repository": "https://github.com/manugarg/pacparser"
}
```

</p>
</details>

## Implementation notes / special instructions

None.