### PR TITLE
feat(libtatsu): add package

### DIFF
--- a/packages/libtatsu/brioche.lock
+++ b/packages/libtatsu/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libimobiledevice/libtatsu/releases/download/1.0.5/libtatsu-1.0.5.tar.bz2": {
+      "type": "sha256",
+      "value": "536fa228b14f156258e801a7f4d25a3a9dd91bb936bf6344e23171403c57e440"
+    }
+  }
+}

--- a/packages/libtatsu/project.bri
+++ b/packages/libtatsu/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import curl from "curl";
+import libplist from "libplist";
+import openssl from "openssl";
+
+export const project = {
+  name: "libtatsu",
+  version: "1.0.5",
+  repository: "https://github.com/libimobiledevice/libtatsu",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/libtatsu-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libtatsu(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libplist, openssl, curl({ minimal: true }))
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libtatsu-1.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libtatsu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtatsu`
- **Website / repository:** `https://github.com/libimobiledevice/libtatsu`
- **Repology URL:** `https://repology.org/project/libtatsu/versions`
- **Short description:** Library handling the communication with Apple's Tatsu Signing Server (TSS).

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 483008 (std/core/recipes/process.bri:240:14)
[483008] 1.0.5
Process 483008 ran in 0.05s
Build finished, completed 1 job in 2.75s
Result: a826ee49324f2bc5d6d467db7ddc18630e8ea541eb7c603c471ab475f696f50a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 483048 (std/runtime_utils.bri:49:6)
Process 483048 ran in 0.02s
Build finished, completed 1 job in 5.98s
Running brioche-run
{
  "name": "libtatsu",
  "version": "1.0.5",
  "repository": "https://github.com/libimobiledevice/libtatsu"
}
```

</p>
</details>

## Implementation notes / special instructions

None.