### PR TITLE
feat(lv2): add package

### DIFF
--- a/packages/lv2/brioche.lock
+++ b/packages/lv2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/lv2/lv2/archive/refs/tags/v1.18.10.tar.gz": {
+      "type": "sha256",
+      "value": "250a9a213551795f7f11ea44ae1013a1a9ee2dbb910dc2616a954797bd0e272f"
+    }
+  }
+}

--- a/packages/lv2/project.bri
+++ b/packages/lv2/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "lv2",
+  version: "1.18.10",
+  repository: "https://github.com/lv2/lv2",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lv2(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      tests: "disabled",
+      docs: "disabled",
+      plugins: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lv2 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lv2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lv2`
- **Website / repository:** https://github.com/lv2/lv2
- **Repology URL:** https://repology.org/project/lv2/versions
- **Short description:** LV2 audio plugin specification: C API headers, pkg-config file, and reference `.lv2` bundle data files for plugin/host developers.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 297306 in 1.25s
Launched process 297306 (std/core/recipes/process.bri:240:14)
[297306] 1.18.10
Process 297306 ran in 0.26s
Build finished, completed 1 job in 9.00s
Result: 00610658e2f27decc2db148ece3e90ff9048dbbdf44a0f326e3438956457ee14
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 297491 in 0.28s
Process 297491 ran in 0.28s
Build finished, completed 1 job in 18.26s
Running brioche-run
{
  "name": "lv2",
  "version": "1.18.10",
  "repository": "https://github.com/lv2/lv2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.