### PR TITLE
feat(sse2neon): add package

### DIFF
--- a/packages/bugstalker/project.bri
+++ b/packages/bugstalker/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 import libunwind from "libunwind";
 import { cargoBuild } from "rust";
 
-// Currently, BugStalker only support x86-64 Linux
+// Currently, this recipe only supports x86-64 Linux
 // @brioche-packages skip-platform aarch64-linux
 export const project = {
   name: "bugstalker",

--- a/packages/sse2neon/brioche.lock
+++ b/packages/sse2neon/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.9.1.tar.gz": {
+      "type": "sha256",
+      "value": "6b70e7cb8c5ce4641002b85deaafe97efdf9ade9b49884edeaf678b35f0e132f"
+    }
+  }
+}

--- a/packages/sse2neon/project.bri
+++ b/packages/sse2neon/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+
+export const project = {
+  name: "sse2neon",
+  version: "1.9.1",
+  repository: "https://github.com/DLTcollab/sse2neon",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function sse2neon(): std.Recipe<std.Directory> {
+  return std.runBash`
+    # Manual installation
+    cp sse2neon.h "$BRIOCHE_OUTPUT/include/"
+  `
+    .workDir(source)
+    .outputScaffold(
+      std.directory({
+        include: std.directory(),
+      }),
+    )
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so we just
+  // build a simple program to ensure it works
+  const src = std.directory({
+    "main.cpp": std.file(std.indoc`
+      #include <sse2neon.h>
+      #include <cstdlib>
+      #include <iostream>
+
+      int main()
+      {
+          __m128 a = _mm_setzero_ps();
+          float v = _mm_cvtss_f32(a);
+          std::cout << v;
+
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    g++ main.cpp -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, sse2neon)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  const expected = "0";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/sse2neon/project.bri
+++ b/packages/sse2neon/project.bri
@@ -1,5 +1,7 @@
 import * as std from "std";
 
+// This recipe only supports aarch64 Linux
+// @brioche-packages skip-platform x86-64-linux
 export const project = {
   name: "sse2neon",
   version: "1.9.1",

--- a/packages/svt_vp9/project.bri
+++ b/packages/svt_vp9/project.bri
@@ -2,7 +2,7 @@ import * as std from "std";
 import nasm from "nasm";
 import { cmakeBuild } from "cmake";
 
-// SVT-VP9 only supports x86-64 (uses x86 SIMD intrinsics with no ARM fallback)
+// This recipe only supports x86-64 (uses x86 SIMD intrinsics with no ARM fallback)
 // @brioche-packages skip-platform aarch64-linux
 export const project = {
   name: "svt_vp9",


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `sse2neon`
- **Website / repository:** https://github.com/DLTcollab/sse2neon
- **Repology URL:** https://repology.org/project/sse2neon/versions
- **Short description:** A C/C++ header file that translates Intel SSE intrinsics to Arm/Aarch64 NEON intrinsics.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
0
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "sse2neon",
  "version": "1.9.1",
  "repository": "https://github.com/DLTcollab/sse2neon"
}
```

</p>
</details>

## Implementation notes / special instructions

None.