### PR TITLE
feat(matio): add package

### DIFF
--- a/packages/matio/brioche.lock
+++ b/packages/matio/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/tbeu/matio/releases/download/v1.5.30/matio-1.5.30.tar.gz": {
+      "type": "sha256",
+      "value": "8bd3b9477042ecc00dd71c04762fa58468e14cccc32fd8c6826c2da1e8bc3107"
+    }
+  }
+}

--- a/packages/matio/project.bri
+++ b/packages/matio/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import hdf5 from "hdf5";
+
+export const project = {
+  name: "matio",
+  version: "1.5.30",
+  repository: "https://github.com/tbeu/matio",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/matio-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function matio(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-hdf5 \\
+      --with-zlib \\
+      --enable-shared \\
+      --enable-static
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, hdf5)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/matdump"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion matio | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, matio)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `matio`
- **Website / repository:** `https://github.com/tbeu/matio`
- **Repology URL:** `https://repology.org/project/matio/versions`
- **Short description:** `C library for reading and writing MATLAB MAT files`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 394606 (std/core/recipes/process.bri:240:14)
[394606] 1.5.30
Process 394606 ran in 0.02s
Build finished, completed 1 job in 1.96s
Result: a075c53fdb9ba87e37b02f45fb2e2c669080b7a9b60955734d96db242c4167aa
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.39s
Running brioche-run
{
  "name": "matio",
  "version": "1.5.30",
  "repository": "https://github.com/tbeu/matio"
}
```

</p>
</details>

## Implementation notes / special instructions

None.