### PR TITLE
feat(maturin): add package

### DIFF
--- a/packages/maturin/brioche.lock
+++ b/packages/maturin/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/maturin/1.13.3/download": {
+      "type": "sha256",
+      "value": "8b4e123c32db7b76ff7ad0d3b5c9795ef9d4f013cb75bc0baaa5c17a70995ed3"
+    }
+  }
+}

--- a/packages/maturin/project.bri
+++ b/packages/maturin/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "maturin",
+  version: "1.13.3",
+  extra: {
+    crateName: "maturin",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function maturin(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/maturin",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    maturin --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(maturin)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `maturin ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `maturin`
- **Website / repository:** `https://github.com/PyO3/maturin`
- **Repology URL:** `https://repology.org/project/maturin/versions`
- **Short description:** `Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 48001 (std/core/recipes/process.bri:240:14)
[48001] maturin 1.13.3
Process 48001 ran in 0.11s
Build finished, completed 1 job in 7.02s
Result: a940328350a30d3cffdd04bd964f79f714fe317a9c12d84bf89daa9183f44d33
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 48103 (std/runtime_utils.bri:49:6)
Process 48103 ran in 0.05s
Build finished, completed 1 job in 12.62s
Running brioche-run
{
  "name": "maturin",
  "version": "1.13.3",
  "repository": "https://github.com/PyO3/maturin",
  "extra": {
    "crateName": "maturin"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.