### PR TITLE
feat(dalfox): add package

### DIFF
--- a/packages/dalfox/brioche.lock
+++ b/packages/dalfox/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/hahwul/dalfox.git": {
+      "v3.0.2": "e4445c17edc91b85fa73734ac316527470075763"
+    }
+  }
+}

--- a/packages/dalfox/project.bri
+++ b/packages/dalfox/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "dalfox",
+  version: "3.0.2",
+  repository: "https://github.com/hahwul/dalfox.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function dalfox(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/dalfox",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dalfox --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dalfox)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `dalfox ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `dalfox`
- **Website / repository:** `https://github.com/hahwul/dalfox`
- **Repology URL:** `https://repology.org/project/dalfox/versions`
- **Short description:** `Powerful open-source XSS scanner and utility focused on automation`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 16087 (std/core/recipes/process.bri:240:14)
[16087] dalfox 3.0.2
Process 16087 ran in 0.01s
Build finished, completed 1 job in 2.62s
Result: 67fe3fc2ce981b56e11a2a21764b055c1fcdc1f030c3750df06c82ab9afa673a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 16188 (std/runtime_utils.bri:49:6)
Process 16188 ran in 0.01s
Build finished, completed 1 job in 2.75s
Running brioche-run
{
  "name": "dalfox",
  "version": "3.0.2",
  "repository": "https://github.com/hahwul/dalfox.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.