### PR TITLE
feat(m4ri): add package

### DIFF
--- a/packages/m4ri/brioche.lock
+++ b/packages/m4ri/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/malb/m4ri/releases/download/20260122/m4ri-20260122.tar.gz": {
+      "type": "sha256",
+      "value": "7e033ca1fd36be8861e2f67d9d124c398fc0d830209bb0226462485876346404"
+    }
+  }
+}

--- a/packages/m4ri/project.bri
+++ b/packages/m4ri/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import libpng from "libpng";
+
+export const project = {
+  name: "m4ri",
+  version: "20260122",
+  repository: "https://github.com/malb/m4ri",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/m4ri-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function m4ri(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libpng)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion m4ri | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, m4ri)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^(?<version>\d{8})$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `m4ri`
- **Website / repository:** `https://github.com/malb/m4ri`
- **Repology URL:** `https://repology.org/project/m4ri/versions`
- **Short description:** `C library for fast arithmetic with dense matrices over GF(2)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 549994 (std/core/recipes/process.bri:240:14)
[549994] 20260122
Process 549994 ran in 0.01s
Build finished, completed 1 job in 1.48s
Result: 5505043d10a6d71070d97e8fcda4f0e052862ad6c049949b2ca5500928bba11f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 550117 (std/runtime_utils.bri:49:6)
Process 550117 ran in 0.01s
Build finished, completed 1 job in 4.17s
Running brioche-run
{
  "name": "m4ri",
  "version": "20260122",
  "repository": "https://github.com/malb/m4ri"
}
```

</p>
</details>

## Implementation notes / special instructions

None.