### PR TITLE
feat(zfp): add package

### DIFF
--- a/packages/zfp/brioche.lock
+++ b/packages/zfp/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/LLNL/zfp.git": {
+      "1.0.1": "f40868a6a1c190c802e7d8b5987064f044bf7812"
+    }
+  }
+}

--- a/packages/zfp/project.bri
+++ b/packages/zfp/project.bri
@@ -1,0 +1,71 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "zfp",
+  version: "1.0.1",
+  repository: "https://github.com/LLNL/zfp.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function zfp(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTING: "OFF",
+      BUILD_EXAMPLES: "OFF",
+      BUILD_CFP: "OFF",
+    },
+    runnable: "bin/zfp",
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <zfp.h>
+
+      int main(void)
+      {
+          printf("%s", zfp_version_string);
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -lzfp -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, zfp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `zfp version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `zfp`
- **Website / repository:** `https://github.com/LLNL/zfp`
- **Repology URL:** `https://repology.org/project/zfp/versions`
- **Short description:** Compressed numerical arrays that support high-speed random access

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 72771 (std/core/recipes/process.bri:240:14)
[72771] zfp version 1.0.1 (December 15, 2023)
Process 72771 ran in 0.29s
Build finished, completed 1 job in 1.99s
Result: 99255b42ba5aaf8646d90ef9f0d08d1c6986448080ea4cfe6ccc971350e79b46
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 72722 (std/runtime_utils.bri:49:6)
Process 72722 ran in 0.03s
Build finished, completed 1 job in 3.96s
Running brioche-run
{
  "name": "zfp",
  "version": "1.0.1",
  "repository": "https://github.com/LLNL/zfp.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.