### PR TITLE
feat(mmctl): add package

### DIFF
--- a/packages/mmctl/brioche.lock
+++ b/packages/mmctl/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mattermost/mattermost.git": {
+      "v11.7.1": "de117ab1cc09f4114aa7cb716fe760946ae7696c"
+    }
+  }
+}

--- a/packages/mmctl/project.bri
+++ b/packages/mmctl/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { goBuild, project as goProject } from "go";
+
+export const project = {
+  name: "mmctl",
+  version: "11.7.1",
+  repository: "https://github.com/mattermost/mattermost.git",
+};
+
+// Retrieve the source directly from the GitHub repository and not from the Go
+// proxy. Since, the one from Go proxy doesn't follow the same tagging scheme.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+})
+  // Ship a go.work file so the server module resolves its companion
+  // module from the local tree instead of the registry.
+  .insert(
+    "server/go.work",
+    std.file(std.indoc`
+      go ${goProject.version}
+
+      use (
+          .
+          ./public
+      )
+    `),
+  );
+
+export default function mmctl(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    currentDir: "server",
+    path: "./cmd/mmctl",
+    buildParams: {
+      ldflags: ["-s", "-w"],
+    },
+    runnable: "bin/mmctl",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    mmctl version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(mmctl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version:\t${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `mmctl`
- **Website / repository:** `https://github.com/mattermost/mattermost`
- **Repology URL:** `https://repology.org/project/mmctl/versions`
- **Short description:** A remote CLI tool for Mattermost.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/mmctl^test
[...]
mmctl:
Version:	11.7.1
BuiltDate:	dev
CommitDate:	dev
GitCommit:	dev
GitTreeState:	dev
GoVersion:	go1.26.2
Compiler:	gc
Platform:	linux/arm64
Build finished, completed 1 job in 1.57s
Result: d3cd1f3b83212f0025b5a0cbb58c7abe96924b2962eff1205c23865af74f5b98
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/mmctl^liveUpdate
Build finished, completed 1 job in 5.82s
Running brioche-run
{
  "name": "mmctl",
  "version": "11.7.1",
  "repository": "https://github.com/mattermost/mattermost.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.