### PR TITLE
fix(std): sanitize absolute paths in GNU ld linker scripts

### DIFF
--- a/packages/cargo_c/project.bri
+++ b/packages/cargo_c/project.bri
@@ -77,8 +77,8 @@ interface CargoCBuildParameters {
  * @param path - Optionally set a subpath to the crate to build relative to
  *   the workspace root. This is useful when building a crate in a workspace.
  * @param disablePostBuildSteps - If set, the post build steps will not run. By
- *   default, `std.libtoolSanitizeDependencies` and `std.pkgConfigMakePathsRelative`
- *   will be executed.
+ *   default, `std.libtoolSanitizeDependencies`, `std.linkerScriptMakePathsRelative`,
+ *   and `std.pkgConfigMakePathsRelative` will be executed.
  * @param runnable - Optionally set a path to the binary to run
  *   by default (e.g. `bin/foo`).
  * @param dependencies - Optionally add additional dependencies to the build.
@@ -241,6 +241,11 @@ export function cargoCBuild(
       options.disablePostBuildSteps ?? false
         ? recipe
         : std.libtoolSanitizeDependencies(recipe),
+    )
+    .pipe((recipe) =>
+      options.disablePostBuildSteps ?? false
+        ? recipe
+        : std.linkerScriptMakePathsRelative(recipe),
     )
     .pipe((recipe) =>
       options.disablePostBuildSteps ?? false

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -111,8 +111,8 @@ export default function cmake(): std.Recipe<std.Directory> {
  * @param set - Optionally set CMake cache variables during the build, as if
  *   by passing `-D...`.
  * @param disablePostBuildSteps - If set, the post build steps will not run. By
- *   default, `std.libtoolSanitizeDependencies`, `std.pkgConfigMakePathsRelative`,
- *   and `cmakeSanitizePaths` will be executed.
+ *   default, `std.libtoolSanitizeDependencies`, `std.linkerScriptMakePathsRelative`,
+ *   `std.pkgConfigMakePathsRelative`, and `cmakeSanitizePaths` will be executed.
  * @param generator - Optionally set the CMake generator to use (e.g. `"Ninja"`).
  *   When using Ninja, make sure to include `ninja` in `dependencies`.
  * @param runnable - Optionally set a path to the binary to run by default
@@ -248,6 +248,11 @@ export function cmakeBuild(
       options.disablePostBuildSteps ?? false
         ? recipe
         : std.libtoolSanitizeDependencies(recipe),
+    )
+    .pipe((recipe) =>
+      options.disablePostBuildSteps ?? false
+        ? recipe
+        : std.linkerScriptMakePathsRelative(recipe),
     )
     .pipe((recipe) =>
       options.disablePostBuildSteps ?? false

--- a/packages/libbsd/project.bri
+++ b/packages/libbsd/project.bri
@@ -23,6 +23,7 @@ export default function libbsd(): std.Recipe<std.Directory> {
     .dependencies(std.toolchain, libmd)
     .toDirectory()
     .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.linkerScriptMakePathsRelative)
     .pipe(std.pkgConfigMakePathsRelative)
     .pipe((recipe) =>
       std.setEnv(recipe, {

--- a/packages/meson/project.bri
+++ b/packages/meson/project.bri
@@ -102,8 +102,8 @@ export function liveUpdate(): std.Recipe<std.Directory> {
  * @param set - Optionally set Meson variables during the build, as if by passing
  *    `-D...`.
  * @param disablePostBuildSteps - If set, the post build steps will not run. By
- *   default, `std.libtoolSanitizeDependencies`, `std.pkgConfigMakePathsRelative`,
- *   and `cmakeSanitizePaths` will be executed.
+ *   default, `std.libtoolSanitizeDependencies`, `std.linkerScriptMakePathsRelative`,
+ *   `std.pkgConfigMakePathsRelative`, and `cmakeSanitizePaths` will be executed.
  * @param runnable - Optionally set a path to the binary to run by default
  *   (e.g. `bin/foo`).
  */
@@ -187,6 +187,11 @@ export function mesonBuild(
       options.disablePostBuildSteps ?? false
         ? recipe
         : std.libtoolSanitizeDependencies(recipe),
+    )
+    .pipe((recipe) =>
+      options.disablePostBuildSteps ?? false
+        ? recipe
+        : std.linkerScriptMakePathsRelative(recipe),
     )
     .pipe((recipe) =>
       options.disablePostBuildSteps ?? false

--- a/packages/std/extra/linker_script_make_paths_relative.bri
+++ b/packages/std/extra/linker_script_make_paths_relative.bri
@@ -5,15 +5,27 @@ export const LINKER_SCRIPT_MAKE_PATHS_RELATIVE_SCRIPT = std.indoc`
   fix_linker_script_paths () {
     local -r file="$1"
 
-    sed -i 's| //lib/| |g; s| /lib/| |g' "$file"
+    sed -i -E 's|([( \\t])/+lib(64)?/|\\1|g' "$file"
   }
 
-  # No lib dir found, exit
-  if [[ ! -d "$BRIOCHE_OUTPUT/lib" ]]; then
+  # Candidate directories relative to $BRIOCHE_OUTPUT
+  lib_dirs=(lib lib64)
+
+  # Collect only those that are present
+  find_roots=()
+  for rel in "\${lib_dirs[@]}"; do
+    dir="$BRIOCHE_OUTPUT/$rel"
+    if [[ -d "$dir" ]]; then
+      find_roots+=("$dir")
+    fi
+  done
+
+  # No directory found, exit
+  if [[ \${#find_roots[@]} -eq 0 ]]; then
     exit 0
   fi
 
-  find -L "$BRIOCHE_OUTPUT/lib" -maxdepth 1 -name '*.so' -type f -print0 \\
+  find -L "\${find_roots[@]}" -maxdepth 1 -name '*.so' -type f -print0 \\
     | while IFS= read -r -d $'\\0' file; do
       if grep -qE 'GROUP|INPUT' "$file" 2>/dev/null; then
         fix_linker_script_paths "$file"
@@ -22,23 +34,16 @@ export const LINKER_SCRIPT_MAKE_PATHS_RELATIVE_SCRIPT = std.indoc`
 `;
 
 /**
- * Create a recipe that replaces absolute paths in GNU ld linker scripts
- * with relative filenames.
- *
- * Linker scripts from glibc (e.g. `libc.so`, `libm.so`) contain absolute
- * paths like `/lib/libc.so.6` that depend on gcc's `--sysroot` to resolve
- * correctly. Tools that parse these scripts without `--sysroot` fail to
- * resolve the absolute paths. This function strips the absolute directory
- * prefix so the linker resolves library names via its search paths instead.
+ * Create a recipe that sanitizes GNU ld linker scripts by stripping
+ * absolute directory prefixes from library references so the linker
+ * resolves them via its search paths instead.
  *
  * @param recipe - The recipe to apply the transformation to.
  *
- * @returns A new recipe with the fixed linker scripts.
+ * @returns A new recipe with the sanitized linker scripts.
  *
- * @remarks This function looks for `.so` files in `lib/` relative to
- *   the `$BRIOCHE_OUTPUT` output directory that contain GNU ld script
- *   directives (`GROUP` or `INPUT`), and strips absolute `/lib/` path
- *   prefixes from them.
+ * @remarks This function looks for `.so` files in the standard locations
+ *   `lib` and `lib64` relative to the `$BRIOCHE_OUTPUT` output directory.
  */
 export function linkerScriptMakePathsRelative(
   recipe: std.RecipeLike<std.Directory>,


### PR DESCRIPTION
This PR fixes a problem with GNU ld linker scripts that hardcode absolute paths.

When libbsd is built with `--prefix=/`, the install step generates `libbsd.so` as a GNU ld linker script with this content:

```
OUTPUT_FORMAT(elf64-littleaarch64)
GROUP(//lib/libbsd.so.0.12.2 AS_NEEDED(-lmd))
```

The `//lib/...` path is baked into the file at install time and does not exist in any consumer's sandbox. Any package that depends on libbsd fails to link with:

```
ld.gold: error: cannot open //lib/libbsd.so.0.12.2: No such file or directory
```

The existing `std.linkerScriptMakePathsRelative` helper already handled a similar case for glibc's linker scripts (where the absolute path is preceded by a space, like `GROUP ( /lib/libc.so.6 ...)`), but its regex did not match libbsd's format because the path sits directly next to `(` with no space.

`std.linkerScriptMakePathsRelative` is generalized to also strip prefixes when the path is adjacent to `(`, and now searches both `lib/` and `lib64/`. The structure matches `std.libtoolSanitizeDependencies` (same `find_roots` loop, same TSDoc style).

The libbsd recipe adds `.pipe(std.linkerScriptMakePathsRelative)` so the bad path is rewritten at build time.

`cmakeBuild`, `mesonBuild`, and `cargoCBuild` now run `std.linkerScriptMakePathsRelative` as a default post-build step, gated by the existing `disablePostBuildSteps` flag, alongside the other sanitization helpers.

After the fix, libbsd's `libbsd.so` becomes:

```
OUTPUT_FORMAT(elf64-littleaarch64)
GROUP(libbsd.so.0.12.2 AS_NEEDED(-lmd))
```

ld then resolves the library via `LIBRARY_PATH` as expected.