### PR TITLE
feat(cffi): add package

### DIFF
--- a/packages/cffi/brioche.lock
+++ b/packages/cffi/brioche.lock
@@ -1,0 +1,17 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248"
+    },
+    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"
+    },
+    "https://files.pythonhosted.org/packages/source/c/cffi/cffi-2.0.0.tar.gz": {
+      "type": "sha256",
+      "value": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
+    }
+  }
+}

--- a/packages/cffi/brioche.lock
+++ b/packages/cffi/brioche.lock
@@ -1,13 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl": {
+    "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl": {
       "type": "sha256",
-      "value": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248"
-    },
-    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl": {
-      "type": "sha256",
-      "value": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"
+      "value": "a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"
     },
     "https://files.pythonhosted.org/packages/source/c/cffi/cffi-2.0.0.tar.gz": {
       "type": "sha256",

--- a/packages/cffi/project.bri
+++ b/packages/cffi/project.bri
@@ -1,0 +1,101 @@
+import * as std from "std";
+import python, { injectVenvPackages } from "python";
+import libffi from "libffi";
+import pycparser, { project as pycparserProject } from "pycparser";
+
+export const project = {
+  name: "cffi",
+  version: "2.0.0",
+  extra: {
+    packageName: "cffi",
+  },
+};
+
+const source = Brioche.download(
+  `https://files.pythonhosted.org/packages/source/c/cffi/cffi-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+const pipDependencies = std.directory({
+  "setuptools-80.9.0-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl",
+  ),
+  "wheel-0.45.1-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
+  ),
+});
+
+export default function cffi(): std.Recipe<std.Directory> {
+  // Create a venv
+  let venv = std.recipe(python);
+
+  // Install build dependencies (setuptools, wheel)
+  venv = std.runBash`
+    pip install setuptools wheel
+  `
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Inject pycparser into the venv
+  venv = injectVenvPackages(venv, [
+    {
+      recipe: pycparser(),
+      name: pycparserProject.name,
+      version: pycparserProject.version,
+    },
+  ]);
+
+  // Install the application into the venv
+  venv = std.runBash`
+    pip install .
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libffi)
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Create the final recipe with the venv under `venv`
+  return std
+    .directory({
+      venv,
+    })
+    .pipe((recipe) =>
+      std.addRunnable(recipe, "bin/python3", {
+        command: { relativePath: "venv/bin/python3" },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    python3 -c "import cffi; print(cffi.__version__)" | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cffi)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromPythonPackages({ project });
+}

--- a/packages/cffi/project.bri
+++ b/packages/cffi/project.bri
@@ -18,11 +18,8 @@ const source = Brioche.download(
   .peel();
 
 const pipDependencies = std.directory({
-  "setuptools-80.9.0-py3-none-any.whl": Brioche.download(
-    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl",
-  ),
-  "wheel-0.45.1-py3-none-any.whl": Brioche.download(
-    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
+  "setuptools-82.0.1-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl",
   ),
 });
 
@@ -30,9 +27,9 @@ export default function cffi(): std.Recipe<std.Directory> {
   // Create a venv
   let venv = std.recipe(python);
 
-  // Install build dependencies (setuptools, wheel)
+  // Install build dependencies (setuptools)
   venv = std.runBash`
-    pip install setuptools wheel
+    pip install setuptools
   `
     .env({
       PATH: std.tpl`${std.outputPath}/bin`,
@@ -53,14 +50,12 @@ export default function cffi(): std.Recipe<std.Directory> {
 
   // Install the application into the venv
   venv = std.runBash`
-    pip install .
+    pip install --no-build-isolation .
   `
     .workDir(source)
     .dependencies(std.toolchain, libffi)
     .env({
       PATH: std.tpl`${std.outputPath}/bin`,
-      PIP_FIND_LINKS: pipDependencies,
-      PIP_NO_INDEX: "1",
     })
     .outputScaffold(venv)
     .toDirectory();

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -371,3 +371,62 @@ export function wrapVenvScripts(
     )
     .pipe((recipe) => addVenvRunnable(recipe, options));
 }
+
+/**
+ * A Python package to inject into a venv.
+ *
+ * @param recipe - A pre-built Python package recipe.
+ * @param name - The distribution name under `site-packages`.
+ * @param version - The distribution version.
+ */
+export interface VenvPackageSource {
+  recipe: std.Recipe<std.Directory>;
+  name: string;
+  version: string;
+}
+
+/**
+ * Options for {@link injectVenvPackages}.
+ *
+ * @param pythonVersion - The Python minor version shared by the source
+ *   and target venvs.
+ */
+interface InjectVenvPackagesOptions {
+  pythonVersion?: PythonVersion;
+}
+
+/**
+ * Inject the installed contents of pre-built Python packages into a
+ * venv, so `pip install` treats them as already satisfied.
+ *
+ * @remarks The target recipe must be the venv root.
+ *
+ * @param recipe - The target venv recipe.
+ * @param packages - The source packages to inject.
+ * @param options - Additional options.
+ *
+ * @returns The venv recipe with the source packages merged in.
+ */
+export function injectVenvPackages(
+  recipe: std.Recipe<std.Directory>,
+  packages: VenvPackageSource[],
+  options: InjectVenvPackagesOptions = {},
+): std.Recipe<std.Directory> {
+  const { pythonVersion = getLatestVersion() } = options;
+  const sitePackages = `lib/python${pythonVersion}/site-packages`;
+
+  return packages.reduce((target, pkg) => {
+    const module = std.castToDirectory(
+      pkg.recipe.get(`venv/${sitePackages}/${pkg.name}`),
+    );
+    const distInfo = std.castToDirectory(
+      pkg.recipe.get(
+        `venv/${sitePackages}/${pkg.name}-${pkg.version}.dist-info`,
+      ),
+    );
+
+    return target
+      .insert(`${sitePackages}/${pkg.name}`, module)
+      .insert(`${sitePackages}/${pkg.name}-${pkg.version}.dist-info`, distInfo);
+  }, recipe);
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cffi`
- **Website / repository:** `https://github.com/python-cffi/cffi`
- **Repology URL:** `https://repology.org/project/python:cffi/versions`
- **Short description:** `Foreign Function Interface for Python calling C code.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.74s
Result: b89182ea37971388da5bfd1b9e242603454fd919c88e2b89b22a664c021062f5
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.85s
Running brioche-run
{
  "name": "cffi",
  "version": "2.0.0",
  "extra": {
    "packageName": "cffi"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

There is a new helper in the `python` package that copies the installed module + `dist-info` of pre-built Python packages into a venv, so `pip install` treats them as already satisfied via `importlib.metadata`. It avoids vendoring a wheel for any dependency already packaged in this repo.