### PR TITLE
feat(libexif): add package

### DIFF
--- a/packages/libexif/brioche.lock
+++ b/packages/libexif/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libexif/libexif/releases/download/v0.6.26/libexif-0.6.26.tar.xz": {
+      "type": "sha256",
+      "value": "4a055ed6575e61ca46c3172be3c753cc16c9becd0f99ec71d58dd0e471476c0c"
+    }
+  }
+}

--- a/packages/libexif/project.bri
+++ b/packages/libexif/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+
+export const project = {
+  name: "libexif",
+  version: "0.6.26",
+  repository: "https://github.com/libexif/libexif",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libexif-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libexif(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libexif | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libexif)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libexif`
- **Website / repository:** `https://github.com/libexif/libexif`
- **Repology URL:** `https://repology.org/project/libexif/versions`
- **Short description:** `C library for parsing, editing, and saving EXIF metadata from image files`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 381642 (std/core/recipes/process.bri:240:14)
[381642] 0.6.26
Process 381642 ran in 0.02s
Build finished, completed 1 job in 1.58s
Result: c1a965c69d504f3a42d964defb6b9725c02b2e4996d57ea4c3827b93b6493bd6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 381738 (std/runtime_utils.bri:49:6)
Process 381738 ran in 0.01s
Build finished, completed 1 job in 3.83s
Running brioche-run
{
  "name": "libexif",
  "version": "0.6.26",
  "repository": "https://github.com/libexif/libexif"
}
```

</p>
</details>

## Implementation notes / special instructions

None.