### PR TITLE
feat(cgit): add package

### DIFF
--- a/packages/cgit/brioche.lock
+++ b/packages/cgit/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://git.zx2c4.com/cgit/snapshot/cgit-1.3.1.tar.xz": {
+      "type": "sha256",
+      "value": "c40fd71e120783d5e57d822208f3e17333cde2cd4baf3e7c8c75630b68afe12a"
+    }
+  }
+}

--- a/packages/cgit/project.bri
+++ b/packages/cgit/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { source as gitSource } from "git";
+import openssl from "openssl";
+import zlib from "zlib";
+
+export const project = {
+  name: "cgit",
+  version: "1.3.1",
+  repository: "https://github.com/zx2c4/cgit",
+};
+
+const source = Brioche.download(
+  `https://git.zx2c4.com/cgit/snapshot/cgit-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function cgit(): std.Recipe<std.Directory> {
+  const sourceWithGit = source.insert("git", gitSource);
+
+  return std.runBash`
+    make -j "$(nproc)"
+    make \\
+      prefix=/ \\
+      CGIT_SCRIPT_PATH=/share/webapps/cgit \\
+      CGIT_DATA_PATH=/share/webapps/cgit \\
+      install \\
+      DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(sourceWithGit)
+    .dependencies(std.toolchain, openssl({ version: "3" }), zlib)
+    .toDirectory();
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    "$cgit_dir/share/webapps/cgit/cgit.cgi" \\
+      | grep -oE "cgit v[0-9]+(\\.[0-9]+)+" \\
+      | head -1 \\
+      | tee "$BRIOCHE_OUTPUT"
+  `
+    .env({ cgit_dir: cgit })
+    .dependencies(std.toolchain)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cgit v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}

--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -8,7 +8,7 @@ export const project = {
   repository: "https://github.com/git/git",
 };
 
-const source = Brioche.download(
+export const source = Brioche.download(
   `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
 )
   .unarchive("tar", "gzip")


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cgit`
- **Website / repository:** `https://git.zx2c4.com/cgit/` (GitHub mirror: `https://github.com/zx2c4/cgit`)
- **Repology URL:** `https://repology.org/project/cgit/versions`
- **Short description:** A fast web frontend (CGI) for git repositories, written in C.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/cgit^test
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 3603 (std/core/recipes/process.bri:240:14)
[3603] cgit v1.3.1
Process 3603 ran in 0.01s
Build finished, completed 1 job in 2.41s
Result: ec6ee6914c3313c056cfb344febb2e71f282ce866b73cd3eedfcf3945d42c233
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/cgit^liveUpdate
Preparing process (std/runtime_utils.bri:49:6)
Launched process 3694 (std/runtime_utils.bri:49:6)
Process 3694 ran in 0.02s
Build finished, completed 1 job in 2.52s
Running brioche-run
{
  "name": "cgit",
  "version": "1.3.1",
  "repository": "https://github.com/zx2c4/cgit"
}
```

</p>
</details>

## Implementation notes / special instructions

None.