### PR TITLE
feat(serd): add package

### DIFF
--- a/packages/serd/brioche.lock
+++ b/packages/serd/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/drobilla/serd/archive/refs/tags/v0.32.10.tar.gz": {
+      "type": "sha256",
+      "value": "3d754863c4910205f126aa031a409b678ee0cd51fe2b5b3b9b9eb7fdfebab74d"
+    }
+  }
+}

--- a/packages/serd/project.bri
+++ b/packages/serd/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+
+export const project = {
+  name: "serd",
+  version: "0.32.10",
+  repository: "https://github.com/drobilla/serd",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function serd(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja],
+    set: {
+      default_library: "both",
+      tests: "disabled",
+      docs: "disabled",
+      singlehtml: "disabled",
+      man: "disabled",
+      man_html: "disabled",
+      html: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion serd-0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, serd)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `serd`
- **Website / repository:** https://github.com/drobilla/serd
- **Repology URL:** https://repology.org/project/serd/versions
- **Short description:** Lightweight C library for RDF syntax (Turtle, TriG, NTriples, NQuads), with a `serdi` command-line utility.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 11.14s
Result: 14cf851581cb017a89da85740f8abafe98da4ca54b4d2080feb9153f127e997f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 18.04s
Running brioche-run
{
  "name": "serd",
  "version": "0.32.10",
  "repository": "https://github.com/drobilla/serd"
}
```

</p>
</details>

## Implementation notes / special instructions

None.