### PR TITLE
feat(maeparser): add package

### DIFF
--- a/packages/maeparser/brioche.lock
+++ b/packages/maeparser/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/schrodinger/maeparser": {
+      "v1.3.3": "da0679ef5a41a33a238f823c43603a319337a866"
+    }
+  }
+}

--- a/packages/maeparser/project.bri
+++ b/packages/maeparser/project.bri
@@ -1,0 +1,68 @@
+import * as std from "std";
+import boost from "boost";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "maeparser",
+  version: "1.3.3",
+  repository: "https://github.com/schrodinger/maeparser",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function maeparser(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, boost],
+    set: {
+      MAEPARSER_BUILD_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.cpp": std.file(std.indoc`
+      #include <maeparser/Reader.hpp>
+      #include <cstdlib>
+      #include <iostream>
+
+      int main()
+      {
+          std::cout << "ok";
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    g++ main.cpp -lmaeparser -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, boost, maeparser)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `maeparser`
- **Website / repository:** `https://github.com/schrodinger/maeparser`
- **Repology URL:** `https://repology.org/project/maeparser/versions`
- **Short description:** `Parser for Schrodinger Maestro files`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 4143
[4143] ok
Process 4143 ran in 2.37s
Build finished, completed 1 job in 5.02s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.92s
Running brioche-run
{
  "name": "maeparser",
  "version": "1.3.3",
  "repository": "https://github.com/schrodinger/maeparser"
}
```

</p>
</details>

## Implementation notes / special instructions

None.