### PR TITLE
feat(gitlab_pages): add package

### DIFF
--- a/packages/gitlab_pages/brioche.lock
+++ b/packages/gitlab_pages/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://gitlab.com/gitlab-org/gitlab-pages.git": {
+      "v19.0.0": "3b081a50561c5a5a6e45bb7cd9fc7db18b79bb5b"
+    }
+  }
+}

--- a/packages/gitlab_pages/project.bri
+++ b/packages/gitlab_pages/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { gitCheckout } from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "gitlab_pages",
+  version: "19.0.0",
+  repository: "https://gitlab.com/gitlab-org/gitlab-pages.git",
+};
+
+// Retrieve the source directly from the GitLab repository and not from the Go
+// proxy, because the v19+ major version is not encoded in the module path
+const gitRef = await Brioche.gitRef({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+const source = gitCheckout(gitRef);
+
+export default function gitlabPages(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.VERSION=${project.version}`,
+        "-X",
+        `main.REVISION=${gitRef.commit}`,
+      ],
+    },
+    runnable: "bin/gitlab-pages",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gitlab-pages -version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gitlabPages)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gitlab_pages`
- **Website / repository:** `https://gitlab.com/gitlab-org/gitlab-pages`
- **Repology URL:** `https://repology.org/project/gitlab-pages/versions`
- **Short description:** `GitLab Pages daemon used to serve static websites for GitLab users`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.92s
Result: 5d48dc4fb4c000994dd53ca532157d25c540e60e7acbbeeda1eda66a6996d352
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.74s
Running brioche-run
{
  "name": "gitlab_pages",
  "version": "19.0.0",
  "repository": "https://gitlab.com/gitlab-org/gitlab-pages.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.