### PR TITLE
feat(litehtml): add package

### DIFF
--- a/packages/litehtml/brioche.lock
+++ b/packages/litehtml/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/litehtml/litehtml.git": {
+      "v0.9": "6ca1ab0419e770e6d35a1ef690238773a1dafcee"
+    }
+  }
+}

--- a/packages/litehtml/project.bri
+++ b/packages/litehtml/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "litehtml",
+  version: "0.9",
+  repository: "https://github.com/litehtml/litehtml",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: `v${project.version}`,
+});
+
+export default function litehtml(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      LITEHTML_BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "CMakeLists.txt": std.file(std.indoc`
+      cmake_minimum_required(VERSION 4.0)
+      project(QueryLibrary)
+
+      find_package(litehtml REQUIRED CONFIG)
+      message(STATUS "litehtml found: YES")
+    `),
+  });
+
+  const script = std.runBash`
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, cmake, litehtml)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "litehtml found: YES";
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `litehtml`
- **Website / repository:** `https://github.com/litehtml/litehtml`
- **Repology URL:** `https://repology.org/project/litehtml/versions`
- **Short description:** `Lightweight HTML/CSS rendering engine library`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 550166 (std/core/recipes/process.bri:240:14)
[550166] -- The C compiler identification is GNU 13.2.0
[550166] -- The CXX compiler identification is GNU 13.2.0
[550166] -- Detecting C compiler ABI info
[550166] -- Detecting C compiler ABI info - done
[550166] -- Check for working C compiler: /home/brioche-runner-1cd5feb9b20c41af2fe9cd09c69d539499c1e4795254a458869ca15ba43136da/.local/share/brioche/locals/860266387c53e164b0d3e74232b04dda00c13ba43c631d68c3b70c20fb859de4/bin/cc - skipped
[550166] -- Detecting C compile features
[550166] -- Detecting C compile features - done
[550166] -- Detecting CXX compiler ABI info
[550166] -- Detecting CXX compiler ABI info - done
[550166] -- Check for working CXX compiler: /home/brioche-runner-1cd5feb9b20c41af2fe9cd09c69d539499c1e4795254a458869ca15ba43136da/.local/share/brioche/locals/860266387c53e164b0d3e74232b04dda00c13ba43c631d68c3b70c20fb859de4/bin/c++ - skipped
[550166] -- Detecting CXX compile features
[550166] -- Detecting CXX compile features - done
[550166] -- litehtml found: YES
[550166] -- Configuring done (0.4s)
[550166] -- Generating done (0.0s)
[550166] -- Build files have been written to: /home/brioche-runner-1cd5feb9b20c41af2fe9cd09c69d539499c1e4795254a458869ca15ba43136da/work/tmp
Process 550166 ran in 0.41s
Build finished, completed 1 job in 2.12s
Result: e67b623e6e69dd35e5beb98f5ad5464bb1e1f0cc4fe4a3950c6b68f22687daa3
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 550321 (std/runtime_utils.bri:49:6)
Process 550321 ran in 0.01s
Build finished, completed 1 job in 3.80s
Running brioche-run
{
  "name": "litehtml",
  "version": "0.9",
  "repository": "https://github.com/litehtml/litehtml"
}
```

</p>
</details>

## Implementation notes / special instructions

None.