### PR TITLE
feat(tpm2_tss): add package

### DIFF
--- a/packages/tpm2_tss/brioche.lock
+++ b/packages/tpm2_tss/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/tpm2-software/tpm2-tss/releases/download/4.1.3/tpm2-tss-4.1.3.tar.gz": {
+      "type": "sha256",
+      "value": "37f1580200ab78305d1fc872d89241aaee0c93cbe85bc559bf332737a60d3be8"
+    }
+  }
+}

--- a/packages/tpm2_tss/project.bri
+++ b/packages/tpm2_tss/project.bri
@@ -1,0 +1,69 @@
+import * as std from "std";
+import curl from "curl";
+import jsonC from "json_c";
+import openssl from "openssl";
+
+export const project = {
+  name: "tpm2_tss",
+  version: "4.1.3",
+  repository: "https://github.com/tpm2-software/tpm2-tss",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/tpm2-tss-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function tpm2Tss(): std.Recipe<std.Directory> {
+  return std.runBash`
+    # tpm2-tss checks for these at configure time so it can create a
+    # 'tss' user during 'make install'. With DESTDIR set, the install
+    # step skips user creation, so pre-seed the cache to satisfy the
+    # configure-time check.
+    export groupadd=yes useradd=yes
+    ./configure \\
+      --prefix=/ \\
+      --disable-doxygen-doc \\
+      --disable-dependency-tracking
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      openssl({ version: "3" }),
+      curl({ minimal: true }),
+      jsonC,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion tss2-esys | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, tpm2Tss)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `tpm2_tss`
- **Website / repository:** `https://github.com/tpm2-software/tpm2-tss`
- **Repology URL:** `https://repology.org/project/tpm2-tss/versions`
- **Short description:** OSS implementation of the TCG TPM2 Software Stack (TSS2), providing the SAPI, ESAPI, FAPI, TCTI and Marshaling/Unmarshaling libraries for interacting with TPM 2.0 devices.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 339497 (std/core/recipes/process.bri:240:14)
[339497] 4.1.3
Process 339497 ran in 0.01s
Build finished, completed 1 job in 1.80s
Result: d6d3760f4fdc850036a466af3b1bf2a682d201867c59bee040d3afb78872cdda
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 339591 (std/runtime_utils.bri:49:6)
Process 339591 ran in 0.01s
Build finished, completed 1 job in 3.19s
Running brioche-run
{
  "name": "tpm2_tss",
  "version": "4.1.3",
  "repository": "https://github.com/tpm2-software/tpm2-tss"
}
```

</p>
</details>

## Implementation notes / special instructions

Pre-seeds `groupadd=yes useradd=yes` to bypass a configure-time check; the actual user creation in `make install` is skipped when `DESTDIR` is set.