### PR TITLE
feat(libultrahdr): add package

### DIFF
--- a/packages/libultrahdr/brioche.lock
+++ b/packages/libultrahdr/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/libultrahdr.git": {
+      "v1.4.0": "d52a0d13814ca399fc8a07e23de1d2c63f0e8404"
+    }
+  }
+}

--- a/packages/libultrahdr/project.bri
+++ b/packages/libultrahdr/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import libjpegTurbo from "libjpeg_turbo";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libultrahdr",
+  version: "1.4.0",
+  repository: "https://github.com/google/libultrahdr.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libultrahdr(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libjpegTurbo],
+    set: {
+      UHDR_BUILD_EXAMPLES: "OFF",
+      UHDR_BUILD_TESTS: "OFF",
+      UHDR_BUILD_BENCHMARK: "OFF",
+      UHDR_BUILD_FUZZERS: "OFF",
+      UHDR_BUILD_JAVA: "OFF",
+      BUILD_SHARED_LIBS: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libuhdr | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libultrahdr)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libultrahdr`
- **Website / repository:** `https://github.com/google/libultrahdr`
- **Repology URL:** `https://repology.org/project/libultrahdr/versions`
- **Short description:** `HDR image compression library using gain map technology for backward-compatible HDR image storage`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 391251 (std/core/recipes/process.bri:240:14)
[391251] 1.4.0
Process 391251 ran in 0.20s
Build finished, completed 1 job in 22.41s
Result: f527d21102adf366d6c52e79f9eb83a9939feb039d5b62f023f359959fb7b0d6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 52.37s
Running brioche-run
{
  "name": "libultrahdr",
  "version": "1.4.0",
  "repository": "https://github.com/google/libultrahdr.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.