### PR TITLE
feat(tagparser): add package

### DIFF
--- a/packages/tagparser/brioche.lock
+++ b/packages/tagparser/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Martchus/tagparser": {
+      "v12.5.3": "8e7f0ffb0eea4c3c07e1d39f9ed0a25765826780"
+    }
+  }
+}

--- a/packages/tagparser/project.bri
+++ b/packages/tagparser/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import cppUtilities from "cpp_utilities";
+import isoCodes from "iso_codes";
+
+export const project = {
+  name: "tagparser",
+  version: "12.5.3",
+  repository: "https://github.com/Martchus/tagparser",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function tagparser(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, cppUtilities, isoCodes],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TESTING: "OFF",
+      LANGUAGE_FILE_ISO_639_2: std.tpl`${isoCodes}/share/iso-codes/json/iso_639-2.json`,
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion tagparser | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, tagparser)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Verify that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `tagparser`
- **Website / repository:** https://github.com/Martchus/tagparser
- **Repology URL:** https://repology.org/project/tagparser/versions
- **Short description:** C++ library for reading and writing MP4 (iTunes), ID3, Vorbis, Opus, FLAC and Matroska tags

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 20136 (std/core/recipes/process.bri:240:14)
[20136] 12.5.3
Process 20136 ran in 0.03s
Build finished, completed 1 job in 8.80s
Result: 0f347193251b97e04a6a41852ec4c68facede6a6c72bb29d43915c6551ae8adc
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 9.93s
Running brioche-run
{
  "name": "tagparser",
  "version": "12.5.3",
  "repository": "https://github.com/Martchus/tagparser"
}
```

</p>
</details>

## Implementation notes / special instructions

None.