### PR TITLE
feat(libplist): add package

### DIFF
--- a/packages/libplist/brioche.lock
+++ b/packages/libplist/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libimobiledevice/libplist/releases/download/2.7.0/libplist-2.7.0.tar.bz2": {
+      "type": "sha256",
+      "value": "7ac42301e896b1ebe3c654634780c82baa7cb70df8554e683ff89f7c2643eb8b"
+    }
+  }
+}

--- a/packages/libplist/project.bri
+++ b/packages/libplist/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+
+export const project = {
+  name: "libplist",
+  version: "2.7.0",
+  repository: "https://github.com/libimobiledevice/libplist",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/libplist-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libplist(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --without-cython \\
+      --without-tests \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/plistutil"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libplist-2.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libplist)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libplist`
- **Website / repository:** https://github.com/libimobiledevice/libplist
- **Repology URL:** https://repology.org/project/libplist/versions
- **Short description:** A small portable C library to handle Apple Property List files in binary, XML, JSON, or OpenStep format.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 455377 in 4.86s
Launched process 455377 (std/core/recipes/process.bri:240:14)
[455377] 2.7.0
Process 455377 ran in 2.41s
Build finished, completed 1 job in 24.30s
Result: 54c5834916171d3c40ff1791f22442a4f4a01a328f790e759c9b8798b534be08
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1m 4s
Running brioche-run
{
  "name": "libplist",
  "version": "2.7.0",
  "repository": "https://github.com/libimobiledevice/libplist"
}
```

</p>
</details>

## Implementation notes / special instructions

None.