### PR TITLE
feat(libsolv): add package

### DIFF
--- a/packages/libsolv/brioche.lock
+++ b/packages/libsolv/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/openSUSE/libsolv": {
+      "0.7.39": "2f58c6f86edd978d6bdbd87dce9c85388e9b9dcc"
+    }
+  }
+}

--- a/packages/libsolv/project.bri
+++ b/packages/libsolv/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import rpm from "rpm";
+import zchunk from "zchunk";
+
+export const project = {
+  name: "libsolv",
+  version: "0.7.39",
+  repository: "https://github.com/openSUSE/libsolv",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libsolv(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, rpm, zchunk],
+    set: {
+      ENABLE_COMPLEX_DEPS: "ON",
+      ENABLE_CONDA: "ON",
+      ENABLE_LZMA_COMPRESSION: "ON",
+      ENABLE_BZIP2_COMPRESSION: "ON",
+      ENABLE_ZSTD_COMPRESSION: "ON",
+      ENABLE_ZCHUNK_COMPRESSION: "ON",
+      WITH_SYSTEM_ZCHUNK: "ON",
+      ENABLE_COMPS: "ON",
+      ENABLE_PUBKEY: "ON",
+      ENABLE_RPMDB: "ON",
+      ENABLE_RPMDB_BYRPMHEADER: "ON",
+      ENABLE_RPMMD: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libsolv | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libsolv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libsolv`
- **Website / repository:** `https://github.com/openSUSE/libsolv`
- **Repology URL:** `https://repology.org/project/libsolv/versions`
- **Short description:** `Library for solving package dependencies using a SAT solver, used by package managers like zypper, dnf, and micromamba.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.95s
Result: 36d9878ee53824045edb02a8b9872f7c5d9cb510d5ec0666d740b6f20585b03d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.65s
Running brioche-run
{
  "name": "libsolv",
  "version": "0.7.39",
  "repository": "https://github.com/openSUSE/libsolv"
}
```

</p>
</details>

## Implementation notes / special instructions

None.