### PR TITLE
feat(gpgmepp): add package

### DIFF
--- a/packages/gpgmepp/brioche.lock
+++ b/packages/gpgmepp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-2.1.0.tar.xz": {
+      "type": "sha256",
+      "value": "57f804468f0204504b172c6b139cb05124b4263be7ad514932c7c4c5062a16e2"
+    }
+  }
+}

--- a/packages/gpgmepp/project.bri
+++ b/packages/gpgmepp/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import gpgme from "gpgme";
+import libgpgError from "libgpg_error";
+
+export const project = {
+  name: "gpgmepp",
+  version: "2.1.0",
+  repository: "https://www.gnupg.org/",
+};
+
+const source = Brioche.download(
+  `https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel()
+  .pipe((source) =>
+    // Drop the "-unknown" suffix appended when no git tag is present.
+    std.runBash`
+      sed -i 's|version}-unknown|version}|' "$BRIOCHE_OUTPUT/cmake/modules/G10GetFullVersion.cmake"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function gpgmepp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, gpgme, libgpgError],
+    set: {
+      BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion gpgmepp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, gpgmepp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://gnupg.org/ftp/gcrypt/gpgmepp/
+      | lines
+      | where ($it | str contains "gpgmepp-") and ($it | str contains ".tar.xz") and (not ($it | str contains ".sig"))
+      | parse --regex '<a href="gpgmepp-(?<version>\\d+\\.\\d+\\.\\d+)\\.tar\\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `gpgmepp`
- **Website / repository:** `https://www.gnupg.org/`
- **Repology URL:** `https://repology.org/project/gpgmepp/versions`
- **Short description:** `C++ bindings for gpgme (GnuPG Made Easy)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.59s
Result: b687b05c6adf851d65b347cde5cdcb0f54e7a6e68768989c158cd4dc57ddf46d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "gpgmepp",
  "version": "2.1.0",
  "repository": "https://www.gnupg.org/"
}
```

</p>
</details>

## Implementation notes / special instructions

None.