### PR TITLE
feat(panache): add package

### DIFF
--- a/packages/panache/brioche.lock
+++ b/packages/panache/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/jolars/panache.git": {
+      "v2.53.0": "6c50cedb4b7514c923d27799bd9f16e3779398e2"
+    }
+  }
+}

--- a/packages/panache/project.bri
+++ b/packages/panache/project.bri
@@ -1,0 +1,40 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "panache",
+  version: "2.53.0",
+  repository: "https://github.com/jolars/panache.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function panache(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/panache",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    panache --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(panache)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `panache ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `panache`
- **Website / repository:** `https://github.com/jolars/panache.git`
- **Repology URL:** `https://repology.org/project/panache/versions`
- **Short description:** A language server, formatter, and linter for Markdown, Quarto, and R Markdown, built in Rust with a lossless CST parser and support for external formatters and linters on code blocks.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed 1 job in 34.94s
Result: ea2833d46e866afb167cca8524993ebf8859345778dc7c4d07d6f1c5da747413
```

The test script (a `std.runBash` invocation of `panache --version`) writes `panache 2.53.0` to the test result file. The build recipe asserts this matches `panache ${project.version}` (`panache 2.53.0`); the assertion passed and the build returned the expected result hash.

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 50.43s
Running brioche-run
{
  "name": "panache",
  "version": "2.53.0",
  "repository": "https://github.com/jolars/panache.git"
}
```

`liveUpdateFromGithubReleases` returns the current project metadata. The version already matches the latest GitHub release (`v2.53.0`), so no update is required.

</p>
</details>

## Implementation notes / special instructions

None.