### PR TITLE
feat(coffeescript): add package

### DIFF
--- a/packages/coffeescript/brioche.lock
+++ b/packages/coffeescript/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/coffeescript/project.bri
+++ b/packages/coffeescript/project.bri
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { npmInstallGlobal } from "nodejs";
+
+export const project = {
+  name: "coffeescript",
+  version: "2.7.0",
+  extra: {
+    packageName: "coffeescript",
+  },
+};
+
+export default function coffeescript(): std.Recipe<std.Directory> {
+  return npmInstallGlobal({
+    packageName: project.extra.packageName,
+    version: project.version,
+  }).pipe((recipe) => std.withRunnableLink(recipe, "bin/coffee"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    coffee --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(coffeescript)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `CoffeeScript version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromNpmPackages({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `coffeescript`
- **Website / repository:** https://github.com/jashkenas/coffeescript
- **Repology URL:** https://repology.org/project/coffeescript/versions
- **Short description:** Unfancy JavaScript -- a small language that compiles to JavaScript.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 92910 in 2.81s
Launched process 92910 (std/core/recipes/process.bri:240:14)
[92910] CoffeeScript version 2.7.0
Process 92910 ran in 0.09s
Build finished, completed 1 job in 6.06s
Result: 68495ec816f77487a85accc77aea26e0a512d481fa9e919359790c420e23401b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 92890 (std/runtime_utils.bri:49:6)
Process 92890 ran in 0.02s
Build finished, completed 1 job in 3.17s
Running brioche-run
{
  "name": "coffeescript",
  "version": "2.7.0",
  "extra": {
    "packageName": "coffeescript"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.