### PR TITLE
feat(cargo_pgrx): add package

### DIFF
--- a/packages/cargo_pgrx/brioche.lock
+++ b/packages/cargo_pgrx/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-pgrx/0.18.1/download": {
+      "type": "sha256",
+      "value": "aa05ede73d521cac20519f85ee9ac94894148817a5757de8088ed4c91d32d218"
+    }
+  }
+}

--- a/packages/cargo_pgrx/project.bri
+++ b/packages/cargo_pgrx/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import rust, { cargoBuild } from "rust";
+import openssl from "openssl";
+
+export const project = {
+  name: "cargo_pgrx",
+  version: "0.18.1",
+  extra: {
+    crateName: "cargo-pgrx",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoPgrx(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [openssl],
+    runnable: "bin/cargo-pgrx",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cargo pgrx --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rust, cargoPgrx)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cargo-pgrx ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cargo_pgrx`
- **Website / repository:** `https://github.com/pgcentralfoundation/pgrx`
- **Repology URL:** `https://repology.org/project/cargo-pgrx/versions`
- **Short description:** `Cargo subcommand for 'pgrx' to make Postgres extension development easy`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
cargo-pgrx 0.18.1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "cargo_pgrx",
  "version": "0.18.1",
  "extra": {
    "crateName": "cargo-pgrx"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.
