### PR TITLE
feat(pulsarctl): add package

### DIFF
--- a/packages/pulsarctl/brioche.lock
+++ b/packages/pulsarctl/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/streamnative/pulsarctl": {
+      "v4.2.0.10": "0869b80cfe7745f900b60350656fc360ded6119b"
+    }
+  }
+}

--- a/packages/pulsarctl/project.bri
+++ b/packages/pulsarctl/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "pulsarctl",
+  version: "4.2.0.10",
+  repository: "https://github.com/streamnative/pulsarctl",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function pulsarctl(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `github.com/streamnative/pulsarctl/pkg/cmdutils.ReleaseVersion=${project.version}`,
+      ],
+    },
+    runnable: "bin/pulsarctl",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pulsarctl --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pulsarctl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Release Version: ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: /^v(?<version>\d+\.\d+\.\d+\.\d+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pulsarctl`
- **Website / repository:** `https://github.com/streamnative/pulsarctl`
- **Repology URL:** `https://repology.org/project/pulsarctl/versions`
- **Short description:** `A CLI tool for managing Apache Pulsar clusters`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 15826 (std/core/recipes/process.bri:240:14)
[15826] Release Version: v4.2.0.10
Process 15826 ran in 0.02s
Build finished, completed 1 job in 2.31s
Result: 79ffcb59896c95c3d2458a6e357d47e4804e4ce8b3cb40e37a2ee90ae6279b9d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Running brioche-run
{
  "name": "pulsarctl",
  "version": "4.2.0.10",
  "repository": "https://github.com/streamnative/pulsarctl"
}
```

</p>
</details>

## Implementation notes / special instructions

None.