### PR TITLE
feat(quickjs_ng): add package

### DIFF
--- a/packages/quickjs_ng/brioche.lock
+++ b/packages/quickjs_ng/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/quickjs-ng/quickjs": {
+      "v0.14.0": "3c051980ab7e783dfbfb1c70c014ce5e05ecf24c"
+    }
+  }
+}

--- a/packages/quickjs_ng/project.bri
+++ b/packages/quickjs_ng/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "quickjs_ng",
+  version: "0.14.0",
+  repository: "https://github.com/quickjs-ng/quickjs",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function quickjsNg(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    runnable: "bin/qjs",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    (qjs --help || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(quickjsNg)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `QuickJS-ng version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `quickjs_ng`
- **Website / repository:** `https://github.com/quickjs-ng/quickjs`
- **Repology URL:** `https://repology.org/project/quickjs-ng/versions`
- **Short description:** `QuickJS-NG, a small and embeddable JavaScript engine supporting the latest ECMAScript specification`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.96s
Result: 9b2eece370bdf09ab0e32fdd11448ce43712dac093645caf1d56b09c227cffac
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "quickjs_ng",
  "version": "0.14.0",
  "repository": "https://github.com/quickjs-ng/quickjs"
}
```

</p>
</details>

## Implementation notes / special instructions

None.