### PR TITLE
feat(userspace_rcu): add package

### DIFF
--- a/packages/userspace_rcu/brioche.lock
+++ b/packages/userspace_rcu/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.lttng.org/files/urcu/userspace-rcu-0.15.6.tar.bz2": {
+      "type": "sha256",
+      "value": "850b192096eb11ebf2c70e8f97bc7da7479ee41da1bebeb44e3986908bac414f"
+    }
+  }
+}

--- a/packages/userspace_rcu/project.bri
+++ b/packages/userspace_rcu/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+
+export const project = {
+  name: "userspace_rcu",
+  version: "0.15.6",
+  repository: "https://github.com/urcu/userspace-rcu",
+};
+
+const source = Brioche.download(
+  `https://www.lttng.org/files/urcu/userspace-rcu-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function userspaceRcu(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared \\
+      --enable-static
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion liburcu | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, userspaceRcu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `userspace_rcu`
- **Website / repository:** `https://github.com/urcu/userspace-rcu`
- **Repology URL:** `https://repology.org/project/userspace-rcu/versions`
- **Short description:** `Userspace RCU (read-copy-update) library providing data synchronization with read-side access scaling linearly across cores, plus lock-free data structures (hash tables, queues, stacks, doubly-linked lists).`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/userspace_rcu^test
...
[process] 0.15.6
Build finished, completed 4 jobs in 30.90s
Result: 9841fb6f4441b461282395c45af9197aee24aac8b8bf011033ded8a97d03b739
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/userspace_rcu^liveUpdate
Build finished, completed 1 job in 4.07s
Running brioche-run
{
  "name": "userspace_rcu",
  "version": "0.15.6",
  "repository": "https://github.com/urcu/userspace-rcu"
}
```

</p>
</details>

## Implementation notes / special instructions

None.