### PR TITLE
feat(cgif): add package

### DIFF
--- a/packages/cgif/brioche.lock
+++ b/packages/cgif/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/dloebl/cgif/archive/refs/tags/v0.5.3.tar.gz": {
+      "type": "sha256",
+      "value": "dcc7731e974ee77db75df26c99aca4d95f11ca2d267d870d42bce1e0d1e1e75f"
+    }
+  }
+}

--- a/packages/cgif/project.bri
+++ b/packages/cgif/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "cgif",
+  version: "0.5.3",
+  repository: "https://github.com/dloebl/cgif",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cgif(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      examples: "false",
+      tests: "false",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion cgif | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cgif)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cgif`
- **Website / repository:** `https://github.com/dloebl/cgif`
- **Repology URL:** `https://repology.org/project/cgif/versions`
- **Short description:** `A fast and lightweight GIF encoder library written in C`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 375425 (std/core/recipes/process.bri:240:14)
[375425] 0.5.3
Process 375425 ran in 0.01s
Build finished, completed 1 job in 1.63s
Result: c207807f3ffe9f2380d57236aae83823cc076830a44dd4ea03e620318f960e5b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 375521 (std/runtime_utils.bri:49:6)
Process 375521 ran in 0.01s
Build finished, completed 1 job in 3.53s
Running brioche-run
{
  "name": "cgif",
  "version": "0.5.3",
  "repository": "https://github.com/dloebl/cgif"
}
```

</p>
</details>

## Implementation notes / special instructions

None.