### PR TITLE
[nushell] (Live update)

### DIFF
--- a/packages/nodejs/find-nodejs-bins.nu
+++ b/packages/nodejs/find-nodejs-bins.nu
@@ -6,7 +6,7 @@ ls bin/**/*
       | path relative-to (pwd --physical)
 
     let firstLine = open $bin.name --raw
-      | split row -r '\n'
+      | lines
       | first
 
     { name: $bin.name, target: $target, firstLine: $firstLine }

--- a/packages/nushell/brioche.lock
+++ b/packages/nushell/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/nushell/nushell.git": {
-      "0.112.2": "d80ee8c19e07a8058e50a30a4205d3e97068f585"
+      "0.113.0": "ed10ecae9864dba2a38dce6fcc51860fd334a0a8"
     }
   }
 }

--- a/packages/nushell/project.bri
+++ b/packages/nushell/project.bri
@@ -7,7 +7,7 @@ export { runNushell } from "./run_nushell.bri";
 
 export const project = {
   name: "nushell",
-  version: "0.112.2",
+  version: "0.113.0",
   repository: "https://github.com/nushell/nushell.git",
 };
 

--- a/packages/pnpm/find-pnpm-binstubs.nu
+++ b/packages/pnpm/find-pnpm-binstubs.nu
@@ -2,7 +2,7 @@ ls .bin/**/*
   | where type == file
   | each {|bin|
     let firstLine = open $bin.name --raw
-      | split row -r '\n'
+      | lines
       | first
 
     { name: $bin.name, firstLine: $firstLine }

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -79,13 +79,12 @@ export function liveUpdate(): NushellRunnable {
           | parse --regex '^version-(?<version>\\d+\\.\\d+\\.\\d+)$'
           | into record
       }
-      | where (($it | get -o version) | is-not-empty)
+      | where ($it.version? | is-not-empty)
       | sort-by --natural version
 
     let latestTag = $tags
       | last
-    let version = $latestTag
-      | get version
+    let version = $latestTag.version
 
     # Extract the release year
     let tagRef = http get $'https://api.github.com/repos/sqlite/sqlite/git/ref/tags/version-($version)'

--- a/packages/std/extra/live_update/scripts/live_update_from_forgejo_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_forgejo_releases.nu
@@ -7,7 +7,7 @@ let releases = http get $'($env.baseUrl)/api/v1/repos/($env.repoOwner)/($env.rep
       | into record
       | insert created_at $release.created_at
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($releases | is-empty) {
@@ -33,7 +33,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -41,7 +41,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 
@@ -50,7 +50,7 @@ if ($project | get extra?.versionUnderscore?) != null {
 }
 
 # Extract the release date (if needed by the project)
-if ($project | get extra?.releaseDate?) != null {
+if $project.extra?.releaseDate? != null {
   let $createdDate = $latestReleaseInfo
     | get created_at
     | into datetime

--- a/packages/std/extra/live_update/scripts/live_update_from_forgejo_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_forgejo_tags.nu
@@ -7,7 +7,7 @@ let tags = http get $'($env.baseUrl)/api/v1/repos/($env.repoOwner)/($env.repoNam
       | parse --regex $env.matchTag
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($tags | is-empty) {
@@ -15,12 +15,11 @@ if ($tags | is-empty) {
 }
 
 # Get the latest tag
-mut latestTag = $tags
+let latestTag = $tags
   | last
 
 # Get the version
-mut version = $latestTag
-  | get version
+mut version = $latestTag.version
 
 if $env.normalizeVersion == "true" {
   $version = $version
@@ -34,7 +33,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -42,7 +41,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 

--- a/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitea_releases.nu
@@ -7,7 +7,7 @@ let releases = http get $'($env.baseUrl)/api/v1/repos/($env.repoOwner)/($env.rep
       | into record
       | insert created_at $release.created_at
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($releases | is-empty) {
@@ -33,7 +33,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -41,7 +41,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 
@@ -50,7 +50,7 @@ if ($project | get extra?.versionUnderscore?) != null {
 }
 
 # Extract the release date (if needed by the project)
-if ($project | get extra?.releaseDate?) != null {
+if $project.extra?.releaseDate? != null {
   let $createdDate = $latestReleaseInfo
     | get created_at
     | into datetime

--- a/packages/std/extra/live_update/scripts/live_update_from_gitea_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitea_tags.nu
@@ -7,7 +7,7 @@ let tags = http get $'($env.baseUrl)/api/v1/repos/($env.repoOwner)/($env.repoNam
       | parse --regex $env.matchTag
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($tags | is-empty) {
@@ -15,12 +15,11 @@ if ($tags | is-empty) {
 }
 
 # Get the latest tag
-mut latestTag = $tags
+let latestTag = $tags
   | last
 
 # Get the version
-mut version = $latestTag
-  | get version
+mut version = $latestTag.version
 
 if $env.normalizeVersion == "true" {
   $version = $version
@@ -34,7 +33,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -42,7 +41,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 

--- a/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_releases.nu
@@ -30,7 +30,7 @@ let releases = http get --allow-errors --headers $gh_headers $'https://api.githu
       | into record
       | insert created_at $release.created_at
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($releases | is-empty) {
@@ -56,7 +56,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -64,7 +64,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 
@@ -72,7 +72,7 @@ if ($project | get extra?.versionUnderscore?) != null {
     | update extra.versionUnderscore $versionUnderscore
 }
 
-if ($project | get extra?.otherVersions?) != null {
+if $project.extra?.otherVersions? != null {
   # Ensure the newest version is in the list of other versions, then
   # update the metadata of each other version
   let otherVersions = $project.extra.otherVersions
@@ -92,7 +92,7 @@ if ($project | get extra?.otherVersions?) != null {
 }
 
 # Extract the release date (if needed by the project)
-if ($project | get extra?.releaseDate?) != null {
+if $project.extra?.releaseDate? != null {
   let $createdDate = $latestReleaseInfo
     | get created_at
     | into datetime

--- a/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_github_tags.nu
@@ -33,7 +33,7 @@ let tags = http get --allow-errors --headers $gh_headers $'https://api.github.co
       | parse --regex $env.matchTag
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($tags | is-empty) {
@@ -41,12 +41,11 @@ if ($tags | is-empty) {
 }
 
 # Get the latest tag
-mut latestTag = $tags
+let latestTag = $tags
   | last
 
 # Get the version
-mut version = $latestTag
-  | get version
+mut version = $latestTag.version
 
 if $env.normalizeVersion == "true" {
   $version = $version
@@ -60,7 +59,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -68,7 +67,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 
@@ -76,7 +75,7 @@ if ($project | get extra?.versionUnderscore?) != null {
     | update extra.versionUnderscore $versionUnderscore
 }
 
-if ($project | get extra?.otherVersions?) != null {
+if $project.extra?.otherVersions? != null {
   # Ensure the newest version is in the list of other versions, then
   # update the metadata of each other version
   let otherVersions = $project.extra.otherVersions

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_releases.nu
@@ -10,7 +10,7 @@ let releases = http get $'($env.baseUrl)/api/v4/projects/($projectId)/releases'
       | into record
       | insert created_at $release.created_at
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($releases | is-empty) {
@@ -36,7 +36,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -44,7 +44,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 
@@ -53,7 +53,7 @@ if ($project | get extra?.versionUnderscore?) != null {
 }
 
 # Extract the release date (if needed by the project)
-if ($project | get extra?.releaseDate?) != null {
+if $project.extra?.releaseDate? != null {
   let $createdDate = $latestReleaseInfo
     | get created_at
     | into datetime

--- a/packages/std/extra/live_update/scripts/live_update_from_gitlab_tags.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_gitlab_tags.nu
@@ -10,7 +10,7 @@ let tags = http get $'($env.baseUrl)/api/v4/projects/($projectId)/repository/tag
       | parse --regex $env.matchTag
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($tags | is-empty) {
@@ -18,12 +18,11 @@ if ($tags | is-empty) {
 }
 
 # Get the latest tag
-mut latestTag = $tags
+let latestTag = $tags
   | last
 
 # Get the version
-mut version = $latestTag
-  | get version
+mut version = $latestTag.version
 
 if $env.normalizeVersion == "true" {
   $version = $version
@@ -37,7 +36,7 @@ mut project = $env.project
 $project = $project
   | update version $version
 
-if ($project | get extra?.versionDash?) != null {
+if $project.extra?.versionDash? != null {
   let $versionDash = $version
     | str replace --all "." "-"
 
@@ -45,7 +44,7 @@ if ($project | get extra?.versionDash?) != null {
     | update extra.versionDash $versionDash
 }
 
-if ($project | get extra?.versionUnderscore?) != null {
+if $project.extra?.versionUnderscore? != null {
   let $versionUnderscore = $version
     | str replace --all "." "_"
 

--- a/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_go_modules.nu
@@ -46,7 +46,7 @@ let releases = http get --pool $'https://proxy.golang.org/($moduleName)/@v/list'
       | parse --regex $env.matchVersion
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($releases | is-empty) {

--- a/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_npm_packages.nu
@@ -1,11 +1,10 @@
 # Retrieve the latest release from npm registry
 let latestReleaseInfo = http get $'https://registry.npmjs.org/($env.packageName)/latest'
 
-let parsedVersion = $latestReleaseInfo
-  | get version
+let parsedVersion = $latestReleaseInfo.version
   | parse --regex $env.matchVersion
   | into record
-if (($parsedVersion | get -o version) | is-empty) {
+if ($parsedVersion.version? | is-empty) {
   error make { msg: $'Latest release does not match regex ($env.matchVersion)' }
 }
 

--- a/packages/std/extra/live_update/scripts/live_update_from_python_packages.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_python_packages.nu
@@ -1,11 +1,10 @@
 # Retrieve the latest release from PyPI registry
 let packageInfo = http get $'https://pypi.org/pypi/($env.packageName)/json'
 
-let parsedVersion = $packageInfo
-  | get info.version
+let parsedVersion = $packageInfo.info.version
   | parse --regex $env.matchVersion
   | into record
-if (($parsedVersion | get -o version) | is-empty) {
+if ($parsedVersion.version? | is-empty) {
   error make { msg: $'Latest release does not match regex ($env.matchVersion)' }
 }
 

--- a/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
+++ b/packages/std/extra/live_update/scripts/live_update_from_rust_crates.nu
@@ -8,7 +8,7 @@ let versions = http get $'https://crates.io/api/v1/crates/($env.crateName)'
       | parse --regex $env.matchVersion
       | into record
   }
-  | where (($it | get -o version) | is-not-empty)
+  | where ($it.version? | is-not-empty)
   | sort-by --natural version
 
 if ($versions | is-empty) {


### PR DESCRIPTION
- Bump `nushell` from `0.112.2` to `0.113.0`.
- Refactor the 14 `.nu` scripts in the repo to apply v0.113 idioms while keeping the common shape: cell-path optional access (`.field?`) instead of `get -o field`, `lines | first` instead of `split row -r '\n' | first`, and `let latestTag` to parallel `let latestReleaseInfo` in the release scripts.