### PR TITLE
feat(libdicom): add package

### DIFF
--- a/packages/libdicom/brioche.lock
+++ b/packages/libdicom/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/ImagingDataCommons/libdicom/releases/download/v1.2.1/libdicom-1.2.1.tar.xz": {
+      "type": "sha256",
+      "value": "7a448d295b179a4c0b311c09f5253655446a44bf66b3b7d2aa4c09d15f02f1f8"
+    }
+  }
+}

--- a/packages/libdicom/project.bri
+++ b/packages/libdicom/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import uthash from "uthash";
+
+export const project = {
+  name: "libdicom",
+  version: "1.2.1",
+  repository: "https://github.com/ImagingDataCommons/libdicom",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libdicom-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libdicom(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, uthash],
+    set: {
+      tests: "false",
+      default_library: "both",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libdicom | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libdicom)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libdicom`
- **Website / repository:** `https://github.com/ImagingDataCommons/libdicom`
- **Repology URL:** `https://repology.org/project/libdicom/versions`
- **Short description:** `C library and command-line tools for reading DICOM WSI files`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 375652 (std/core/recipes/process.bri:240:14)
[375652] 1.2.1
Process 375652 ran in 0.02s
Build finished, completed 1 job in 2.83s
Result: 533ab8419757ea9170f559b09f12537dde6c5a83e08b41bbdf9939779808757a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 375753 (std/runtime_utils.bri:49:6)
Process 375753 ran in 0.01s
Build finished, completed 1 job in 3.26s
Running brioche-run
{
  "name": "libdicom",
  "version": "1.2.1",
  "repository": "https://github.com/ImagingDataCommons/libdicom"
}
```

</p>
</details>

## Implementation notes / special instructions

None.