### PR TITLE
feat(libtpms): add package

### DIFF
--- a/packages/libtpms/brioche.lock
+++ b/packages/libtpms/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/stefanberger/libtpms": {
+      "v0.10.2": "03ff2481e133540be3b3ffe3daa1483d2a73d967"
+    }
+  }
+}

--- a/packages/libtpms/project.bri
+++ b/packages/libtpms/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import openssl from "openssl";
+
+export const project = {
+  name: "libtpms",
+  version: "0.10.2",
+  repository: "https://github.com/stefanberger/libtpms",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libtpms(): std.Recipe<std.Directory> {
+  return std.runBash`
+    autoreconf --install --force
+    ./configure \\
+      --prefix=/ \\
+      --with-openssl \\
+      --with-tpm2 \\
+      --with-tpm1 \\
+      --disable-static
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, openssl({ version: "3" }))
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libtpms | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libtpms)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtpms`
- **Website / repository:** `https://github.com/stefanberger/libtpms`
- **Repology URL:** `https://repology.org/project/libtpms/versions`
- **Short description:** Library providing software emulation of a Trusted Platform Module (TPM 1.2 and TPM 2.0) for integration into hypervisors such as QEMU.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 367453 (std/core/recipes/process.bri:240:14)
[367453] 0.10.2
Process 367453 ran in 0.01s
Build finished, completed 1 job in 1.28s
Result: df575b89082990bbe11df1bb0bdc7c58ccff4660c37ac9d4914fd1def1983ca1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.46s
Running brioche-run
{
  "name": "libtpms",
  "version": "0.10.2",
  "repository": "https://github.com/stefanberger/libtpms"
}
```

</p>
</details>

## Implementation notes / special instructions

None.