### PR TITLE
feat(quickjs): add package

### DIFF
--- a/packages/quickjs/brioche.lock
+++ b/packages/quickjs/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://bellard.org/quickjs/quickjs-2025-09-13-2.tar.xz": {
+      "type": "sha256",
+      "value": "996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
+    }
+  }
+}

--- a/packages/quickjs/project.bri
+++ b/packages/quickjs/project.bri
@@ -1,0 +1,65 @@
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "quickjs",
+  version: "2025-09-13-2",
+};
+
+const source = Brioche.download(
+  `https://bellard.org/quickjs/quickjs-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function quickjs(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/qjs"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    (qjs --help || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(quickjs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `QuickJS version ${project.version.slice(0, 10)}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://bellard.org/quickjs/
+      | lines
+      | where ($it | str contains '.tar.xz')
+      | parse --regex 'quickjs-(?<version>\\d{4}-\\d{2}-\\d{2}(?:-\\d+)?)\\.tar\\.xz'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `quickjs`
- **Website / repository:** `https://bellard.org/quickjs/`
- **Repology URL:** `https://repology.org/project/quickjs/versions`
- **Short description:** `Small and embeddable JavaScript engine`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Launched process 4940
[4940] QuickJS version 2025-09-13
[4940] usage: qjs [options] [file [args]]
[4940] -h  --help         list options
[4940] -e  --eval EXPR    evaluate EXPR
[4940] -i  --interactive  go to interactive mode
[4940] -m  --module       load as ES6 module (default=autodetect)
[4940]     --script       load as ES6 script (default=autodetect)
[4940] -I  --include file include an additional file
[4940]     --std          make 'std' and 'os' available to the loaded script
[4940] -T  --trace        trace memory allocation
[4940] -d  --dump         dump the memory usage stats
[4940]     --memory-limit n  limit the memory usage to 'n' bytes (SI suffixes allowed)
[4940]     --stack-size n    limit the stack size to 'n' bytes (SI suffixes allowed)
[4940]     --no-unhandled-rejection  ignore unhandled promise rejections
[4940] -s                    strip all the debug info
[4940]     --strip-source    strip the source code
[4940] -q  --quit         just instantiate the interpreter and quit
Process 4940 ran in 0.01s
Build finished, completed 1 job in 1.36s
Result: 89c2cb50d7be5016a5faf6af6a27c0983f5d9eb9d4a36954d12acf0e7a952d1b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.37s
Running brioche-run
{
  "name": "quickjs",
  "version": "2025-09-13-2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.