### PR TITLE
feat(gnupg): add package

### DIFF
--- a/packages/gnupg/brioche.lock
+++ b/packages/gnupg/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.20.tar.bz2": {
+      "type": "sha256",
+      "value": "6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6"
+    }
+  }
+}

--- a/packages/gnupg/project.bri
+++ b/packages/gnupg/project.bri
@@ -1,0 +1,95 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import gnutls from "gnutls";
+import libassuan from "libassuan";
+import libgcrypt from "libgcrypt";
+import libgpgError from "libgpg_error";
+import libidn2 from "libidn2";
+import libksba from "libksba";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import libusb from "libusb";
+import nettle from "nettle";
+import npth from "npth";
+import p11Kit from "p11_kit";
+import sqlite from "sqlite";
+import tpm2Tss from "tpm2_tss";
+
+export const project = {
+  name: "gnupg",
+  version: "2.5.20",
+  repository: "https://www.gnupg.org/",
+};
+
+const source = Brioche.download(
+  `https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function gnupg(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-doc \\
+      --disable-tests \\
+      --enable-ccid-driver
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      libgpgError,
+      libgcrypt,
+      libassuan,
+      libksba,
+      npth,
+      gnutls,
+      nettle,
+      libtasn1,
+      libidn2,
+      libunistring,
+      p11Kit,
+      sqlite,
+      libusb,
+      tpm2Tss,
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/gpg"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    gpg --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gnupg())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `gpg (GnuPG) ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://gnupg.org/ftp/gcrypt/gnupg/
+      | lines
+      | where ($it | str contains "gnupg-") and ($it | str contains ".tar.bz2") and (not ($it | str contains ".sig"))
+      | parse --regex '<a href="gnupg-(?<version>\\d+\\.\\d+\\.\\d+)\\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}

--- a/packages/libusb/project.bri
+++ b/packages/libusb/project.bri
@@ -30,7 +30,9 @@ export default function libusb(): std.Recipe<std.Directory> {
     .pipe(std.pkgConfigMakePathsRelative)
     .pipe((recipe) =>
       std.setEnv(recipe, {
-        CPATH: { append: [{ path: "include" }] },
+        CPATH: {
+          append: [{ path: "include" }, { path: "include/libusb-1.0" }],
+        },
         LIBRARY_PATH: { append: [{ path: "lib" }] },
         PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
       }),


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gnupg`
- **Website / repository:** `https://www.gnupg.org/`
- **Repology URL:** `https://repology.org/project/gnupg/versions`
- **Short description:** GNU Privacy Guard, a complete implementation of the OpenPGP standard for encryption, signing, and key management.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 520275 in 1.06s
Launched process 520275 (std/core/recipes/process.bri:240:14)
[520275] gpg (GnuPG) 2.5.20
[520275] libgcrypt 1.12.1
[520275] Copyright (C) 2026 g10 Code GmbH
[520275] License GNU GPL-3.0-or-later <https://gnu.org/licenses/gpl.html>
[520275] This is free software: you are free to change and redistribute it.
[520275] There is NO WARRANTY, to the extent permitted by law.
[520275] 
[520275] Home: /home/brioche-runner-40e0cc96fa5d7d066f054fd609d463a911b95303b76c548d86bf60eebe3ea3a6/.gnupg
[520275] Supported algorithms:
[520275] Pubkey: RSA, Kyber, ELG, DSA, ECDH, ECDSA, EDDSA
[520275] Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
[520275]         CAMELLIA128, CAMELLIA192, CAMELLIA256
[520275] Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
[520275] Compression: Uncompressed, ZIP, ZLIB, BZIP2
Process 520275 ran in 0.10s
Build finished, completed 1 job in 4.79s
Result: c461d4e317582a3cde7771448259f177a84a80dec1a2800eed5671aa14b97f10
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 5.26s
Running brioche-run
{
  "name": "gnupg",
  "version": "2.5.20",
  "repository": "https://www.gnupg.org/"
}
```

</p>
</details>

## Implementation notes / special instructions

None.