### PR TITLE
feat(sratom): add package

### DIFF
--- a/packages/gitlab_runner/project.bri
+++ b/packages/gitlab_runner/project.bri
@@ -47,7 +47,7 @@ export async function test(): Promise<std.Recipe<std.File>> {
 
   const result = (await script.read()).trim();
 
-  // Output format: "Version:      18.7.0"
+  // Check that the result contains the expected version
   const versionLine = result
     .split("\n")
     .find((line) => line.startsWith("Version:"));
@@ -63,8 +63,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGitlabReleases({
-    gitlabUrl: "https://gitlab.com",
-    project,
-  });
+  return std.liveUpdateFromGitlabReleases({ project });
 }

--- a/packages/libapparmor/project.bri
+++ b/packages/libapparmor/project.bri
@@ -51,8 +51,5 @@ export async function test(): Promise<std.Recipe<std.File>> {
 }
 
 export function liveUpdate(): std.Recipe<std.Directory> {
-  return std.liveUpdateFromGitlabReleases({
-    gitlabUrl: "https://gitlab.com",
-    project,
-  });
+  return std.liveUpdateFromGitlabReleases({ project });
 }

--- a/packages/sratom/brioche.lock
+++ b/packages/sratom/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gitlab.com/lv2/sratom/-/archive/v0.6.22/sratom-v0.6.22.tar.bz2": {
+      "type": "sha256",
+      "value": "fbcb3bdde9352b2eea09c05641e226c2d04569ddd98fd3764b862e8a09e6d773"
+    }
+  }
+}

--- a/packages/sratom/project.bri
+++ b/packages/sratom/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import lv2 from "lv2";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import serd from "serd";
+import sord from "sord";
+import zix from "zix";
+
+export const project = {
+  name: "sratom",
+  version: "0.6.22",
+  repository: "https://gitlab.com/lv2/sratom",
+};
+
+const source = Brioche.download(
+  `${project.repository}/-/archive/v${project.version}/sratom-v${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function sratom(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, lv2, serd, sord, zix],
+    set: {
+      default_library: "both",
+      tests: "disabled",
+      docs: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion sratom-0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, sratom)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the version matches the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sratom`
- **Website / repository:** https://gitlab.com/lv2/sratom
- **Repology URL:** https://repology.org/project/sratom/versions
- **Short description:** A small C library for serialising LV2 atoms to/from Turtle/RDF

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 28.84s
Result: f071c69704f1be4ffa5f675e0ec496fb777ed667758d416099ebe2ae1bb10fec
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1m 9s
Running brioche-run
{
  "name": "sratom",
  "version": "0.6.22",
  "repository": "https://gitlab.com/lv2/sratom"
}
```

</p>
</details>

## Implementation notes / special instructions

None.