### PR TITLE
feat(lilv): add package

### DIFF
--- a/packages/lilv/brioche.lock
+++ b/packages/lilv/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gitlab.com/lv2/lilv/-/archive/v0.28.0/lilv-v0.28.0.tar.bz2": {
+      "type": "sha256",
+      "value": "209452fc8b10c742e315d6309a0dcb95dcdaefc7fdd5e6e0ddd07c0326481794"
+    }
+  }
+}

--- a/packages/lilv/project.bri
+++ b/packages/lilv/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import lv2 from "lv2";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import serd from "serd";
+import sord from "sord";
+import sratom from "sratom";
+import zix from "zix";
+
+export const project = {
+  name: "lilv",
+  version: "0.28.0",
+  repository: "https://gitlab.com/lv2/lilv",
+};
+
+const source = Brioche.download(
+  `${project.repository}/-/archive/v${project.version}/lilv-v${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function lilv(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, ninja, lv2, serd, sord, sratom, zix],
+    set: {
+      default_library: "both",
+      tools: "disabled",
+      tests: "disabled",
+      docs: "disabled",
+      bindings_cpp: "disabled",
+      bindings_py: "disabled",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion lilv-0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, lilv)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lilv`
- **Website / repository:** https://gitlab.com/lv2/lilv
- **Repology URL:** https://repology.org/project/lilv/versions
- **Short description:** A C library for hosting LV2 audio plugins, part of the LV2 plugin specification ecosystem.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 335445 (std/core/recipes/process.bri:240:14)
[335445] 0.28.0
Process 335445 ran in 0.03s
Build finished, completed 1 job in 4.71s
Result: 7cce6c784c922a0911daa327a79210fa9555b64d4ae79d1ae522b3d1dc7d0ed1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 335455 (std/runtime_utils.bri:49:6)
Process 335455 ran in 0.01s
Build finished, completed 1 job in 4.51s
Running brioche-run
{
  "name": "lilv",
  "version": "0.28.0",
  "repository": "https://gitlab.com/lv2/lilv"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
