### PR TITLE
feat(luamake): add package

### DIFF
--- a/packages/luamake/brioche.lock
+++ b/packages/luamake/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/actboy168/luamake": {
+      "v1.7": "66dffad0f8cd08affddeffc89ca5fdf2b6e92ad1"
+    }
+  }
+}

--- a/packages/luamake/project.bri
+++ b/packages/luamake/project.bri
@@ -1,0 +1,66 @@
+import * as std from "std";
+import ninja from "ninja";
+
+export const project = {
+  name: "luamake",
+  version: "1.7",
+  repository: "https://github.com/actboy168/luamake",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+  options: {
+    submodules: true,
+  },
+});
+
+export default function luamake(): std.Recipe<std.Directory> {
+  // Compile the bootstrap interpreter, which gets copied to ./luamake.
+  const binary = std.runBash`
+    sh ./compile/build.sh luamake
+    cp luamake "$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, ninja)
+    .toFile();
+
+  // At runtime the binary loads main.lua and scripts/ from its own directory,
+  // so keep all three together under libexec.
+  return std
+    .directory({
+      "libexec/luamake": std.directory({
+        luamake: binary,
+        "main.lua": source.get("main.lua"),
+        scripts: source.get("scripts"),
+      }),
+    })
+    .pipe((recipe) =>
+      std.addRunnable(recipe, "bin/luamake", {
+        command: { relativePath: "libexec/luamake/luamake" },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    luamake version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(luamake)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `luamake`
- **Website / repository:** `https://github.com/actboy168/luamake`
- **Repology URL:** `https://repology.org/project/luamake/versions`
- **Short description:** `A cross-platform build tool that uses Lua scripts (make.lua) to drive Ninja, used by projects like lua-language-server.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
version: 1.7
--------------------
hostos: linux
hostshell: sh
compiler: gcc
os: linux
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "luamake",
  "version": "1.7",
  "repository": "https://github.com/actboy168/luamake"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
