### PR TITLE
feat(libre): add package

### DIFF
--- a/packages/libre/brioche.lock
+++ b/packages/libre/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/baresip/re": {
+      "v4.8.1": "89aed31f37449da32004ba608e5d1aa483b8bb21"
+    }
+  }
+}

--- a/packages/libre/project.bri
+++ b/packages/libre/project.bri
@@ -1,0 +1,48 @@
+import * as std from "std";
+import openssl from "openssl";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libre",
+  version: "4.8.1",
+  repository: "https://github.com/baresip/re",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libre(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, openssl],
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libre | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libre)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libre`
- **Website / repository:** `https://github.com/baresip/re`
- **Repology URL:** `https://repology.org/project/libre/versions`
- **Short description:** `Generic library for real-time communications with async IO support and a complete SIP stack`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.80s
Result: e65c62af1dd800831ae8ee00b273e3f4373bc82b9ef004da0e54ddfc44f2d0de
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 5.14s
Running brioche-run
{
  "name": "libre",
  "version": "4.8.1",
  "repository": "https://github.com/baresip/re"
}
```

</p>
</details>

## Implementation notes / special instructions

None.