### PR TITLE
feat(librevenge): add package

### DIFF
--- a/packages/librevenge/brioche.lock
+++ b/packages/librevenge/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/libwpd/librevenge/librevenge-0.0.5/librevenge-0.0.5.tar.xz": {
+      "type": "sha256",
+      "value": "106d0c44bb6408b1348b9e0465666fa83b816177665a22cd017e886c1aaeeb34"
+    }
+  }
+}

--- a/packages/librevenge/project.bri
+++ b/packages/librevenge/project.bri
@@ -1,0 +1,71 @@
+import boost from "boost";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "librevenge",
+  version: "0.0.5",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/libwpd/librevenge/librevenge-${project.version}/librevenge-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function librevenge(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-werror \\
+      --disable-static \\
+      --without-docs \\
+      --disable-tests
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, boost)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion librevenge-0.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, librevenge)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/libwpd/files/librevenge/
+      | lines
+      | where ($it | str contains 'href="/projects/libwpd/files/librevenge/librevenge-')
+      | parse --regex '<a href="/projects/libwpd/files/librevenge/librevenge-(?<version>\\d+\\.\\d+\\.\\d+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `librevenge`
- **Website / repository:** `https://sourceforge.net/p/libwpd/wiki/librevenge/`
- **Repology URL:** `https://repology.org/project/librevenge/versions`
- **Short description:** `Base library for writing document import filters (text, vector graphics, spreadsheets, presentations).`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 69034 (std/core/recipes/process.bri:240:14)
[69034] 0.0.5
Process 69034 ran in 0.01s
Build finished, completed 1 job in 1.33s
Result: 4d095ff285ca7026e515b8aba1eb9bfe387975cb3eebb38778e4c35316e2d735
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 69143 (std/runtime_utils.bri:49:6)
Process 69143 ran in 0.01s
Build finished, completed 1 job in 3.33s
Running brioche-run
{
  "name": "librevenge",
  "version": "0.0.5"
}
```

</p>
</details>

## Implementation notes / special instructions

None.