### PR TITLE
feat(keyutils): add package

### DIFF
--- a/packages/keyutils/brioche.lock
+++ b/packages/keyutils/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git": {
+      "v1.6.3": "cb3bb194cca88211cbfcdde2f10c0f43c3fb8ec3"
+    }
+  }
+}

--- a/packages/keyutils/project.bri
+++ b/packages/keyutils/project.bri
@@ -1,0 +1,79 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "keyutils",
+  version: "1.6.3",
+  repository:
+    "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+}).pipe((source) =>
+  // Make the devel symlink relative instead of an absolute path.
+  std.runBash`
+    sed -i 's#$(LNS) $(LIBDIR)/$(SONAME)#$(LNS) $(SONAME)#' "$BRIOCHE_OUTPUT/Makefile"
+  `
+    .outputScaffold(source)
+    .toDirectory(),
+);
+
+export default function keyutils(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install \\
+      DESTDIR="$BRIOCHE_OUTPUT" \\
+      PREFIX=/ \\
+      SBINDIR=/bin \\
+      LIBDIR=/lib \\
+      USRLIBDIR=/lib \\
+      INCLUDEDIR=/include \\
+      MANDIR=/share/man \\
+      SHAREDIR=/share/keyutils
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/keyctl"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libkeyutils | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, keyutils)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = ^git ls-remote --tags ${project.repository}
+      | lines
+      | parse --regex 'refs/tags/v(?<version>[\\d.]+)$'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `keyutils`
- **Website / repository:** `https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git`
- **Repology URL:** `https://repology.org/project/keyutils/versions`
- **Short description:** `Utilities and a library (libkeyutils) for managing the Linux kernel key-management facility (keyrings)`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 289535 (std/core/recipes/process.bri:240:14)
[289535] 1.6.3
Process 289535 ran in 0.01s
Build finished, completed 1 job in 1.41s
Result: a6e93e5d99380ccc5662c760a8d05dc89f2d34aefd6dfbd95084537c0d191e17
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.64s
Running brioche-run
{
  "name": "keyutils",
  "version": "1.6.3",
  "repository": "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
