### PR TITLE
feat(csmith): add package

### DIFF
--- a/packages/csmith/brioche.lock
+++ b/packages/csmith/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/csmith-project/csmith.git": {
+      "csmith-2.3.0": "30dccd73b78652c4719f36572994778a5b233a4e"
+    }
+  }
+}

--- a/packages/csmith/project.bri
+++ b/packages/csmith/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import libbsd from "libbsd";
+import libmd from "libmd";
+
+export const project = {
+  name: "csmith",
+  version: "2.3.0",
+  repository: "https://github.com/csmith-project/csmith.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `csmith-${project.version}`,
+});
+
+export default function csmith(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, libbsd, libmd],
+    set: {
+      // Required for building with CMake 3.5 or later
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5",
+    },
+    runnable: "bin/csmith",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    csmith --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(csmith)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `csmith ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^csmith-(?<version>\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `csmith`
- **Website / repository:** https://github.com/csmith-project/csmith
- **Repology URL:** https://repology.org/project/csmith/versions
- **Short description:** Random generator of C programs for finding compiler bugs via differential testing.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Fetching artifact from cache (std/core/recipes/process.bri:252:14)
Fetched 0 B for artifact from cache in 3.31s (std/core/recipes/process.bri:252:14)
Fetching artifact from cache (std/core/recipes/process.bri:240:14)
Fetched 128.5 MiB for artifact from cache in 11.59s (std/core/recipes/process.bri:240:14)
Preparing process (git/project.bri:140:8)
Prepared process 625507 in 3.30s
Launched process 625507 (git/project.bri:140:8)
[625507] Cloning into '/home/brioche-runner-738dd8cedb5e904a219cf2cd754b776750a6a2e5b78c5ef5f3df76e8dc14f72a/.local/share/brioche/outputs/output-738dd8cedb5e904a219cf2cd754b776750a6a2e5b78c5ef5f3df76e8dc14f72a'...
Process 625507 ran in 1.38s
Process 625507 finalized in 1.15s
Preparing process (git/project.bri:204:10)
Prepared process 625537 in 1.42s
Launched process 625537 (git/project.bri:204:10)
Process 625537 ran in 0.07s
Process 625537 finalized in 3.36s
Preparing process (std/core/recipes/process.bri:252:14)
Launched process 625558 (std/core/recipes/process.bri:252:14)
Process 625558 ran in 0.09s
Build finished, completed 5 jobs in 39.98s
Result: 65862688acf2ec13ed2fc2aa38550433339b734cde440b591f390867e4081db4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Fetching artifact from cache (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.01s (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.02s (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.02s (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.02s (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.03s (rust/project.bri:321:6)
Fetched 0 B for artifact from cache in 0.04s (rust/project.bri:321:6)
Build finished, completed 6 jobs in 29.13s
Running brioche-run
{
  "name": "csmith",
  "version": "2.3.0",
  "repository": "https://github.com/csmith-project/csmith.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.