### PR TITLE
feat(yaz): add package

### DIFF
--- a/packages/yaz/brioche.lock
+++ b/packages/yaz/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.indexdata.com/pub/yaz/yaz-5.37.3.tar.gz": {
+      "type": "sha256",
+      "value": "975d7878b272cc999e5acbd02dc272a46607f95e6ee4f35ac655e8e4d333bf2b"
+    }
+  }
+}

--- a/packages/yaz/project.bri
+++ b/packages/yaz/project.bri
@@ -1,0 +1,87 @@
+import * as std from "std";
+import gnutls from "gnutls";
+import icu from "icu";
+import libiconv from "libiconv";
+import libidn2 from "libidn2";
+import libmemcached from "libmemcached";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import libxml2 from "libxml2";
+import libxslt from "libxslt";
+import nettle from "nettle";
+import openssl from "openssl";
+import p11Kit from "p11_kit";
+
+export const project = {
+  name: "yaz",
+  version: "5.37.3",
+  repository: "https://github.com/indexdata/yaz",
+};
+
+const source = Brioche.download(
+  `https://ftp.indexdata.com/pub/yaz/yaz-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function yaz(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-gnutls \\
+      --with-icu \\
+      --with-memcached \\
+      --with-xml2 \\
+      --with-xslt
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      gnutls,
+      icu,
+      libiconv,
+      libidn2,
+      libmemcached,
+      libtasn1,
+      libunistring,
+      libxml2,
+      libxslt,
+      nettle,
+      openssl,
+      p11Kit,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/yaz-client"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion yaz | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, yaz)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `yaz`
- **Website / repository:** `https://github.com/indexdata/yaz`
- **Repology URL:** `https://repology.org/project/yaz/versions`
- **Short description:** `Toolkit for Z39.50/SRW/SRU clients and servers from Index Data`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 436081 (std/core/recipes/process.bri:240:14)
[436081] 5.37.3
Process 436081 ran in 0.01s
Build finished, completed 1 job in 3.84s
Result: 74bef38e347971ee1773a6b4ef732d490ebb34d85162acc1669399ec4d71adb5
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.47s
Running brioche-run
{
  "name": "yaz",
  "version": "5.37.3",
  "repository": "https://github.com/indexdata/yaz"
}
```

</p>
</details>

## Implementation notes / special instructions

None.