### PR TITLE
feat(cweb): add package

### DIFF
--- a/packages/cweb/brioche.lock
+++ b/packages/cweb/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/ascherer/cweb/archive/refs/tags/cweb-4.12.2.tar.gz": {
+      "type": "sha256",
+      "value": "519ac1c03610eea18956ed62d2996dc5a629f0c3af91f38cf4621d5deab749fd"
+    }
+  }
+}

--- a/packages/cweb/project.bri
+++ b/packages/cweb/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+
+export const project = {
+  name: "cweb",
+  version: "4.12.2",
+  repository: "https://github.com/ascherer/cweb",
+};
+
+const source = Brioche.download(
+  `https://github.com/ascherer/cweb/archive/refs/tags/cweb-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cweb(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make all \\
+      CC=gcc \\
+      CWEBINPUTS="$BRIOCHE_OUTPUT/lib/cweb"
+
+    # Manual installation
+    cp ctangle cweave "$BRIOCHE_OUTPUT/bin/"
+    cp c++lib.w iso_types.w "$BRIOCHE_OUTPUT/lib/cweb/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+        lib: std.directory({
+          cweb: std.directory(),
+        }),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ctangle"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "test.w": std.file(std.indoc`
+      @* Test.
+      @c
+      int main(void) { return 0; }
+    `),
+  });
+
+  const script = std.runBash`
+    ctangle test.w | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(cweb)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `(Version ${project.version})`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^cweb-(?<version>\d+\.\d+(?:\.\d+)?)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cweb`
- **Website / repository:** `https://github.com/ascherer/cweb`
- **Repology URL:** `https://repology.org/project/cweb/versions`
- **Short description:** `Literate programming system that lets C, C++, and Java sources and their TeX documentation be written together (Knuth/Levy CWEB).`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
[288599] This is CTANGLE (Version 4.12.2)
[288599] *1
[288599] Writing the output file (test.c):
[288599] Done.
[288599] (No errors were found.)
Build finished, completed 2 jobs in 2.67s
Result: fd342a006b046bdffe033d6b6216ac5a18536e07338d89a6d45a23f14e38215f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.64s
Running brioche-run
{
  "name": "cweb",
  "version": "4.12.2",
  "repository": "https://github.com/ascherer/cweb"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
