### PR TITLE
feat(cmake): scan package-scoped dirs in cmakeSanitizePaths

### DIFF
--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -380,15 +380,17 @@ const CMAKE_SANITIZE_PATHS_SCRIPT = std.indoc`
   }
 
   # Candidate cmake directories relative to $BRIOCHE_OUTPUT
-  cmake_dirs=(lib/cmake share/cmake)
+  cmake_dirs=(lib/cmake "lib/*/cmake" share/cmake "share/*/cmake")
 
   # Collect only those that are present
+  shopt -s nullglob
   find_roots=()
   for rel in "\${cmake_dirs[@]}"; do
-    dir="$BRIOCHE_OUTPUT/$rel"
-    if [[ -d "$dir" ]]; then
-      find_roots+=("$dir")
-    fi
+    for dir in "$BRIOCHE_OUTPUT"/$rel; do
+      if [[ -d "$dir" ]]; then
+        find_roots+=("$dir")
+      fi
+    done
   done
 
   # No cmake dir found, exit
@@ -422,9 +424,9 @@ const CMAKE_SANITIZE_PATHS_SCRIPT = std.indoc`
  *
  * @returns A new recipe with the sanitized CMake files.
  *
- * @remarks This function looks for CMake files (*.cmake) in the standard
- *   locations `lib/cmake` and `share/cmake` relative to
- *   the `$BRIOCHE_OUTPUT` output directory.
+ * @remarks This function looks for CMake files (*.cmake) in `lib/cmake`,
+ *   `lib/<package>/cmake`, `share/cmake`, and `share/<package>/cmake`
+ *   relative to the `$BRIOCHE_OUTPUT` output directory.
  */
 export function cmakeSanitizePaths(
   recipe: std.RecipeLike<std.Directory>,


### PR DESCRIPTION
This PR extends `cmakeSanitizePaths` to also process cmake files installed under `lib/<package>/cmake/` and `share/<package>/cmake/`, alongside the existing `lib/cmake` and `share/cmake` locations. Some projects, notably those using the c++utilities/Martchus build system, install their cmake config and targets files in these package-scoped directories. Previously, the sanitizer skipped them entirely, leaving absolute build-time paths in `INTERFACE_INCLUDE_DIRECTORIES`, which broke downstream `find_package()` calls when consuming the library from another package. Glob expansion is handled with `shopt -s nullglob` and an inner `for` loop, so non-glob entries iterate once with the literal path while glob entries iterate over all matches.