### PR TITLE
feat(7zip): add package

### DIFF
--- a/packages/7zip/brioche.lock
+++ b/packages/7zip/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://7-zip.org/a/7z2601-src.tar.xz": {
+      "type": "sha256",
+      "value": "b2389e0e930b2f9a348cf0fe7d9870a46482a8ec044ee0bdf42e2136db31c3d6"
+    }
+  }
+}

--- a/packages/7zip/project.bri
+++ b/packages/7zip/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "7zip",
+  version: "26.01",
+  repository: "https://github.com/ip7z/7zip",
+  extra: {
+    majorVersion: "26",
+    minorVersion: "01",
+  },
+};
+
+// Ensure the major version number matches the version
+std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+// Ensure the minor version number matches the version
+std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+
+export const source = Brioche.download(
+  `https://7-zip.org/a/7z${project.extra.majorVersion}${project.extra.minorVersion}-src.tar.xz`,
+).unarchive("tar", "xz");
+
+export default function _7zip(): std.Recipe<std.Directory> {
+  return std.runBash`
+    cd CPP/7zip/Bundles/Alone2
+    make -j "$(nproc)" -f ../../cmpl_gcc.mak DISABLE_RAR_COMPRESS=1
+
+    # Manual installation
+    cp b/g/7zz "$BRIOCHE_OUTPUT/bin/7zz"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/7zz"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    7zz | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(_7zip)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `7-Zip (z) ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://api.github.com/repos/ip7z/7zip/releases/latest
+      | get tag_name
+
+    let parts = $version | split row '.'
+    let majorVersion = $parts | get 0
+    let minorVersion = $parts | get 1
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.majorVersion $majorVersion
+      | update extra.minorVersion $minorVersion
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `7zip`
- **Website / repository:** `https://github.com/ip7z/7zip`
- **Repology URL:** `https://repology.org/project/7zip/versions`
- **Short description:** `Command-line file archiver with high compression ratio, supporting 7z, zip, tar, gzip, xz, and many other formats.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.62s
Result: 2f6f4fa80023844922167eee730223eae57bfb419aaaf216bdab618bf8e6986d
Writing output to /tmp/7zip-test-out
Wrote output to /tmp/7zip-test-out

7-Zip (z) 26.01 (arm64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-04-27
 64-bit arm_v:8-A locale=C UTF8=- Threads:8 OPEN_MAX:4096

Usage: 7zz <command> [<switches>...] <archive_name> [<file_names>...] [@listfile]
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.40s
Running brioche-run
{
  "name": "7zip",
  "version": "26.01",
  "repository": "https://github.com/ip7z/7zip",
  "extra": {
    "majorVersion": "26",
    "minorVersion": "01"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.
