### PR TITLE
Resolve more lints

### DIFF
--- a/packages/kmod/project.bri
+++ b/packages/kmod/project.bri
@@ -4,7 +4,7 @@ import { mesonBuild } from "meson";
 import ninja from "ninja";
 import openssl from "openssl";
 import scdoc from "scdoc";
-import { nushellRunnable, NushellRunnable } from "nushell";
+import { nushellRunnable, type NushellRunnable } from "nushell";
 
 export const project = {
   name: "kmod",

--- a/packages/smol_toml/parse.bri
+++ b/packages/smol_toml/parse.bri
@@ -54,7 +54,7 @@ function peekTable(
   let hasOwn = false;
   let state: MetaState;
 
-  for (let i = 0; i < key.length; i++) {
+  for (const [i, currentKey] of key.entries()) {
     if (i !== 0) {
       t = hasOwn ? t[k as string] : (t[k as string] = {});
       m = (state = m[k as string] as MetaState).c;
@@ -73,7 +73,7 @@ function peekTable(
       }
     }
 
-    k = key[i] as string;
+    k = currentKey;
     if (
       (hasOwn = Object.hasOwn(t, k)) &&
       m[k]?.t === Type.DOTTED &&

--- a/packages/smol_toml/struct.bri
+++ b/packages/smol_toml/struct.bri
@@ -164,10 +164,10 @@ export function parseInlineTable(
       let hasOwn = false;
 
       const [key, keyEndPtr] = parseKey(str, ptr - 1);
-      for (let i = 0; i < key.length; i++) {
+      for (const [i, currentKey] of key.entries()) {
         if (i !== 0) t = hasOwn ? t[k as string] : (t[k as string] = {});
 
-        k = key[i] as string;
+        k = currentKey;
         if (
           (hasOwn = Object.hasOwn(t, k)) &&
           (typeof t[k] !== "object" || seen.has(t[k]))

--- a/packages/smol_toml/util.bri
+++ b/packages/smol_toml/util.bri
@@ -128,7 +128,7 @@ export function getStringEnd(str: string, seek: number): number {
       : first;
 
   seek += target.length - 1;
-  do seek = str.indexOf(target, ++seek);
+  do seek = str.indexOf(target, seek + 1);
   while (
     seek > -1 &&
     first !== "'" &&

--- a/packages/std/core/console.bri
+++ b/packages/std/core/console.bri
@@ -38,10 +38,12 @@ export function displayAll(...values: unknown[]): string[] {
     return [];
   }
 
-  const displayed = [];
+  const displayed: string[] = [];
   const remaining = [...values];
-  if (typeof remaining[0] === "string") {
-    displayed.push(remaining.shift() as string);
+  const first = remaining[0];
+  if (typeof first === "string") {
+    displayed.push(first);
+    remaining.shift();
   }
 
   for (const value of remaining) {

--- a/packages/std/core/recipes/download.bri
+++ b/packages/std/core/recipes/download.bri
@@ -1,5 +1,5 @@
-import { File } from "./file.bri";
-import { Hash } from "./hash.bri";
+import type { File } from "./file.bri";
+import type { Hash } from "./hash.bri";
 import { type Recipe, createRecipe } from "./recipe.bri";
 
 /**

--- a/packages/std/core/recipes/hash.bri
+++ b/packages/std/core/recipes/hash.bri
@@ -1,5 +1,5 @@
 import * as runtime from "../runtime.bri";
-import { assert, ImplementsEquatable } from "../utils.bri";
+import { assert, type ImplementsEquatable } from "../utils.bri";
 
 /**
  * Represents an expected SHA-256 hash. Should be a hex-encoded

--- a/packages/std/extra/oci_container_image.bri
+++ b/packages/std/extra/oci_container_image.bri
@@ -82,11 +82,12 @@ export function ociContainerImage(
       diffIds.push(`sha256:${layerSha256Digest}`);
 
       const layerTarGzip = gzip(layerTar);
-      let layerDigest = "";
-      let layerSize = 0;
-      let layerPath = "";
-      [imageDir, { digest: layerDigest, size: layerSize, path: layerPath }] =
-        await addBlob(imageDir, layerTarGzip);
+      const {
+        digest: layerDigest,
+        size: layerSize,
+        path: layerPath,
+      } = await blobInfo(layerTarGzip);
+      imageDir = imageDir.insert(layerPath, layerTarGzip);
 
       layerPaths.push(layerPath);
       layerDescriptors.push({
@@ -111,42 +112,42 @@ export function ociContainerImage(
       imageConfig["Labels"] = options.labels;
     }
 
-    let configDigest: string = "";
-    let configSize: number = 0;
-    let configPath: string = "";
-    [imageDir, { digest: configDigest, size: configSize, path: configPath }] =
-      await addBlob(
-        imageDir,
-        std.file(
-          JSON.stringify({
-            architecture: platform.architecture,
-            os: platform.os,
-            config: imageConfig,
-            rootfs: {
-              type: "layers",
-              diff_ids: diffIds,
-            },
-          }),
-        ),
-      );
-
-    let manifestDigest = "";
-    let manifestSize = 0;
-    [imageDir, { digest: manifestDigest, size: manifestSize }] = await addBlob(
-      imageDir,
-      std.file(
-        JSON.stringify({
-          schemaVersion: 2,
-          mediaType: "application/vnd.oci.image.manifest.v1+json",
-          config: {
-            mediaType: "application/vnd.oci.image.config.v1+json",
-            digest: configDigest,
-            size: configSize,
-          },
-          layers: layerDescriptors,
-        }),
-      ),
+    const configFile = std.file(
+      JSON.stringify({
+        architecture: platform.architecture,
+        os: platform.os,
+        config: imageConfig,
+        rootfs: {
+          type: "layers",
+          diff_ids: diffIds,
+        },
+      }),
     );
+    const {
+      digest: configDigest,
+      size: configSize,
+      path: configPath,
+    } = await blobInfo(configFile);
+    imageDir = imageDir.insert(configPath, configFile);
+
+    const manifestFile = std.file(
+      JSON.stringify({
+        schemaVersion: 2,
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        config: {
+          mediaType: "application/vnd.oci.image.config.v1+json",
+          digest: configDigest,
+          size: configSize,
+        },
+        layers: layerDescriptors,
+      }),
+    );
+    const {
+      digest: manifestDigest,
+      size: manifestSize,
+      path: manifestPath,
+    } = await blobInfo(manifestFile);
+    imageDir = imageDir.insert(manifestPath, manifestFile);
 
     imageDir = imageDir.insert(
       "index.json",
@@ -190,20 +191,19 @@ export function ociContainerImage(
   });
 }
 
-interface AddBlobResult {
+interface BlobInfo {
   digest: string;
   size: number;
   path: string;
 }
 
-async function addBlob(
-  imageDir: std.Recipe<std.Directory>,
-  blob: std.Recipe<std.File>,
-): Promise<[std.Recipe<std.Directory>, AddBlobResult]> {
+async function blobInfo(blob: std.Recipe<std.File>): Promise<BlobInfo> {
   const { sha256Digest, size } = await describeBlob(blob);
-  const path = `blobs/sha256/${sha256Digest}`;
-  imageDir = imageDir.insert(path, blob);
-  return [imageDir, { digest: `sha256:${sha256Digest}`, size, path }];
+  return {
+    digest: `sha256:${sha256Digest}`,
+    size,
+    path: `blobs/sha256/${sha256Digest}`,
+  };
 }
 
 interface DescribeBlobResult {

--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -1,7 +1,7 @@
 import * as std from "/core";
 import { setEnv } from "/extra/set_env.bri";
 import stage2 from "/toolchain/stage2";
-import { buildAutopackConfig, AutopackOptions } from "/extra/autopack.bri";
+import { buildAutopackConfig, type AutopackOptions } from "/extra/autopack.bri";
 import { PKG_CONFIG_MAKE_PATHS_RELATIVE_SCRIPT } from "/extra/pkg_config_make_paths_relative.bri";
 import { LIBTOOL_SANITIZE_DEPENDENCIES_SCRIPT } from "/extra/libtool_sanitize_dependencies.bri";
 import { LINKER_SCRIPT_MAKE_PATHS_RELATIVE_SCRIPT } from "/extra/linker_script_make_paths_relative.bri";


### PR DESCRIPTION
Companion PR of https://github.com/brioche-dev/brioche/pull/467.

Resolves the following lints:

```
[Warning] file:///tmp/brioche-packages/packages/std/toolchain/native/index.bri:4:1
Imports "AutopackOptions" are only used as type.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/hash.bri:2:1
Imports "ImplementsEquatable" are only used as type.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/util.bri:131:35
The value assigned to 'seek' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/core/console.bri:44:20
This assertion is unnecessary since the receiver accepts the original type of the expression.

[Warning] file:///tmp/brioche-packages/packages/kmod/project.bri:7:1
Imports "NushellRunnable" are only used as type.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/parse.bri:76:9
This assertion is unnecessary since the receiver accepts the original type of the expression.

[Warning] file:///tmp/brioche-packages/packages/smol_toml/struct.bri:170:13
This assertion is unnecessary since the receiver accepts the original type of the expression.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/download.bri:1:1
All imports in the declaration are only used as types. Use `import type`.

[Warning] file:///tmp/brioche-packages/packages/std/core/recipes/download.bri:2:1
All imports in the declaration are only used as types. Use `import type`.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:85:11
The value assigned to 'layerDigest' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:86:11
The value assigned to 'layerSize' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:87:11
The value assigned to 'layerPath' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:114:9
The value assigned to 'configDigest' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:115:9
The value assigned to 'configSize' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:116:9
The value assigned to 'configPath' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:133:9
The value assigned to 'manifestDigest' is not used in subsequent statements.

[Warning] file:///tmp/brioche-packages/packages/std/extra/oci_container_image.bri:134:9
The value assigned to 'manifestSize' is not used in subsequent statements.
```