### PR TITLE
feat(zix): add package

### DIFF
--- a/packages/zix/brioche.lock
+++ b/packages/zix/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/drobilla/zix/archive/refs/tags/v0.8.2.tar.gz": {
+      "type": "sha256",
+      "value": "9b92244d475cf695d19b643d509791288ba826734202ca53bbe6aa457810cee5"
+    }
+  }
+}

--- a/packages/zix/project.bri
+++ b/packages/zix/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "zix",
+  version: "0.8.2",
+  repository: "https://github.com/drobilla/zix",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function zix(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      tests: "disabled",
+      docs: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion zix-0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, zix)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `zix`
- **Website / repository:** https://github.com/drobilla/zix
- **Repology URL:** https://repology.org/project/zix/versions
- **Short description:** Lightweight C library of portability wrappers and data structures (hash tables, ring buffer, B-tree, threads, semaphores, etc.)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 297443 (std/core/recipes/process.bri:240:14)
[297443] 0.8.2
Process 297443 ran in 0.14s
Build finished, completed 1 job in 8.99s
Result: 1ee5ed80e74fad6c15b54994bb9e0cb8f481ff69ed099a8ea66c3ca282b22ee1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 22.03s
Running brioche-run
{
  "name": "zix",
  "version": "0.8.2",
  "repository": "https://github.com/drobilla/zix"
}
```

</p>
</details>

## Implementation notes / special instructions

None.