### PR TITLE
Add protobuf package

### DIFF
--- a/packages/protobuf/brioche.lock
+++ b/packages/protobuf/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/protocolbuffers/protobuf.git": {
+      "v35.0": "e59364c38e10de3686a3305ff11fbfc59a10dbd8"
+    }
+  }
+}

--- a/packages/protobuf/project.bri
+++ b/packages/protobuf/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import abseilCpp from "abseil_cpp";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "protobuf",
+  version: "35.0",
+  repository: "https://github.com/protocolbuffers/protobuf.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function protobuf(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, abseilCpp],
+    set: {
+      protobuf_BUILD_TESTS: "OFF",
+      protobuf_BUILD_CONFORMANCE: "OFF",
+      protobuf_BUILD_EXAMPLES: "OFF",
+      protobuf_WITH_ZLIB: "ON",
+    },
+    runnable: "bin/protoc",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    protoc --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, protobuf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `libprotoc ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `protobuf`
- **Website / repository:** https://github.com/protocolbuffers/protobuf
- **Repology URL:** https://repology.org/project/protobuf/versions
- **Short description:** Google Protocol Buffers compiler and libraries

## Related issue(s) or discussion(s)

N/A

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

```bash
brioche build ./packages/protobuf^test
```

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.28s
Result: b2a5863cc1582059d8de9705ac633aa49de7687e47455bfda1b39123e28d616f
```

</p>
</details>

2. Run the **live-update** scenario:

```bash
brioche run ./packages/protobuf^liveUpdate
```

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.74s
Running brioche-run
{
  "name": "protobuf",
  "version": "35.0",
  "repository": "https://github.com/protocolbuffers/protobuf.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.