### PR TITLE
feat(go_mockery): support versions 2 and 3

### DIFF
--- a/packages/7zip/project.bri
+++ b/packages/7zip/project.bri
@@ -11,10 +11,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 export const source = Brioche.download(
   `https://7-zip.org/a/7z${project.extra.majorVersion}${project.extra.minorVersion}-src.tar.xz`,

--- a/packages/dart/project.bri
+++ b/packages/dart/project.bri
@@ -18,7 +18,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((minorVersion) =>
     project.version.startsWith(`${minorVersion}.`),
   ),
-  "Dart package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/glib/project.bri
+++ b/packages/glib/project.bri
@@ -18,10 +18,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/glib/${project.extra.majorVersion}.${project.extra.minorVersion}/glib-${project.version}.tar.xz`,

--- a/packages/gnutls/project.bri
+++ b/packages/gnutls/project.bri
@@ -16,10 +16,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://www.gnupg.org/ftp/gcrypt/gnutls/v${project.extra.majorVersion}.${project.extra.minorVersion}/gnutls-${project.version}.tar.xz`,

--- a/packages/go/project.bri
+++ b/packages/go/project.bri
@@ -17,7 +17,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((minorVersion) =>
     project.version.startsWith(`${minorVersion}.`),
   ),
-  "Go package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/go_mockery/brioche.lock
+++ b/packages/go_mockery/brioche.lock
@@ -2,6 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/vektra/mockery.git": {
+      "v2.53.6": "7f76fe11cc119c71e81e196eedb4265029eea4c4",
       "v3.7.0": "61b1a4512604843293e2b3201c158029d052a73d"
     }
   }

--- a/packages/go_mockery/project.bri
+++ b/packages/go_mockery/project.bri
@@ -5,43 +5,115 @@ export const project = {
   name: "go_mockery",
   version: "3.7.0",
   repository: "https://github.com/vektra/mockery.git",
+  extra: {
+    otherVersions: {
+      "3": "3.7.0",
+      "2": "2.53.6",
+    },
+  },
 };
 
-const source = Brioche.gitCheckout({
-  repository: project.repository,
-  ref: `v${project.version}`,
-});
+std.assert(
+  Object.keys(project.extra.otherVersions).some((version) =>
+    project.version.startsWith(`${version}.`),
+  ),
+  "Package version not found in extra.otherVersions",
+);
 
