### PR TITLE
feat(cpuinfo): add package

### DIFF
--- a/packages/boost/project.bri
+++ b/packages/boost/project.bri
@@ -1,5 +1,6 @@
 import * as std from "std";
 import cmake, { cmakeSanitizePaths } from "cmake";
+import icu from "icu";
 
 export const project = {
   name: "boost",
@@ -7,7 +8,7 @@ export const project = {
   repository: "https://github.com/boostorg/boost",
 };
 
-const source = Brioche.download(
+export const source = Brioche.download(
   `${project.repository}/releases/download/boost-${project.version}/boost-${project.version}-b2-nodocs.tar.xz`,
 )
   .unarchive("tar", "xz")
@@ -15,16 +16,17 @@ const source = Brioche.download(
 
 export default function boost(): std.Recipe<std.Directory> {
   return std.runBash`
-    ./bootstrap.sh
+    ./bootstrap.sh \\
+      --with-icu
     ./b2 \\
       --prefix="$BRIOCHE_OUTPUT" \\
       -j8 \\
-      --layout=system \\
       install \\
       variant=release \\
-      threading=multi
+      threading=multi \\
+      link=shared,static
   `
-    .dependencies(std.toolchain)
+    .dependencies(std.toolchain, icu)
     .workDir(source)
     .toDirectory()
     .pipe(cmakeSanitizePaths)

--- a/packages/cpuinfo/brioche.lock
+++ b/packages/cpuinfo/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/cpuinfo/project.bri
+++ b/packages/cpuinfo/project.bri
@@ -1,0 +1,90 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "cpuinfo",
+  version: "2026-06-12",
+  repository: "https://github.com/pytorch/cpuinfo.git",
+  extra: {
+    // No tags or releases published, pin to the latest commit on main.
+    gitRef: "4628dc060ce4e82345dc166bbac875609db4ff69",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+});
+
+export default function cpuinfo(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      CPUINFO_BUILD_UNIT_TESTS: "OFF",
+      CPUINFO_BUILD_MOCK_TESTS: "OFF",
+      CPUINFO_BUILD_BENCHMARKS: "OFF",
+      CPUINFO_BUILD_TOOLS: "OFF",
+      CPUINFO_LIBRARY_TYPE: "shared",
+      USE_SYSTEM_LIBS: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // The library does not export a version in its CMake config
+  const src = std.directory({
+    "CMakeLists.txt": std.file(std.indoc`
+      cmake_minimum_required(VERSION 4.0)
+      project(QueryLibrary)
+
+      find_package(cpuinfo REQUIRED CONFIG)
+      message(STATUS "cpuinfo found: TRUE")
+    `),
+  });
+
+  const script = std.runBash`
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, cmake, cpuinfo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that cpuinfo was found
+  const expected = "cpuinfo found: TRUE";
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let gitRef = ^git ls-remote ${project.repository} refs/heads/main
+      | lines
+      | parse --regex '(?<hash>[0-9a-f]+)\\s+'
+      | get 0.hash
+
+    let version = http get $"https://api.github.com/repos/pytorch/cpuinfo/commits/($gitRef)"
+      | get commit.author.date
+      | format date '%Y-%m-%d'
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}

--- a/packages/gd/project.bri
+++ b/packages/gd/project.bri
@@ -12,7 +12,6 @@ import libpng from "libpng";
 import libtiff from "libtiff";
 import libwebp from "libwebp";
 import rav1e from "rav1e";
-import zstd from "zstd";
 
 export const project = {
   name: "gd",
@@ -56,7 +55,6 @@ export default function gd(): std.Recipe<std.Directory> {
       libtiff,
       libwebp,
       rav1e,
-      zstd,
     )
     .toDirectory()
     .pipe(std.libtoolSanitizeDependencies)

--- a/packages/grokj2k/project.bri
+++ b/packages/grokj2k/project.bri
@@ -5,8 +5,6 @@ import lcms2 from "lcms2";
 import libjpegTurbo from "libjpeg_turbo";
 import libpng from "libpng";
 import libtiff from "libtiff";
-import xz from "xz";
-import zstd from "zstd";
 
 export const project = {
   name: "grokj2k",
@@ -23,16 +21,7 @@ const source = Brioche.download(
 export default function grokj2k(): std.Recipe<std.Directory> {
   return cmakeBuild({
     source,
-    dependencies: [
-      std.toolchain,
-      fmt,
-      lcms2,
-      libjpegTurbo,
-      libpng,
-      libtiff,
-      xz,
-      zstd,
-    ],
+    dependencies: [std.toolchain, fmt, lcms2, libjpegTurbo, libpng, libtiff],
     set: {
       BUILD_TESTING: "OFF",
       GRK_BUILD_CODEC: "ON",


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `cpuinfo`
- **Website / repository:** https://github.com/pytorch/cpuinfo.git
- **Repology URL:** https://repology.org/project/cpuinfo-pytorch/versions
- **Short description:** CPU INFOrmation library (x86/x86-64/ARM/ARM64, Linux/Windows/Android/macOS/iOS) to detect essential performance optimization information about the host CPU.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: .../bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: .../bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- cpuinfo found: TRUE
-- Configuring done (2.0s)
-- Generating done (0.0s)
-- Build files have been written to: .../work/tmp
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "cpuinfo",
  "version": "2026-06-12",
  "repository": "https://github.com/pytorch/cpuinfo.git",
  "extra": {
    "gitRef": "4628dc060ce4e82345dc166bbac875609db4ff69"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

The upstream cpuinfo repository has no tags or formal releases, so the recipe pins to the latest commit on `main`.