### PR TITLE
fix(ci): redirect brioche stderr to stdout inside log groups

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,7 +46,7 @@ jobs:
               echo "$label: skipping (does not support $PLATFORM)"
             else
               echo "::group::$label"
-              brioche build "$package" --sync --locked --display plain-reduced --experimental-lazy
+              brioche build "$package" --sync --locked --display plain-reduced --experimental-lazy 2>&1
               echo "::endgroup::"
             fi
           done
@@ -78,7 +78,7 @@ jobs:
                 echo "$label: skipping (does not support $PLATFORM)"
               else
                 echo "::group::$label"
-                brioche build "$package"^test --sync --locked --display plain-reduced --experimental-lazy
+                brioche build "$package"^test --sync --locked --display plain-reduced --experimental-lazy 2>&1
                 echo "::endgroup::"
               fi
             else

--- a/.github/workflows/live-updates.yml
+++ b/.github/workflows/live-updates.yml
@@ -77,7 +77,7 @@ jobs:
                 git clean -ffdx 2>/dev/null
               fi
 
-              if ! brioche live-update "$package" --locked; then
+              if ! brioche live-update "$package" --locked 2>&1; then
                 echo "🔴 Failed to update $package"
                 echo "::error file=$package/project.bri::Failed to update $package"
                 failed_packages+=("$package")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
             label="$package ($n / ${#packages[@]})"
             ((n++))
             echo "::group::$label"
-            brioche publish --no-verify "$package"
+            brioche publish --no-verify "$package" 2>&1
             echo "::endgroup::"
           done
         env:


### PR DESCRIPTION
In CI logs (example: https://github.com/brioche-dev/brioche-packages/actions/runs/26368426948/job/77621296352), some package blocks render outside their `::group::` and lose indentation:

```
./packages/asdf (29 / 1072)
  Updated tags:
  asdf latest (updated)
  asdf 0.18.1 (updated)
Updated tags:
asmfmt latest (updated)
asmfmt 1.3.2 (updated)
./packages/asmfmt (30 / 1072)
```

The Plain console reporter writes via `eprintln!` (`brioche-core/src/reporter/console.rs`), so brioche output lands on stderr while the surrounding `echo "::group::"` markers go to stdout. With independent buffering on the two streams, output can reach the GitHub Actions log collector out of order, causing the lines to render outside their group.

Redirecting stderr to stdout (`2>&1`) on every `brioche` command wrapped in a group keeps the sequencing intact.