-export default function goMockery(): std.Recipe<std.Directory> {
+/**
+ * The go-mockery major version.
+ */
+export type MockeryVersion = keyof typeof project.extra.otherVersions;
+
+/**
+ * Get the latest major version of go-mockery.
+ *
+ * @returns The latest major version of go-mockery.
+ */
+export function getLatestVersion(): MockeryVersion {
+  const versions = Object.keys(project.extra.otherVersions);
+  versions.sort((a, b) => parseInt(b) - parseInt(a));
+
+  return versions[0] as MockeryVersion;
+}
+
+const sources: { [version: string]: std.Recipe<std.Directory> } = {
+  "3": Brioche.gitCheckout({
+    repository: project.repository,
+    ref: `v${project.extra.otherVersions["3"]}`,
+  }),
+  "2": Brioche.gitCheckout({
+    repository: project.repository,
+    ref: `v${project.extra.otherVersions["2"]}`,
+  }),
+} satisfies Record<MockeryVersion, std.Recipe<std.Directory>>;
+
+/**
+ * Extra options for go-mockery.
+ *
+ * @param version - The major version of go-mockery to use. Defaults to the
+ *   latest stable major release.
+ */
+interface MockeryOptions {
+  version?: MockeryVersion;
+}
+
+export default function goMockery(
+  options: MockeryOptions = {},
+): std.Recipe<std.Directory> {
+  const { version = getLatestVersion() } = options;
+
+  const source = sources[version];
+  std.assert(
+    source != null,
+    `Expected go-mockery version ${JSON.stringify(
+      version,
+    )} to be one of ${JSON.stringify(Object.keys(sources))}`,
+  );
+
+  const semVerPaths = {
+    "3": "github.com/vektra/mockery/v3/internal/logging.SemVer",
+    "2": "github.com/vektra/mockery/v2/pkg/logging.SemVer",
+  } satisfies Record<MockeryVersion, string>;
+  const fullVersion = project.extra.otherVersions[version];
+
   return goBuild({
     source,
     buildParams: {
       generate: true,
-      ldflags: [
-        "-s",
-        "-w",
-        "-X",
-        `github.com/vektra/mockery/v3/internal/logging.SemVer=${project.version}`,
-      ],
+      ldflags: ["-s", "-w", "-X", `${semVerPaths[version]}=${fullVersion}`],
     },
     runnable: "bin/mockery",
   });
 }
 
-export async function test(): Promise<std.Recipe<std.File>> {
-  const script = std.runBash`
-    mockery version | tee "$BRIOCHE_OUTPUT"
-  `
-    .dependencies(goMockery)
-    .toFile();
+export function test(): std.Recipe<std.Directory> {
+  const versionCommands = {
+    "3": "version",
+    "2": "--version",
+  } satisfies Record<MockeryVersion, string>;
 
-  const result = (await script.read()).trim();
+  const mockeryVersions = Object.keys(
+    project.extra.otherVersions,
+  ) as MockeryVersion[];
 
-  // Check that the result contains the expected version
-  const expected = project.version;
-  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+  const tests = mockeryVersions.map(async (version) => {
+    const script = std.runBash`
+      mockery ${versionCommands[version]} | tee "$BRIOCHE_OUTPUT"
+    `
+      .dependencies(goMockery({ version }))
+      .toFile();
 
-  return script;
+    const result = (await script.read()).trim();
+
+    // Check that the result contains the expected version
+    const expected = project.extra.otherVersions[version];
+    std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+    return std.directory().insert(version, script);
+  });
+
+  return std.merge(...tests);
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {

--- a/packages/gobject_introspection/project.bri
+++ b/packages/gobject_introspection/project.bri
@@ -32,10 +32,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/gobject-introspection/${project.extra.majorVersion}.${project.extra.minorVersion}/gobject-introspection-${project.version}.tar.xz`,

--- a/packages/gsettings_desktop_schemas/project.bri
+++ b/packages/gsettings_desktop_schemas/project.bri
@@ -17,8 +17,10 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/gsettings-desktop-schemas/${project.extra.majorVersion}/gsettings-desktop-schemas-${project.version}.tar.xz`,

--- a/packages/imagemagick/project.bri
+++ b/packages/imagemagick/project.bri
@@ -30,8 +30,10 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
 
 const source = Brioche.download(
   `https://imagemagick.org/archive/releases/ImageMagick-${project.version}.tar.xz`,

--- a/packages/krb5/project.bri
+++ b/packages/krb5/project.bri
@@ -10,10 +10,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://kerberos.org/dist/krb5/${project.extra.majorVersion}.${project.extra.minorVersion}/krb5-${project.version}.tar.gz`,

--- a/packages/libgsf/project.bri
+++ b/packages/libgsf/project.bri
@@ -17,10 +17,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/libgsf/${project.extra.majorVersion}.${project.extra.minorVersion}/libgsf-${project.version}.tar.xz`,

--- a/packages/libssh/project.bri
+++ b/packages/libssh/project.bri
@@ -12,10 +12,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://www.libssh.org/files/${project.extra.majorVersion}.${project.extra.minorVersion}/libssh-${project.version}.tar.xz`,

--- a/packages/libxml2/project.bri
+++ b/packages/libxml2/project.bri
@@ -13,10 +13,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/libxml2/${project.extra.majorVersion}.${project.extra.minorVersion}/libxml2-${project.version}.tar.xz`,

--- a/packages/libxslt/project.bri
+++ b/packages/libxslt/project.bri
@@ -13,10 +13,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.gnome.org/sources/libxslt/${project.extra.majorVersion}.${project.extra.minorVersion}/libxslt-${project.version}.tar.xz`,

--- a/packages/linux/project.bri
+++ b/packages/linux/project.bri
@@ -12,8 +12,10 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
 
 /**
  * The Linux kernel source tree. Cleaned by running `make distclean`

--- a/packages/mbedtls/project.bri
+++ b/packages/mbedtls/project.bri
@@ -18,7 +18,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((version) =>
     project.version.startsWith(`${version}.`),
   ),
-  "MbedTLS package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/nodejs/project.bri
+++ b/packages/nodejs/project.bri
@@ -20,7 +20,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((version) =>
     project.version.startsWith(`${version}.`),
   ),
-  "Node.js package version not found in extra.minorVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/openmpi/project.bri
+++ b/packages/openmpi/project.bri
@@ -19,10 +19,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://download.open-mpi.org/release/open-mpi/v${project.extra.majorVersion}.${project.extra.minorVersion}/openmpi-${project.version}.tar.gz`,

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -17,7 +17,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((version) =>
     project.version.startsWith(`${version}.`),
   ),
-  "OpenSSL package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/perl/project.bri
+++ b/packages/perl/project.bri
@@ -9,8 +9,10 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
 
 const source = Brioche.download(
   `https://www.cpan.org/src/${project.extra.majorVersion}.0/perl-${project.version}.tar.gz`,

--- a/packages/pnpm/project.bri
+++ b/packages/pnpm/project.bri
@@ -19,7 +19,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((version) =>
     project.version.startsWith(`${version}.`),
   ),
-  "pnpm package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -21,7 +21,7 @@ std.assert(
   Object.keys(project.extra.otherVersions).some((minorVersion) =>
     project.version.startsWith(`${minorVersion}.`),
   ),
-  "Python package version not found in extra.otherVersions",
+  "Package version not found in extra.otherVersions",
 );
 
 /**

--- a/packages/sqlite/project.bri
+++ b/packages/sqlite/project.bri
@@ -12,7 +12,6 @@ export const project = {
   },
 };
 
-// Ensure the version number matches the encoded version used for the download
 std.assert(
   encodeVersionNumber(project.version) === project.extra.filenameEncodedVersion,
   `sqlite version number ${encodeVersionNumber(

--- a/packages/unzip/project.bri
+++ b/packages/unzip/project.bri
@@ -10,10 +10,14 @@ export const project = {
   },
 };
 
-// Ensure the major version number matches the version
-std.assert(project.version.startsWith(`${project.extra.majorVersion}.`));
-// Ensure the minor version number matches the version
-std.assert(project.version.split(".").at(1) === project.extra.minorVersion);
+std.assert(
+  project.version.startsWith(`${project.extra.majorVersion}.`),
+  "Package version does not match extra.majorVersion",
+);
+std.assert(
+  project.version.split(".").at(1) === project.extra.minorVersion,
+  "Package version does not match extra.minorVersion",
+);
 
 const source = Brioche.download(
   `https://sourceforge.net/projects/infozip/files/UnZip%20${project.extra.majorVersion}.x%20%28latest%29/UnZip%20${project.version}/unzip${project.extra.majorVersion}${project.extra.minorVersion}.tar.gz/download`,


### PR DESCRIPTION
Resolves #590.

Adds support for building both maintained major versions of go-mockery (v3 and v2).

Verified with `brioche build ^test` (both v3 `3.7.0` and v2 `2.53.6`) and `brioche run ^liveUpdate`.

A second commit uniformizes the version-matching `std.assert` checks across the repo to a message-based assert with no comment and no project name, and fixes a latent message typo in `nodejs` (`extra.minorVersions` to `extra.otherVersions`).