### PR TITLE
feat(cwal): add package

### DIFF
--- a/packages/cwal/brioche.lock
+++ b/packages/cwal/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/nitinbhat972/cwal": {
+      "v0.9.0": "6c634b40cd24cf5468a37d793bde837c8feb60a8"
+    }
+  }
+}

--- a/packages/cwal/project.bri
+++ b/packages/cwal/project.bri
@@ -1,0 +1,64 @@
+import * as std from "std";
+import imagemagick from "imagemagick";
+import libimagequant from "libimagequant";
+import luajit from "luajit";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "cwal",
+  version: "0.9.0",
+  repository: "https://github.com/nitinbhat972/cwal",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function cwal(): std.Recipe<std.Directory> {
+  return (
+    cmakeBuild({
+      source,
+      dependencies: [std.toolchain, imagemagick, libimagequant, luajit],
+    })
+      // cwal reads XDG_DATA_DIRS at runtime to locate its templates and themes
+      // under share/cwal, so wrap the binary to point at its own share dir.
+      .pipe((recipe) =>
+        recipe
+          .insert("libexec/cwal", recipe.get("bin/cwal"))
+          .remove("bin/cwal"),
+      )
+      .pipe((recipe) =>
+        std.addRunnable(recipe, "bin/cwal", {
+          command: { relativePath: "libexec/cwal" },
+          env: {
+            XDG_DATA_DIRS: {
+              append: { relativePath: "share" },
+              separator: ":",
+            },
+          },
+        }),
+      )
+      .pipe((recipe) => std.withRunnableLink(recipe, "bin/cwal"))
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cwal --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cwal)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `cwal v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cwal`
- **Website / repository:** `https://github.com/nitinbhat972/cwal`
- **Repology URL:** `https://repology.org/project/cwal/versions`
- **Short description:** `Fast pywal-like color palette generator written in C`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 3259 (std/core/recipes/process.bri:240:14)
[3259] [[33mW[0m]: Config file not found (/home/brioche-runner-89d1e8a70baea2ec6afbc541375a2abb62786571375073b8152e0fcc7dedce4a/.config/cwal/cwal.ini), using default values.
[3259] cwal v0.9.0
Process 3259 ran in 0.03s
Build finished, completed 1 job in 7.49s
Result: c938c1536f16544ce3ac2ed786d599cff89ad8741973ba38df4ddb38176fb076
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Fetching artifact from cache (rust/project.bri:321:6)
Preparing process (std/runtime_utils.bri:49:6)
Fetching artifact from cache (rust/project.bri:321:6)
Launched process 3352 (std/runtime_utils.bri:49:6)
Fetching artifact from cache (rust/project.bri:321:6)
Process 3352 ran in 0.02s
Fetching artifact from cache (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetching artifact from cache (rust/project.bri:321:6)
Fetched 5.6 MiB for artifact from cache in 3.03s (rust/project.bri:321:6)
Fetched 13.5 MiB for artifact from cache in 3.59s (rust/project.bri:321:6)
Fetched 13.0 MiB for artifact from cache in 3.82s (rust/project.bri:321:6)
Fetched 13.2 MiB for artifact from cache in 3.74s (rust/project.bri:321:6)
Fetched 60.3 MiB for artifact from cache in 15.86s (rust/project.bri:321:6)
Fetched 108.1 MiB for artifact from cache in 23.71s (rust/project.bri:321:6)
Build finished, completed 7 jobs in 28.24s
Running brioche-run
{
  "name": "cwal",
  "version": "0.9.0",
  "repository": "https://github.com/nitinbhat972/cwal"
}
```

</p>
</details>

## Implementation notes / special instructions

None.