### PR TITLE
feat(nu_lint): add package

### DIFF
--- a/packages/nu_lint/brioche.lock
+++ b/packages/nu_lint/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/nu-lint/1.2.1/download": {
+      "type": "sha256",
+      "value": "1f840ba68f035fe70ee4667fbfd83ba8eafb8db55e6e07f38952461e847fe7b0"
+    }
+  }
+}

--- a/packages/nu_lint/project.bri
+++ b/packages/nu_lint/project.bri
@@ -1,0 +1,43 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "nu_lint",
+  version: "1.2.1",
+  extra: {
+    crateName: "nu-lint",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function nuLint(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/nu-lint",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    nu-lint --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nuLint)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `nu-lint ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `nu_lint`
- **Website / repository:** https://crates.io/crates/nu-lint
- **Repology URL:** https://repology.org/project/nu-lint/versions
- **Short description:** Linter for the Nu shell scripting language that suggests improvements and offers automatic fixes.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
nu-lint 1.2.1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "nu_lint",
  "version": "1.2.1",
  "extra": {
    "crateName": "nu-lint"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.