### PR TITLE
feat(sord): add package

### DIFF
--- a/packages/sord/brioche.lock
+++ b/packages/sord/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/drobilla/sord/archive/refs/tags/v0.16.22.tar.gz": {
+      "type": "sha256",
+      "value": "00a70c2b10b668599f5298ac6c1fff714cc83be02aa34c8643cdd995b411b8ae"
+    }
+  }
+}

--- a/packages/sord/project.bri
+++ b/packages/sord/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import pcre2 from "pcre2";
+import serd from "serd";
+import zix from "zix";
+
+export const project = {
+  name: "sord",
+  version: "0.16.22",
+  repository: "https://github.com/drobilla/sord",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sord(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, serd, zix, pcre2],
+    set: {
+      default_library: "both",
+      tests: "disabled",
+      docs: "disabled",
+      man: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sord-0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sord)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sord`
- **Website / repository:** https://github.com/drobilla/sord
- **Repology URL:** https://repology.org/project/sord/versions
- **Short description:** A lightweight C library for storing RDF statements in memory

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 307597 (std/core/recipes/process.bri:240:14)
[307597] 0.16.22
Process 307597 ran in 0.02s
Build finished, completed 1 job in 2.02s
Result: 84ff7b303aa53f54fe666d5d64c590db907a973363512592c15fe3ea7691c58b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 307607 (std/runtime_utils.bri:49:6)
Process 307607 ran in 0.02s
Build finished, completed 1 job in 3.17s
Running brioche-run
{
  "name": "sord",
  "version": "0.16.22",
  "repository": "https://github.com/drobilla/sord"
}
```

</p>
</details>

## Implementation notes / special instructions

None.