### PR TITLE
feat(zchunk): add package

### DIFF
--- a/packages/zchunk/brioche.lock
+++ b/packages/zchunk/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/zchunk/zchunk.git": {
+      "1.5.3": "366cf22e725fc273abe0e082c707753cce76c453"
+    }
+  }
+}

--- a/packages/zchunk/project.bri
+++ b/packages/zchunk/project.bri
@@ -1,0 +1,68 @@
+import * as std from "std";
+import brotli from "brotli";
+import curl from "curl";
+import libpsl from "libpsl";
+import libssh2 from "libssh2";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import openssl from "openssl";
+
+export const project = {
+  name: "zchunk",
+  version: "1.5.3",
+  repository: "https://github.com/zchunk/zchunk",
+};
+
+const source = Brioche.gitCheckout({
+  repository: `${project.repository}.git`,
+  ref: project.version,
+});
+
+export default function zchunk(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [
+      std.toolchain,
+      ninja,
+      openssl,
+      curl,
+      brotli,
+      libpsl,
+      libssh2,
+    ],
+    set: {
+      docs: "false",
+      tests: "false",
+    },
+    runnable: "bin/zck",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    zck --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(zchunk)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `zchunk ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `zchunk`
- **Website / repository:** `https://github.com/zchunk/zchunk`
- **Repology URL:** `https://repology.org/project/zchunk/versions`
- **Short description:** `A file format designed for highly efficient deltas while maintaining good compression`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 49022 (std/core/recipes/process.bri:240:14)
[49022] zchunk 1.5.3
[49022] Copyright (c) 2021 Jonathan Dieter
Process 49022 ran in 0.01s
Build finished, completed 1 job in 4.33s
Result: 88729f40daa143b6926665aaf28d3e7f28ac41d47d2174fb1075c9a2bfa2281c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 49218 (std/runtime_utils.bri:49:6)
Process 49218 ran in 0.01s
Build finished, completed 1 job in 3.03s
Running brioche-run
{
  "name": "zchunk",
  "version": "1.5.3",
  "repository": "https://github.com/zchunk/zchunk"
}
```

</p>
</details>

## Implementation notes / special instructions

None.