### PR TITLE
feat(gpgme): add package

### DIFF
--- a/packages/gpgme/brioche.lock
+++ b/packages/gpgme/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-2.1.0.tar.bz2": {
+      "type": "sha256",
+      "value": "841c5ea53fc26259f4fbf0e8bde982dea1b8a1ca0cb77e681c82b050566bf92b"
+    }
+  }
+}

--- a/packages/gpgme/project.bri
+++ b/packages/gpgme/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import gnupg from "gnupg";
+import libassuan from "libassuan";
+import libgpgError from "libgpg_error";
+
+export const project = {
+  name: "gpgme",
+  version: "2.1.0",
+  repository: "https://www.gnupg.org/",
+};
+
+const source = Brioche.download(
+  `https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function gpgme(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-static \\
+      --enable-shared \\
+      --disable-gpg-test \\
+      --disable-gpgsm-test \\
+      --disable-gpgconf-test \\
+      --disable-g13-test
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libgpgError, libassuan, gnupg)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+        ACLOCAL_PATH: { append: [{ path: "share/aclocal" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion gpgme | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gpgme)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://gnupg.org/ftp/gcrypt/gpgme/
+      | lines
+      | where ($it | str contains "gpgme-") and ($it | str contains ".tar.bz2") and (not ($it | str contains ".sig"))
+      | parse --regex '<a href="gpgme-(?<version>\\d+\\.\\d+\\.\\d+)\\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gpgme`
- **Website / repository:** `https://www.gnupg.org/software/gpgme/`
- **Repology URL:** `https://repology.org/project/gpgme/versions`
- **Short description:** `GnuPG Made Easy: C library providing a high-level API for using GnuPG (OpenPGP/CMS encryption, signing, and key management)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 623505 (std/core/recipes/process.bri:240:14)
[623505] 2.1.0
Process 623505 ran in 0.02s
Build finished, completed 1 job in 2.28s
Result: b687b05c6adf851d65b347cde5cdcb0f54e7a6e68768989c158cd4dc57ddf46d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 606709 (std/runtime_utils.bri:49:6)
Process 606709 ran in 0.01s
Build finished, completed 1 job in 3.73s
Running brioche-run
{
  "name": "gpgme",
  "version": "2.1.0",
  "repository": "https://www.gnupg.org/"
}
```

</p>
</details>

## Implementation notes / special instructions

None.