### PR TITLE
feat(pngquant): add package

### DIFF
--- a/packages/pngquant/brioche.lock
+++ b/packages/pngquant/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/pngquant/3.0.3/download": {
+      "type": "sha256",
+      "value": "68a12bdd8825f9989f4ee9a6ab0b42727dae57728b939ef63453366697a07232"
+    }
+  }
+}

--- a/packages/pngquant/project.bri
+++ b/packages/pngquant/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import lcms2 from "lcms2";
+import libpng from "libpng";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "pngquant",
+  version: "3.0.3",
+  extra: {
+    crateName: "pngquant",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function pngquant(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    dependencies: [libpng, lcms2],
+    runnable: "bin/pngquant",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pngquant --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pngquant)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `pngquant`
- **Website / repository:** `https://github.com/kornelski/pngquant`
- **Repology URL:** `https://repology.org/project/pngquant/versions`
- **Short description:** Lossy PNG compressor that converts 24/32-bit images to efficient 8-bit format with alpha channel.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.05s
Result: 0b0b77273de0f434d2ea6af7b13283d90083a2476730bd612e94cc66da3e3324
Writing output to /tmp/pngquant-test-output
Wrote output to /tmp/pngquant-test-output
```

The test produced a `3.0.3` result file, matching `project.version`.

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.27s
Running brioche-run
{
  "name": "pngquant",
  "version": "3.0.3",
  "extra": {
    "crateName": "pngquant"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.