### PR TITLE
feat(cpp_utilities): add package

### DIFF
--- a/packages/cpp_utilities/brioche.lock
+++ b/packages/cpp_utilities/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Martchus/cpp-utilities": {
+      "v5.34.1": "af8ae569bee6aefc89564020b59dfa78f74cca4f"
+    }
+  }
+}

--- a/packages/cpp_utilities/project.bri
+++ b/packages/cpp_utilities/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "cpp_utilities",
+  version: "5.34.1",
+  repository: "https://github.com/Martchus/cpp-utilities",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cppUtilities(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion c++utilities | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cppUtilities)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Verify that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cpp_utilities`
- **Website / repository:** https://github.com/Martchus/cpp-utilities
- **Repology URL:** https://repology.org/project/cpp-utilities/versions
- **Short description:** Useful C++ classes and routines such as argument parser, IO and conversion utilities

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 12495 (std/core/recipes/process.bri:240:14)
[12495] 5.34.1
Process 12495 ran in 0.01s
Build finished, completed 1 job in 2.72s
Result: 407818629a367faae7423170a5c8a66436276bd556dbc1bb7449e540333472aa
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 11 jobs in 29.57s
Running brioche-run
{
  "name": "cpp_utilities",
  "version": "5.34.1",
  "repository": "https://github.com/Martchus/cpp-utilities"
}
```

</p>
</details>

## Implementation notes / special instructions

None.