### PR TITLE
feat(m4rie): add package

### DIFF
--- a/packages/m4rie/brioche.lock
+++ b/packages/m4rie/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/malb/m4rie/releases/download/20250128/m4rie-20250128.tar.gz": {
+      "type": "sha256",
+      "value": "96f1adafd50e6a0b51dc3aa1cb56cb6c1361ae7c10d97dc35c3fa70822a55bd7"
+    }
+  }
+}

--- a/packages/m4rie/project.bri
+++ b/packages/m4rie/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import m4ri from "m4ri";
+
+export const project = {
+  name: "m4rie",
+  version: "20250128",
+  repository: "https://github.com/malb/m4rie",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/m4rie-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function m4rie(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, m4ri)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion m4rie | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, m4rie)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^(?<version>\d{8})$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `m4rie`
- **Website / repository:** `https://github.com/malb/m4rie`
- **Repology URL:** `https://repology.org/project/m4rie/versions`
- **Short description:** `Library for fast arithmetic with dense matrices over GF(2^e) for 2 <= e <= 16`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 554127 (std/core/recipes/process.bri:240:14)
[554127] 20250128
Process 554127 ran in 0.02s
Build finished, completed 1 job in 1.51s
Result: abe843983c0f0c9ec457aec64cb593d176c57a72d6d36c5aae1ecde44b19f759
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 554224 (std/runtime_utils.bri:49:6)
Process 554224 ran in 0.01s
Build finished, completed 1 job in 3.73s
Running brioche-run
{
  "name": "m4rie",
  "version": "20250128",
  "repository": "https://github.com/malb/m4rie"
}
```

</p>
</details>

## Implementation notes / special instructions

None.