### PR TITLE
feat(bzip2): add package

### DIFF
--- a/packages/bzip2/brioche.lock
+++ b/packages/bzip2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz": {
+      "type": "sha256",
+      "value": "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+    }
+  }
+}

--- a/packages/bzip2/project.bri
+++ b/packages/bzip2/project.bri
@@ -1,0 +1,80 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "bzip2",
+  version: "1.0.8",
+};
+
+const source = Brioche.download(
+  `https://sourceware.org/pub/bzip2/bzip2-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Drop the absolute $(PREFIX) prefix from install symlinks so they stay
+    // relative.
+    std.runBash`
+      sed -i 's@\\(ln -s -f \\)$(PREFIX)/bin/@\\1@' "$BRIOCHE_OUTPUT/Makefile"
+    `
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function bzip2(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -f Makefile-libbz2_so
+    make clean
+
+    make -j "$(nproc)"
+    make install PREFIX="$BRIOCHE_OUTPUT"
+
+    cp -a libbz2.so.* "$BRIOCHE_OUTPUT/lib"
+    ln -s libbz2.so.${project.version} "$BRIOCHE_OUTPUT/lib/libbz2.so"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/bzip2"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    bzip2 --help 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(bzip2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceware.org/pub/bzip2/
+      | lines
+      | where ($it | str contains 'bzip2-') and ($it | str contains '.tar.gz') and (not ($it | str contains 'bzip2-latest'))
+      | parse --regex '<a href="bzip2-(?<version>\\d+\\.\\d+(?:\\.\\d+)?)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `bzip2`
- **Website / repository:** `https://sourceware.org/bzip2/`
- **Repology URL:** `https://repology.org/project/bzip2/versions`
- **Short description:** Freely available, patent-free, high-quality block-sorting data compressor (bzip2 / libbz2).

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 51822 (std/core/recipes/process.bri:240:14)
[51822] bzip2, a block-sorting file compressor.  Version 1.0.8, 13-Jul-2019.
[51822]
[51822]    usage: bzip2 [flags and input files in any order]
[51822]
[51822]    -h --help           print this message
[51822]    -d --decompress     force decompression
[51822]    -z --compress       force compression
[51822]    -k --keep           keep (don't delete) input files
[51822]    -f --force          overwrite existing output files
[51822]    -t --test           test compressed file integrity
[51822]    -c --stdout         output to standard out
[51822]    -q --quiet          suppress noncritical error messages
[51822]    -v --verbose        be verbose (a 2nd -v gives more)
[51822]    -L --license        display software version & license
[51822]    -V --version        display software version & license
[51822]    -s --small          use less memory (at most 2500k)
[51822]    -1 .. -9            set block size to 100k .. 900k
[51822]    --fast              alias for -1
[51822]    --best              alias for -9
[51822]
[51822]    If invoked as `bzip2', default action is to compress.
[51822]               as `bunzip2',  default action is to decompress.
[51822]               as `bzcat', default action is to decompress to stdout.
[51822]
[51822]    If no file names are given, bzip2 compresses or decompresses
[51822]    from standard input to standard output.  You can combine
[51822]    short flags, so `-v -4' means the same as -v4 or -4v, &c.
Process 51822 ran in 0.01s
Build finished, completed 1 job in 1.27s
Result: 5e1ad4c6055d2a638e84db1dc54163822d6cf56458ea3131f8df4f2efa8b0fef
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.37s
Running brioche-run
{
  "name": "bzip2",
  "version": "1.0.8"
}
```

</p>
</details>

## Implementation notes / special instructions

None.