### PR TITLE
Update `gitCheckout` functions to support SHA-256 git hashes

### DIFF
--- a/packages/git/project.bri
+++ b/packages/git/project.bri
@@ -123,9 +123,12 @@ export function gitCheckout(
     const { commit, repository, options: initOptions } = await init;
     options = { ...initOptions, ...options };
 
+    const isSha1Hash = /^[0-9a-f]{40}$/.test(commit);
+    const isSha256Hash = !isSha1Hash && /^[0-9a-f]{64}$/.test(commit);
+
     // Validate that the commit is a hash
     std.assert(
-      /^[0-9a-f]{40}$/.test(commit),
+      isSha1Hash || isSha256Hash,
       `Invalid git commit hash: ${commit}`,
     );
 
@@ -134,27 +137,50 @@ export function gitCheckout(
       "Cannot use 'tag' without 'keepGitDir' enabled",
     );
 
-    // Clone and fetch only the specified commit. See this article:
-    // https://about.gitlab.com/blog/whats-new-in-git-2-49-0/#thin-clone-using---revision
-    let repo = std
-      .process({
-        command: "git",
-        args: [
-          "-c",
-          "advice.detachedHead=false",
-          "clone",
-          "--depth",
-          "1",
-          "--revision",
-          commit,
-          repository,
-          // Clone into the output directory
-          std.outputPath,
-        ],
-        dependencies: [git],
-        unsafe: { networking: true },
-      })
-      .toDirectory();
+    let repo: std.Recipe<std.Directory>;
+    if (isSha1Hash) {
+      // Clone and fetch the specified commit using `git clone --revision`:
+      // https://about.gitlab.com/blog/whats-new-in-git-2-49-0/#thin-clone-using---revision
+      repo = std
+        .process({
+          command: "git",
+          args: [
+            "-c",
+            "advice.detachedHead=false",
+            "clone",
+            "--depth",
+            "1",
+            "--revision",
+            commit,
+            repository,
+            // Clone into the output directory
+            std.outputPath,
+          ],
+          dependencies: [git],
+          unsafe: { networking: true },
+        })
+        .toDirectory();
+    } else {
+      // Clone and fetch the specified commit using the method described in
+      // this article:
+      // https://blog.hartwork.org/posts/clone-arbitrary-single-git-commit/
+      //
+      // NOTE: As of git v2.53, `git clone --revision` doesn't seem to work
+      // with SHA-256 commit hashes (or maybe it's dependent on the remote?),
+      // so we fallback to this older method instead.
+      repo = std.runBash`
+        git -c init.defaultBranch=main init --object-format=sha256
+        git remote add origin "$repository"
+        git fetch --depth 1 origin "$commit"
+        git -c advice.detachedHead=false checkout FETCH_HEAD
+      `
+        .env({ commit, repository })
+        .dependencies(git)
+        .currentDir(std.outputPath)
+        .outputScaffold(std.directory())
+        .unsafe({ networking: true })
+        .toDirectory();
+    }
 
     if (options.tag != null) {
       repo = std


### PR DESCRIPTION
This PR updates the `gitCheckout` function from the `git` package to support checking out repos based on SHA-256 commit hashes. This function is also used by the `Brioche.gitCheckout` function from `std`, so this fix applies there as well.

While testing https://github.com/brioche-dev/brioche-packages/pull/703, I created [a small repo](https://codeberg.org/kylewlacy/git-repo-sha256)[^codeberg] and tried using it with this little example package:

```ts
import * as std from "std";

export default Brioche.gitCheckout({
  repository: "https://codeberg.org/kylewlacy/git-repo-sha256.git",
  ref: "main",
});
```

The lockfile updates properly, but it ends up failing because it trips [this assertion](https://github.com/brioche-dev/brioche-packages/blob/7c7e15a006c17bb365b2256f5a1e2c2efa070862/packages/git/project.bri#L127-L130), which checks for a 40-character hexadecimal hash (SHA-1). SHA-256 hashes are 64 hexadecimal characters.

Even after removing the assertion, it still fails because the `git clone --revision` command gives the following error:

```
Cloning into '/home/brioche-runner-c685f5bb060139f95244d738f99b0514c5c29a7412e43a5581bfad5ddab1c148/.local/share/brioche/outputs/output-c685f5bb060139f95244d738f99b0514c5c29a7412e43a5581bfad5ddab1c148'...
fatal: Remote revision a17d9e7867d105694f3c352f934ce8d326a3c7e61b4b3ab5d6c2a67e817406dd not found in upstream origin
```

I haven't looked into the cause of this issue at all, and I'm unsure if it's a limit of `git clone --revision` itself or if it's something on the remote's side (Codeberg).

Either way, I tried out the older method of cloning a single commit (prior to #703) and it seemed to work fine with SHA-256 hashes. So I decided to split based on whether we're cloning a SHA-1 hash or a SHA-256 hash, which I thought was pretty reasonable (even if it's a little annoying to have two different codepaths for cloning commits)!

[^codeberg]: Codeberg seems to be one of the few-- maybe the only?-- public forge that currently supports repos using the SHA-256 object format!