### PR TITLE
feat(libconfuse): add package

### DIFF
--- a/packages/libconfuse/brioche.lock
+++ b/packages/libconfuse/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libconfuse/libconfuse/releases/download/v3.3/confuse-3.3.tar.gz": {
+      "type": "sha256",
+      "value": "3a59ded20bc652eaa8e6261ab46f7e483bc13dad79263c15af42ecbb329707b8"
+    }
+  }
+}

--- a/packages/libconfuse/project.bri
+++ b/packages/libconfuse/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+
+export const project = {
+  name: "libconfuse",
+  version: "3.3",
+  repository: "https://github.com/libconfuse/libconfuse",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/confuse-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libconfuse(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-examples
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libconfuse | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libconfuse)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libconfuse`
- **Website / repository:** `https://github.com/libconfuse/libconfuse`
- **Repology URL:** `https://repology.org/project/libconfuse/versions`
- **Short description:** `Configuration file parser library written in C`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 373120 (std/core/recipes/process.bri:240:14)
[373120] 3.3
Process 373120 ran in 0.01s
Build finished, completed 1 job in 1.26s
Result: ae7c5b172fee217142b48939e9cc6cd6f915750c23b2462ae4f91ec2bcb7a6eb
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.15s
Running brioche-run
{
  "name": "libconfuse",
  "version": "3.3",
  "repository": "https://github.com/libconfuse/libconfuse"
}
```

</p>
</details>

## Implementation notes / special instructions

None.