### PR TITLE
feat(p7zip): add package

### DIFF
--- a/packages/p7zip/brioche.lock
+++ b/packages/p7zip/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/p7zip-project/p7zip/archive/refs/tags/v17.06.tar.gz": {
+      "type": "sha256",
+      "value": "c35640020e8f044b425d9c18e1808ff9206dc7caf77c9720f57eb0849d714cd1"
+    }
+  }
+}

--- a/packages/p7zip/project.bri
+++ b/packages/p7zip/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+
+export const project = {
+  name: "p7zip",
+  version: "17.06",
+  repository: "https://github.com/p7zip-project/p7zip",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    source.insert("makefile.machine", source.get("makefile.linux_any_cpu")),
+  )
+  .pipe((source) =>
+    // Upstream forgot to bump MY_VERSION
+    std.runBash`
+      # Fail if upstream has fixed the version (so we can remove this workaround)
+      grep -q '#define MY_VERSION "17.05"' "$BRIOCHE_OUTPUT/C/7zVersion.h"
+
+      sed -i 's/"17.05"/"${project.version}"/g; s/"17.05 beta"/"${project.version} beta"/g' "$BRIOCHE_OUTPUT/C/7zVersion.h"
+    `
+      .outputScaffold(source)
+      .dependencies(std.toolchain)
+      .toDirectory(),
+  );
+
+export default function p7zip(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)" 7za
+
+    # Manual installation
+    cp bin/7za "$BRIOCHE_OUTPUT/bin/7za"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/7za"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    7za | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(p7zip)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `p7zip Version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^v(?<version>\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `p7zip`
- **Website / repository:** `https://github.com/p7zip-project/p7zip`
- **Repology URL:** `https://repology.org/project/p7zip/versions`
- **Short description:** Maintained Unix port of the 7-Zip file archiver, providing the `7za` standalone command-line tool.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 38392 (std/core/recipes/process.bri:240:14)
Process 38392 ran in 0.01s
Build finished, completed 1 job in 3.57s
Result: d0510269c96e30b7853c2826cf61907725133d95f1dfce2cd819992a5ea0abb5
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.18s
Running brioche-run
{
  "name": "p7zip",
  "version": "17.06",
  "repository": "https://github.com/p7zip-project/p7zip"
}
```

</p>
</details>

## Implementation notes / special instructions

None.