### PR TITLE
feat(cargo2junit): add package

### DIFF
--- a/packages/cargo2junit/brioche.lock
+++ b/packages/cargo2junit/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo2junit/0.1.15/download": {
+      "type": "sha256",
+      "value": "4d44b708e703a832b449333fc66a96b9c5f50e89d275e7746fb5e964a979b2a8"
+    }
+  }
+}

--- a/packages/cargo2junit/project.bri
+++ b/packages/cargo2junit/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo2junit",
+  version: "0.1.15",
+  extra: {
+    crateName: "cargo2junit",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargo2junit(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo2junit",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so a minimal suite
+  // event stream is piped in to verify the correct installation
+  const script = std.runBash`
+    printf '%s\n%s\n' \\
+      '{"type":"suite","event":"started","test_count":0}' \\
+      '{"type":"suite","event":"ok","passed":0,"failed":0,"allowed_fail":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.0}' \\
+      | cargo2junit | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cargo2junit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = `<?xml version="1.0" encoding="UTF-8"?>`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo2junit`
- **Website / repository:** `https://github.com/johnterickson/cargo2junit`
- **Repology URL:** `https://repology.org/project/cargo2junit/versions`
- **Short description:** `Converts cargo's JSON test output (from stdin) to JUnit XML (to stdout)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 300048 (std/core/recipes/process.bri:240:14)
[300048] <?xml version="1.0" encoding="UTF-8"?>
[300048] <testsuites>
[300048]   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2026-05-21T16:15:58.993908672Z" time="0" />
[300048] </testsuites>
Process 300048 ran in 0.02s
Build finished, completed 1 job in 1.88s
Result: ae6cb0c8fa2f456e1b2de59ecf80f9f63dc57a9e7e47e60466701bc0f25c5bcf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.11s
Running brioche-run
{
  "name": "cargo2junit",
  "version": "0.1.15",
  "extra": {
    "crateName": "cargo2junit"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.