### PR TITLE
feat(cwalk): add package

### DIFF
--- a/packages/cwalk/brioche.lock
+++ b/packages/cwalk/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/likle/cwalk": {
+      "v1.2.9": "f45a23a13abf39d94b347d7c83810eca26a5a8d0"
+    }
+  }
+}

--- a/packages/cwalk/project.bri
+++ b/packages/cwalk/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "cwalk",
+  version: "1.2.9",
+  repository: "https://github.com/likle/cwalk",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cwalk(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      ENABLE_TESTS: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion cwalk | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, cwalk)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cwalk`
- **Website / repository:** `https://github.com/likle/cwalk`
- **Repology URL:** `https://repology.org/project/cwalk/versions`
- **Short description:** `Cross-platform path manipulation library for C/C++ supporting UNIX and Windows path styles`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 13392 (std/core/recipes/process.bri:240:14)
[13392] 1.2.9
Process 13392 ran in 0.01s
Build finished, completed 1 job in 1.42s
Result: d208ea8ef3e119963cfa2aa5a1b065809266a66981f0b1fc2336798a315d7ad3
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 13487 (std/runtime_utils.bri:49:6)
Process 13487 ran in 0.01s
Build finished, completed 1 job in 3.67s
Running brioche-run
{
  "name": "cwalk",
  "version": "1.2.9",
  "repository": "https://github.com/likle/cwalk"
}
```

</p>
</details>

## Implementation notes / special instructions

None.