### PR TITLE
feat(openldap): add package

### DIFF
--- a/packages/openldap/brioche.lock
+++ b/packages/openldap/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.13.tgz": {
+      "type": "sha256",
+      "value": "d693b49517a42efb85a1a364a310aed16a53d428d1b46c0d31ef3fba78fcb656"
+    }
+  }
+}

--- a/packages/openldap/project.bri
+++ b/packages/openldap/project.bri
@@ -1,0 +1,87 @@
+import * as std from "std";
+import cyrusSasl from "cyrus_sasl";
+import gnutls from "gnutls";
+import libiconv from "libiconv";
+import libidn2 from "libidn2";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import nettle from "nettle";
+import p11Kit from "p11_kit";
+
+export const project = {
+  name: "openldap",
+  version: "2.6.13",
+  repository: "https://github.com/openldap/openldap",
+  extra: {
+    versionUnderscore: "2_6_13",
+  },
+};
+
+const source = Brioche.download(
+  `https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${project.version}.tgz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function openldap(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-tls=gnutls \\
+      --enable-static \\
+      --enable-shared
+    make depend
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      cyrusSasl,
+      gnutls,
+      libiconv,
+      libidn2,
+      libtasn1,
+      libunistring,
+      nettle,
+      p11Kit,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ldapsearch"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ldapsearch -VV 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(openldap)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ldapsearch ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({
+    project,
+    matchTag: /^OPENLDAP_REL_ENG_(?<version>\d+_\d+_\d+)$/,
+    normalizeVersion: true,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `openldap`
- **Website / repository:** `https://www.openldap.org/` (mirror: https://github.com/openldap/openldap)
- **Repology URL:** `https://repology.org/project/openldap/versions`
- **Short description:** `Open-source implementation of the Lightweight Directory Access Protocol (LDAP), providing client libraries, command-line tools, and the slapd directory server.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 177155 (std/core/recipes/process.bri:240:14)
[177155] ldapsearch: @(#) $OpenLDAP: ldapsearch 2.6.13 (May 28 2026 15:27:42) $
Process 177155 ran in 0.01s
Build finished, completed 1 job in 2.31s
Result: 5084d448b97b86ea115984b0a5aea9cead8a4f01c7542006fad4e604bbabc80a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.15s
Running brioche-run
{
  "name": "openldap",
  "version": "2.6.13",
  "repository": "https://github.com/openldap/openldap",
  "extra": {
    "versionUnderscore": "2_6_13"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.