### PR TITLE
feat(assimp): add package

### DIFF
--- a/packages/assimp/brioche.lock
+++ b/packages/assimp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/assimp/assimp.git": {
+      "v6.0.5": "392a658f9c271be965271f45e7521a1b80ea4392"
+    }
+  }
+}

--- a/packages/assimp/project.bri
+++ b/packages/assimp/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "assimp",
+  version: "6.0.5",
+  repository: "https://github.com/assimp/assimp.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function assimp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      ASSIMP_BUILD_TESTS: "OFF",
+      ASSIMP_BUILD_SAMPLES: "OFF",
+      ASSIMP_BUILD_ASSIMP_TOOLS: "ON",
+      ASSIMP_WARNINGS_AS_ERRORS: "OFF",
+    },
+    runnable: "bin/assimp",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion assimp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, assimp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `assimp`
- **Website / repository:** `https://github.com/assimp/assimp`
- **Repology URL:** `https://repology.org/project/assimp/versions`
- **Short description:** `Open Asset Import Library (assimp): a portable C/C++ library and CLI tool to import and export various 3D model formats`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 9883 (std/core/recipes/process.bri:240:14)
[9883] 6.0.5
Process 9883 ran in 0.03s
Build finished, completed 1 job in 5.13s
Result: 8b5b2d7b5f8829124c57099714cbf3d9d6b747e204eb8ff7b54f181875f58f81
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 12.29s
Running brioche-run
{
  "name": "assimp",
  "version": "6.0.5",
  "repository": "https://github.com/assimp/assimp.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
