### PR TITLE
feat(flex): add package

### DIFF
--- a/packages/flex/brioche.lock
+++ b/packages/flex/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz": {
+      "type": "sha256",
+      "value": "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"
+    }
+  }
+}

--- a/packages/flex/project.bri
+++ b/packages/flex/project.bri
@@ -1,0 +1,85 @@
+import * as std from "std";
+
+export const project = {
+  name: "flex",
+  version: "2.6.4",
+  repository: "https://github.com/westes/flex",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/flex-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function flex(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      // flex pipes generated scanners through m4 at runtime, so bundle m4 and
+      // point flex at it via the M4 env var the wrappers set.
+      recipe.insert(
+        "libexec/m4",
+        std.castToDirectory(std.toolchain().get("bin")).get("m4"),
+      ),
+    )
+    .pipe((recipe) =>
+      // Move the real binary aside and drop the flex++ symlink, since wrappers
+      // can't preserve the argv[0]-based C++ detection bare flex++ relies on.
+      recipe
+        .insert("libexec/flex", recipe.get("bin/flex"))
+        .remove("bin/flex")
+        .remove("bin/flex++"),
+    )
+    .pipe((recipe) =>
+      std.addRunnable(recipe, "bin/flex", {
+        command: { relativePath: "libexec/flex" },
+        env: {
+          M4: { fallback: { relativePath: "libexec/m4" } },
+        },
+      }),
+    )
+    .pipe((recipe) =>
+      // flex++ is just flex with C++ scanner output, so pass --c++ explicitly.
+      std.addRunnable(recipe, "bin/flex++", {
+        command: { relativePath: "libexec/flex" },
+        args: ["--c++"],
+        env: {
+          M4: { fallback: { relativePath: "libexec/m4" } },
+        },
+      }),
+    )
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/flex"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    flex --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(flex())
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `flex ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `flex`
- **Website / repository:** `https://github.com/westes/flex`
- **Repology URL:** `https://repology.org/project/flex/versions`
- **Short description:** `flex, the fast lexical analyzer generator: a tool for generating scanners that recognize lexical patterns in text.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
$ brioche build ./packages/flex^test
[287357] flex 2.6.4
Process 287357 ran in 0.02s
Build finished, completed 1 job in 2.43s
Result: 21e0d1756eb9b9c5ab30051edc0867e54209a297ce12928b7beacea25f40d44a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
$ brioche run ./packages/flex^liveUpdate
Build finished, completed (no new jobs) in 2.90s
Running brioche-run
{
  "name": "flex",
  "version": "2.6.4",
  "repository": "https://github.com/westes/flex"
}
```

</p>
</details>

## Implementation notes / special instructions

None.