### PR TITLE
feat(mozjpeg): add package

### DIFF
--- a/packages/mozjpeg/brioche.lock
+++ b/packages/mozjpeg/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/mozilla/mozjpeg.git": {
+      "v4.1.5": "6c9f0897afa1c2738d7222a0a9ab49e8b536a267"
+    }
+  }
+}

--- a/packages/mozjpeg/project.bri
+++ b/packages/mozjpeg/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libpng from "libpng";
+import nasm from "nasm";
+
+export const project = {
+  name: "mozjpeg",
+  version: "4.1.5",
+  repository: "https://github.com/mozilla/mozjpeg.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function mozjpeg(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libpng, nasm],
+    set: {
+      WITH_JPEG8: "1",
+      ENABLE_STATIC: "OFF",
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libjpeg | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, mozjpeg)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `mozjpeg`
- **Website / repository:** `https://github.com/mozilla/mozjpeg`
- **Repology URL:** `https://repology.org/project/mozjpeg/versions`
- **Short description:** `Improved JPEG encoder (libjpeg-turbo fork) that produces smaller files while remaining compatible with the libjpeg API`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 392918 in 13.61s
Launched process 392918 (std/core/recipes/process.bri:240:14)
[392918] 4.1.5
Process 392918 ran in 0.29s
Build finished, completed 1 job in 38.43s
Result: 27603a2b6d7149f6bf4a00b1f1bc1558cdea5204b917f243c6af8e48784f9e6a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 53.80s
Running brioche-run
{
  "name": "mozjpeg",
  "version": "4.1.5",
  "repository": "https://github.com/mozilla/mozjpeg.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.