### PR TITLE
feat(minicom): add package

### DIFF
--- a/packages/minicom/brioche.lock
+++ b/packages/minicom/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://deb.debian.org/debian/pool/main/m/minicom/minicom_2.11.1.orig.tar.bz2": {
+      "type": "sha256",
+      "value": "87cf0da91af0531357cd61b8e1906b907edd2c9ef82f9ae74c277e1893d0f98c"
+    }
+  }
+}

--- a/packages/minicom/project.bri
+++ b/packages/minicom/project.bri
@@ -1,0 +1,87 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "minicom",
+  version: "2.11.1",
+  repository: "https://salsa.debian.org/minicom-team/minicom",
+};
+
+const source = Brioche.download(
+  `https://deb.debian.org/debian/pool/main/m/minicom/minicom_${project.version}.orig.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function minicom(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-lock-dir=/var/lock
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .insert(
+      "share/terminfo",
+      std.castToDirectory(std.toolchain().get("share/terminfo")),
+    )
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        TERMINFO_DIRS: { append: [{ path: "share/terminfo" }] },
+      }),
+    )
+    .pipe((recipe) =>
+      recipe
+        .insert("libexec/minicom", recipe.get("bin/minicom"))
+        .remove("bin/minicom"),
+    )
+    .pipe((recipe) =>
+      std.addRunnable(recipe, "bin/minicom", {
+        command: { relativePath: "libexec/minicom" },
+        env: {
+          TERMINFO_DIRS: {
+            fallback: { relativePath: "share/terminfo" },
+          },
+        },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/minicom"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    minicom -v | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(minicom)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `minicom version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://deb.debian.org/debian/pool/main/m/minicom/
+      | lines
+      | where ($it | str contains "minicom_") and ($it | str contains ".orig.tar.bz2")
+      | parse --regex 'href="minicom_(?<version>[0-9.]+)\\.orig\\.tar\\.bz2"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `minicom`
- **Website / repository:** https://salsa.debian.org/minicom-team/minicom
- **Repology URL:** https://repology.org/project/minicom/versions
- **Short description:** Menu-driven serial-port terminal emulator for Linux and other Unix-like systems.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 340880 (std/core/recipes/process.bri:240:14)
[340880] minicom version 2.11.1 (compiled Jun 14 2026)
[340880] Copyright (C) Miquel van Smoorenburg.
[340880] 
[340880] This program is free software; you can redistribute it and/or
[340880] modify it under the terms of the GNU General Public License
[340880] as published by the Free Software Foundation; either version
[340880] 2 of the License, or (at your option) any later version.
Process 340880 ran in 0.02s
Build finished, completed 1 job in 3.36s
Result: 0f1a6eb094eb338ba4e3a9a8e797d8e58dbf9589cf4655ced6fa48d0f85464f4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.64s
Running brioche-run
{
  "name": "minicom",
  "version": "2.11.1",
  "repository": "https://salsa.debian.org/minicom-team/minicom"
}
```

</p>
</details>

## Implementation notes / special instructions

None.