### PR TITLE
fix(std): make includearchdir paths relative in pkg-config files

### DIFF
--- a/packages/std/extra/pkg_config_make_paths_relative.bri
+++ b/packages/std/extra/pkg_config_make_paths_relative.bri
@@ -5,11 +5,12 @@ export const PKG_CONFIG_MAKE_PATHS_RELATIVE_SCRIPT = std.indoc`
   make_pkg_config_paths_relative () {
     local -r file="$1"
 
-    # Update prefix, exec_prefix, libdir and includedir variables
+    # Update prefix, exec_prefix, libdir and the include directory variables
     sed -i 's|^prefix[[:space:]]*=.*|prefix=\${pcfiledir}/../..|' "$file"
     sed -i 's|^exec_prefix[[:space:]]*=.*|exec_prefix=\${prefix}|' "$file"
     sed -i 's|^libdir[[:space:]]*=.*|libdir=\${prefix}/lib|' "$file"
     sed -i 's|^includedir[[:space:]]*=.*/include\\([^"]*\\)"\\?|includedir=\${prefix}/include\\1|' "$file"
+    sed -i 's|^includearchdir[[:space:]]*=.*/include\\([^"]*\\)"\\?|includearchdir=\${prefix}/include\\1|' "$file"
 
     # Find and replace common patterns in Libs and Cflags variables
     sed -i -e "/^Libs:/ s|-L/[^[:space:]]*/lib|-L\\\${libdir}|g" "$file"


### PR DESCRIPTION
This PR makes the pkg-config helper also rewrite the `includearchdir` variable, not just `includedir`. `includearchdir` is the directory for architecture-specific headers.

Before, only `includedir` was made relative. Some packages (such as ImageMagick) also set `includearchdir`, which stayed as an absolute path. When a CMake project consumed that package, CMake checked the path, did not find it, and failed at the generate step.

Locally this came up while building a new package that depends on ImageMagick through pkg-config: the build failed because `MagickWand.pc` carried an absolute `includearchdir`. With this change the path is made relative and the build works without any per-package workaround.