### PR TITLE
feat(re2): add package

### DIFF
--- a/packages/re2/brioche.lock
+++ b/packages/re2/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/google/re2.git": {
+      "2025-11-05": "927f5d53caf8111721e734cf24724686bb745f55"
+    }
+  }
+}

--- a/packages/re2/project.bri
+++ b/packages/re2/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import abseilCpp from "abseil_cpp";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "re2",
+  version: "2025-11-05",
+  repository: "https://github.com/google/re2.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function re2(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, abseilCpp],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      RE2_BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // Version is not exposed via pkg-config, so exercise the library to confirm
+  // it works
+  const src = std.directory({
+    "main.cc": std.file(std.indoc`
+      #include <cstdio>
+      #include <cstdlib>
+      #include <re2/re2.h>
+
+      int main(void)
+      {
+          bool matched = RE2::FullMatch("hello world", "h.*d");
+          printf("%s", matched ? "ok" : "fail");
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    c++ main.cc $(pkg-config --cflags --libs re2) -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, abseilCpp, re2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "ok";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({
+    project,
+    matchTag: std.LIVE_UPDATE_REGEX_CALVER_VERSION_MATCH,
+  });
+}

--- a/packages/rust_analyzer/project.bri
+++ b/packages/rust_analyzer/project.bri
@@ -46,6 +46,6 @@ export async function test(): Promise<std.Recipe<std.File>> {
 export function liveUpdate(): std.Recipe<std.Directory> {
   return std.liveUpdateFromGithubReleases({
     project,
-    matchTag: /^(?<version>\d+-\d+-\d+)$/,
+    matchTag: std.LIVE_UPDATE_REGEX_CALVER_VERSION_MATCH,
   });
 }

--- a/packages/std/extra/live_update/index.bri
+++ b/packages/std/extra/live_update/index.bri
@@ -23,7 +23,7 @@ export const DEFAULT_LIVE_UPDATE_REGEX_VERSION_MATCH =
 // numeric segments where leading zeros are permitted, optionally ending in a
 // modifier.
 export const LIVE_UPDATE_REGEX_CALVER_VERSION_MATCH =
-  /^v?(?<version>\d{4}(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?)$/;
+  /^v?(?<version>\d{4}(?:[._-]\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?)$/;
 
 // The extended regex used for matching versions (includes pre-release versions).
 // Strips an optional "v" prefix, then matches the rest if it looks like a


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `re2`
- **Website / repository:** `https://github.com/google/re2.git`
- **Repology URL:** `https://repology.org/project/re2/versions`
- **Short description:** `RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.96s
Result: 47c3709f7e25b090f2023debf881ab906d1fb2b0aeceaa9d9b6c879f0a3654bf
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 71738 (std/runtime_utils.bri:49:6)
Process 71738 ran in 0.01s
Build finished, completed 1 job in 4.53s
Running brioche-run
{
  "name": "re2",
  "version": "2025-11-05",
  "repository": "https://github.com/google/re2.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.