### PR TITLE
feat(kubazip): add package

### DIFF
--- a/packages/kubazip/brioche.lock
+++ b/packages/kubazip/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/kuba--/zip": {
+      "v0.3.11": "66d5a4098ffe0a859238fd3b2e6c6d772884fd8c"
+    }
+  }
+}

--- a/packages/kubazip/project.bri
+++ b/packages/kubazip/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import cmake, { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "kubazip",
+  version: "0.3.11",
+  repository: "https://github.com/kuba--/zip",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function kubazip(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      CMAKE_DISABLE_TESTING: "ON",
+      ZIP_BUILD_TOOLS: "OFF",
+      BUILD_SHARED_LIBS: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "CMakeLists.txt": std.file(std.indoc`
+      cmake_minimum_required(VERSION 4.0)
+      project(QueryVersion)
+
+      find_package(zip REQUIRED CONFIG)
+      message(STATUS "zip version: \${zip_VERSION}")
+    `),
+  });
+
+  const script = std.runBash`
+    cmake -S . -B tmp | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, cmake, kubazip)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `zip version: ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `kubazip`
- **Website / repository:** https://github.com/kuba--/zip
- **Repology URL:** https://repology.org/project/kubazip/versions
- **Short description:** Portable, simple zip library written in C

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 298278 (std/core/recipes/process.bri:240:14)
[298278] -- The C compiler identification is GNU 13.2.0
[298278] -- The CXX compiler identification is GNU 13.2.0
[298278] -- Detecting C compiler ABI info
[298278] -- Detecting C compiler ABI info - done
[298278] -- Check for working C compiler: .../bin/cc - skipped
[298278] -- Detecting C compile features
[298278] -- Detecting C compile features - done
[298278] -- Detecting CXX compiler ABI info
[298278] -- Detecting CXX compiler ABI info - done
[298278] -- Check for working CXX compiler: .../bin/c++ - skipped
[298278] -- Detecting CXX compile features
[298278] -- Detecting CXX compile features - done
[298278] -- zip version: 0.3.11
[298278] -- Configuring done (4.3s)
[298278] -- Generating done (0.0s)
[298278] -- Build files have been written to: .../work/tmp
Process 298278 ran in 5.12s
Build finished, completed 1 job in 12.89s
Result: ed686ecf66448b26bea678aaf3fd5261411671e683c59a96a097c5914664cac2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 14.84s
Running brioche-run
{
  "name": "kubazip",
  "version": "0.3.11",
  "repository": "https://github.com/kuba--/zip"
}
```

</p>
</details>

## Implementation notes / special instructions

None.