### PR TITLE
feat(sheenbidi): add package

### DIFF
--- a/packages/sheenbidi/brioche.lock
+++ b/packages/sheenbidi/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/Tehreer/SheenBidi.git": {
+      "v3.0.0": "cfe430e7375a7845b679adae9d51dac6deaa8858"
+    }
+  }
+}

--- a/packages/sheenbidi/project.bri
+++ b/packages/sheenbidi/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "sheenbidi",
+  version: "3.0.0",
+  repository: "https://github.com/Tehreer/SheenBidi.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function sheenbidi(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      BUILD_TESTING: "OFF",
+      BUILD_GENERATOR: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sheenbidi | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sheenbidi)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sheenbidi`
- **Website / repository:** `https://github.com/Tehreer/SheenBidi`
- **Repology URL:** `https://repology.org/project/sheenbidi/versions`
- **Short description:** `SheenBidi is a sophisticated implementation of the Unicode Bidirectional Algorithm (UBA).`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 376385 (std/core/recipes/process.bri:240:14)
[376385] 3.0.0
Process 376385 ran in 0.02s
Build finished, completed 1 job in 1.57s
Result: f64596345c393884a3b9ebc1fb2ea502d1e9874a0193760c03d8ffd55b3d89dc
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 376483 (std/runtime_utils.bri:49:6)
Process 376483 ran in 0.01s
Build finished, completed 1 job in 3.71s
Running brioche-run
{
  "name": "sheenbidi",
  "version": "3.0.0",
  "repository": "https://github.com/Tehreer/SheenBidi.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.