### PR TITLE
feat(sleef): add package

### DIFF
--- a/packages/sleef/brioche.lock
+++ b/packages/sleef/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/shibatch/sleef.git": {
+      "3.9.0": "906ca7512ee483296780a81a21b9ca715d40dfe1"
+    }
+  }
+}

--- a/packages/sleef/project.bri
+++ b/packages/sleef/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "sleef",
+  version: "3.9.0",
+  repository: "https://github.com/shibatch/sleef.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function sleef(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      SLEEF_BUILD_TESTS: "OFF",
+      SLEEF_ENABLE_TLFLOAT: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sleef | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sleef)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sleef`
- **Website / repository:** `https://github.com/shibatch/sleef`
- **Repology URL:** `https://repology.org/project/sleef/versions`
- **Short description:** SIMD Library for Evaluating Elementary Functions, a vectorized libm

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 274681 (std/core/recipes/process.bri:240:14)
[274681] 3.9.0
Process 274681 ran in 0.27s
Build finished, completed 1 job in 8.14s
Result: 3796e667390a3ff1e09de706eaee478c0086957b72383bbb702e21ecf30665eb
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 15.95s
Running brioche-run
{
  "name": "sleef",
  "version": "3.9.0",
  "repository": "https://github.com/shibatch/sleef.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.