### PR TITLE
feat(libimobiledevice-glue): add package

### DIFF
--- a/packages/libimobiledevice-glue/brioche.lock
+++ b/packages/libimobiledevice-glue/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libimobiledevice/libimobiledevice-glue/releases/download/1.3.2/libimobiledevice-glue-1.3.2.tar.bz2": {
+      "type": "sha256",
+      "value": "6489a3411b874ecd81c87815d863603f518b264a976319725e0ed59935546774"
+    }
+  }
+}

--- a/packages/libimobiledevice-glue/project.bri
+++ b/packages/libimobiledevice-glue/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import libplist from "libplist";
+
+export const project = {
+  name: "libimobiledevice_glue",
+  version: "1.3.2",
+  repository: "https://github.com/libimobiledevice/libimobiledevice-glue",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/libimobiledevice-glue-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libimobiledeviceGlue(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libplist)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libimobiledevice-glue-1.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libimobiledeviceGlue)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libimobiledevice_glue`
- **Website / repository:** https://github.com/libimobiledevice/libimobiledevice-glue
- **Repology URL:** https://repology.org/project/libimobiledevice-glue/versions
- **Short description:** Library with common code (socket helpers, threading, plist utilities) used by libraries and tools around the libimobiledevice project.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 482998 (std/core/recipes/process.bri:240:14)
[482998] 1.3.2
Process 482998 ran in 0.13s
Build finished, completed 1 job in 2.77s
Result: 83e623d37f06c295890433a54d30ca0e74c0dcca64752d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 483062 (std/runtime_utils.bri:49:6)
Process 483062 ran in 0.01s
Build finished, completed 1 job in 6.35s
Running brioche-run
{
  "name": "libimobiledevice_glue",
  "version": "1.3.2",
  "repository": "https://github.com/libimobiledevice/libimobiledevice-glue"
}
```

</p>
</details>

## Implementation notes / special instructions

None.