### PR TITLE
feat(libftdi): add package

### DIFF
--- a/packages/libftdi/brioche.lock
+++ b/packages/libftdi/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2": {
+      "type": "sha256",
+      "value": "7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049"
+    }
+  }
+}

--- a/packages/libftdi/project.bri
+++ b/packages/libftdi/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libconfuse from "libconfuse";
+import libusb from "libusb";
+
+export const project = {
+  name: "libftdi",
+  version: "1.5",
+  repository: "https://github.com/mcuee/libftdi",
+};
+
+const source = Brioche.download(
+  `https://www.intra2net.com/en/developer/libftdi/download/libftdi1-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libftdi(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libconfuse, libusb],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+      BUILD_TESTS: "OFF",
+      EXAMPLES: "OFF",
+      FTDIPP: "OFF",
+      DOCUMENTATION: "OFF",
+      PYTHON_BINDINGS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libftdi1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libftdi)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libftdi`
- **Website / repository:** `https://www.intra2net.com/en/developer/libftdi/`
- **Repology URL:** `https://repology.org/project/libftdi/versions`
- **Short description:** `Open source library to talk to FTDI USB chips, with the ftdi_eeprom CLI tool.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 475978 (std/core/recipes/process.bri:240:14)
[475978] 1.5
Process 475978 ran in 0.01s
Build finished, completed 1 job in 1.57s
Result: 02798486264b10f06b7815b2c585dbf1a58146ee84e68a9579c2607b4a544ad7
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.42s
Running brioche-run
{
  "name": "libftdi",
  "version": "1.5",
  "repository": "https://github.com/mcuee/libftdi"
}
```

</p>
</details>

## Implementation notes / special instructions

None.