### PR TITLE
feat(yazpp): add package

### DIFF
--- a/packages/yazpp/brioche.lock
+++ b/packages/yazpp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.indexdata.com/pub/yazpp/yazpp-1.9.2.tar.gz": {
+      "type": "sha256",
+      "value": "92516d1d889dd6ff617d92b3af0ba28861dbd1fc436cfcadd0fde65ca9f34fe9"
+    }
+  }
+}

--- a/packages/yazpp/project.bri
+++ b/packages/yazpp/project.bri
@@ -1,0 +1,78 @@
+import * as std from "std";
+import gnutls from "gnutls";
+import libiconv from "libiconv";
+import libidn2 from "libidn2";
+import libmemcached from "libmemcached";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import libxml2 from "libxml2";
+import libxslt from "libxslt";
+import nettle from "nettle";
+import p11Kit from "p11_kit";
+import yaz from "yaz";
+
+export const project = {
+  name: "yazpp",
+  version: "1.9.2",
+  repository: "https://github.com/indexdata/yazpp",
+};
+
+const source = Brioche.download(
+  `https://ftp.indexdata.com/pub/yazpp/yazpp-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function yazpp(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      gnutls,
+      libiconv,
+      libidn2,
+      libmemcached,
+      libtasn1,
+      libunistring,
+      libxml2,
+      libxslt,
+      nettle,
+      p11Kit,
+      yaz,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion yazpp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, yazpp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `yazpp`
- **Website / repository:** `https://github.com/indexdata/yazpp`
- **Repology URL:** `https://repology.org/project/yazpp/versions`
- **Short description:** `C++ wrapper library for the YAZ toolkit, providing a ZOOM C++ binding for Z39.50 client and server applications`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.41s
Result: 10745788c9bd4f53ce1708f3420c04c9a8e746805eb525385ff38912af8f14d6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "yazpp",
  "version": "1.9.2",
  "repository": "https://github.com/indexdata/yazpp"
}
```

</p>
</details>

## Implementation notes / special instructions

None.