### PR TITLE
feat(metaproxy): add package

### DIFF
--- a/packages/metaproxy/brioche.lock
+++ b/packages/metaproxy/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.indexdata.com/pub/metaproxy/metaproxy-1.22.4.tar.gz": {
+      "type": "sha256",
+      "value": "79bffb2786bfd7612dab9603bd69ab1505c6d04053db192e0cc9ef6a842450dc"
+    }
+  }
+}

--- a/packages/metaproxy/project.bri
+++ b/packages/metaproxy/project.bri
@@ -1,0 +1,85 @@
+import * as std from "std";
+import boost from "boost";
+import gnutls from "gnutls";
+import libiconv from "libiconv";
+import libidn2 from "libidn2";
+import libmemcached from "libmemcached";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import libxml2 from "libxml2";
+import libxslt from "libxslt";
+import nettle from "nettle";
+import p11Kit from "p11_kit";
+import yaz from "yaz";
+import yazpp from "yazpp";
+
+export const project = {
+  name: "metaproxy",
+  version: "1.22.4",
+  repository: "https://github.com/indexdata/metaproxy",
+};
+
+const source = Brioche.download(
+  `https://ftp.indexdata.com/pub/metaproxy/metaproxy-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function metaproxy(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      boost,
+      gnutls,
+      libiconv,
+      libidn2,
+      libmemcached,
+      libtasn1,
+      libunistring,
+      libxml2,
+      libxslt,
+      nettle,
+      p11Kit,
+      yaz,
+      yazpp,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/metaproxy"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    metaproxy -V | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(metaproxy)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `metaproxy`
- **Website / repository:** `https://github.com/indexdata/metaproxy`
- **Repology URL:** `https://repology.org/project/metaproxy/versions`
- **Short description:** `Z39.50 proxy and router utilizing the Yaz toolkit`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 59510 in 2.26s
Launched process 59510 (std/core/recipes/process.bri:240:14)
[59510] 1.22.4 bf9643331e5c2a61dc6d1a0d15367a8a7227c7ad
Process 59510 ran in 0.08s
Build finished, completed 1 job in 18.92s
Result: aac0bbd703287ba104193f2a1d0d5e7f16e2134f0cd3a79c79aa61f3a9725c03
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 8.63s
Running brioche-run
{
  "name": "metaproxy",
  "version": "1.22.4",
  "repository": "https://github.com/indexdata/metaproxy"
}
```

</p>
</details>

## Implementation notes / special instructions

None.