### PR TITLE
feat(git_graph): add package

### DIFF
--- a/packages/git_graph/brioche.lock
+++ b/packages/git_graph/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/git-graph/0.7.0/download": {
+      "type": "sha256",
+      "value": "faa05104c30791eb4c7ce947c42664f4c086302575c3c39e6a8cbebd5959aadb"
+    }
+  }
+}

--- a/packages/git_graph/project.bri
+++ b/packages/git_graph/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "git_graph",
+  version: "0.7.0",
+  extra: {
+    crateName: "git-graph",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function gitGraph(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/git-graph",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    git-graph --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(gitGraph)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `git-graph ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `git_graph`
- **Website / repository:** `https://github.com/mlange-42/git-graph`
- **Repology URL:** `https://repology.org/project/git-graph/versions`
- **Short description:** `Command line tool to show clear git graphs arranged for your branching model`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
git-graph 0.7.0
Build finished, completed 1 job in 3.20s
Result: e942a3911345c47d0b871cba473975c8ec49d0374fa0daefd4676ee09e439a9d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Running brioche-run
{
  "name": "git_graph",
  "version": "0.7.0",
  "extra": {
    "crateName": "git-graph"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.
