### PR TITLE
feat(libmemcached): add package

### DIFF
--- a/packages/libmemcached/brioche.lock
+++ b/packages/libmemcached/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/awesomized/libmemcached.git": {
+      "1.1.4": "92d18858b417309f6bdee6bce464a4f3d6a375fd"
+    }
+  }
+}

--- a/packages/libmemcached/project.bri
+++ b/packages/libmemcached/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import libevent from "libevent";
+import openssl from "openssl";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libmemcached",
+  version: "1.1.4",
+  repository: "https://github.com/awesomized/libmemcached.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libmemcached(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libevent, openssl],
+    set: {
+      BUILD_TESTING: "OFF",
+      BUILD_DOCS: "OFF",
+      ENABLE_MEMASLAP: "ON",
+      ENABLE_OPENSSL_CRYPTO: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+      ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libmemcached | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libmemcached)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libmemcached`
- **Website / repository:** `https://github.com/awesomized/libmemcached`
- **Repology URL:** `https://repology.org/project/libmemcached/versions`
- **Short description:** `C/C++ client library and tools for the memcached server (community-maintained awesomized fork)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 195765 (std/core/recipes/process.bri:240:14)
[195765] 1.1.4
Process 195765 ran in 0.02s
Build finished, completed 1 job in 2.70s
Result: 05d5a64f8286aede82c4bf2184edf35e1435f706f4d1991b40442c0b75583abf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 195874 (std/runtime_utils.bri:49:6)
Process 195874 ran in 0.01s
Build finished, completed 1 job in 3.92s
Running brioche-run
{
  "name": "libmemcached",
  "version": "1.1.4",
  "repository": "https://github.com/awesomized/libmemcached.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.