### PR TITLE
feat(pybind11): add package

### DIFF
--- a/packages/pybind11/brioche.lock
+++ b/packages/pybind11/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/pybind/pybind11.git": {
+      "v3.0.4": "d03662f0984f652b60e7ddce53d3868002275197"
+    }
+  }
+}

--- a/packages/pybind11/project.bri
+++ b/packages/pybind11/project.bri
@@ -1,0 +1,50 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "pybind11",
+  version: "3.0.4",
+  repository: "https://github.com/pybind/pybind11.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function pybind11(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      PYBIND11_TEST: "OFF",
+      PYBIND11_NOPYTHON: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "share/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion pybind11 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, pybind11)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pybind11`
- **Website / repository:** `https://github.com/pybind/pybind11`
- **Repology URL:** `https://repology.org/project/pybind11/versions`
- **Short description:** Seamless operability between C++11 and Python, providing a lightweight header-only library for creating Python bindings of existing C++ code.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 39277 (std/core/recipes/process.bri:240:14)
[39277] 3.0.4
Process 39277 ran in 0.11s
Build finished, completed 1 job in 1.43s
Result: c65457790b228504944e0f6c11c932019d196cd73ff5d692243b0718d2ca7dec
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 39382 (std/runtime_utils.bri:49:6)
Process 39382 ran in 0.01s
Build finished, completed 1 job in 2.78s
Running brioche-run
{
  "name": "pybind11",
  "version": "3.0.4",
  "repository": "https://github.com/pybind/pybind11.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.