### PR TITLE
feat(lua_language_server): add package

### DIFF
--- a/packages/lua_language_server/brioche.lock
+++ b/packages/lua_language_server/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/LuaLS/lua-language-server": {
+      "3.18.2": "b5e57c36a9a27b89eb283861fb8946fa787e37d8"
+    }
+  }
+}

--- a/packages/lua_language_server/project.bri
+++ b/packages/lua_language_server/project.bri
@@ -1,0 +1,93 @@
+import * as std from "std";
+import luamake from "luamake";
+import ninja from "ninja";
+
+export const project = {
+  name: "lua_language_server",
+  version: "3.18.2",
+  repository: "https://github.com/LuaLS/lua-language-server",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+  options: {
+    submodules: true,
+  },
+});
+
+export default function luaLanguageServer(): std.Recipe<std.Directory> {
+  // Build the language server binary with the external luamake.
+  const binary = std.runBash`
+    luamake rebuild -notest
+    cp bin/lua-language-server "$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(luamake, ninja, std.toolchain)
+    .toFile();
+
+  // Assemble the install tree from the binary and the Lua scripts and data
+  // shipped in the source.
+  return (
+    std
+      .directory({
+        "libexec/lua-language-server": std.directory({
+          "bin/lua-language-server": binary,
+          "bin/main.lua": source.get("make/bootstrap.lua"),
+          "main.lua": source.get("main.lua"),
+          "debugger.lua": source.get("debugger.lua"),
+          "changelog.md": source.get("changelog.md"),
+          locale: source.get("locale"),
+          meta: source.get("meta"),
+          script: source.get("script"),
+        }),
+      })
+      // Wrap to redirect the log and meta output into the user cache.
+      .pipe((recipe) =>
+        std.addRunnable(recipe, "bin/lua-language-server", {
+          command: std.tools().get("bin/bash"),
+          args: [
+            "-euo",
+            "pipefail",
+            "-c",
+            [
+              'exec "',
+              {
+                relativePath:
+                  "libexec/lua-language-server/bin/lua-language-server",
+              },
+              '" -E "',
+              { relativePath: "libexec/lua-language-server/main.lua" },
+              '" --logpath="${XDG_CACHE_HOME:-$HOME/.cache}/lua-language-server/log"',
+              ' --metapath="${XDG_CACHE_HOME:-$HOME/.cache}/lua-language-server/meta"',
+              ' "$@"',
+            ],
+            "lua-language-server",
+          ],
+        }),
+      )
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    lua-language-server --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(luaLanguageServer)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lua_language_server`
- **Website / repository:** `https://github.com/LuaLS/lua-language-server`
- **Repology URL:** `https://repology.org/project/lua-language-server/versions`
- **Short description:** `A language server providing Lua language support: completion, diagnostics, type checking, and more`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 269778 in 1.24s
Launched process 269778 (std/core/recipes/process.bri:240:14)
[269778] 3.18.2-dev
Process 269778 ran in 0.07s
Build finished, completed 1 job in 4.78s
Result: 0d5a95b423fc22a204b0fdfd08bdfd861a857f06e450c85c72e0b68a5c867988
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.67s
Running brioche-run
{
  "name": "lua_language_server",
  "version": "3.18.2",
  "repository": "https://github.com/LuaLS/lua-language-server"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
