### PR TITLE
feat(lttng_ust): add package

### DIFF
--- a/packages/lttng_ust/brioche.lock
+++ b/packages/lttng_ust/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://lttng.org/files/lttng-ust/lttng-ust-2.15.1.tar.bz2": {
+      "type": "sha256",
+      "value": "37c9b58ea7aa7bc47d6630b52ba1a48ebce095b9a196eab4ddd273d78301792d"
+    }
+  }
+}

--- a/packages/lttng_ust/project.bri
+++ b/packages/lttng_ust/project.bri
@@ -1,0 +1,60 @@
+import * as std from "std";
+import numactl from "numactl";
+import userspaceRcu from "userspace_rcu";
+
+export const project = {
+  name: "lttng_ust",
+  version: "2.15.1",
+  repository: "https://github.com/lttng/lttng-ust",
+};
+
+const source = Brioche.download(
+  `https://lttng.org/files/lttng-ust/lttng-ust-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function lttngUst(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-shared \\
+      --disable-static \\
+      --disable-man-pages \\
+      --disable-examples
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, numactl, userspaceRcu)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lttng-ust | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lttngUst)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lttng_ust`
- **Website / repository:** `https://github.com/lttng/lttng-ust`
- **Repology URL:** `https://repology.org/project/lttng-ust/versions`
- **Short description:** `LTTng Userspace Tracer: high-performance userspace tracing library for Linux applications`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 545467 (std/core/recipes/process.bri:240:14)
[545467] 2.15.1
Process 545467 ran in 0.02s
Build finished, completed 1 job in 1.52s
Result: a97054d83954dc9216c8f0ec0a2b377fc1344a7454f42920fa0adf3f6e3df288
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 545566 (std/runtime_utils.bri:49:6)
Process 545566 ran in 0.01s
Build finished, completed 1 job in 3.54s
Running brioche-run
{
  "name": "lttng_ust",
  "version": "2.15.1",
  "repository": "https://github.com/lttng/lttng-ust"
}
```

</p>
</details>

## Implementation notes / special instructions

None.