### PR TITLE
feat(immich_go): add package

### DIFF
--- a/packages/immich_go/brioche.lock
+++ b/packages/immich_go/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/simulot/immich-go.git": {
+      "v0.31.0": "f747c0ed8b9c05f6ffb05fef665b6cd2d484d334"
+    }
+  }
+}

--- a/packages/immich_go/project.bri
+++ b/packages/immich_go/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import git from "git";
+import { goBuild } from "go";
+
+export const project = {
+  name: "immich_go",
+  version: "0.31.0",
+  repository: "https://github.com/simulot/immich-go.git",
+  extra: {
+    moduleName: "github.com/simulot/immich-go",
+  },
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+  options: {
+    keepGitDir: true,
+    tag: true,
+  },
+});
+
+export default function immichGo(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    dependencies: [git],
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/app.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/immich-go",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    immich-go version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(immichGo)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  const expected = `immich-go version:${project.version},`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `immich_go`
- **Website / repository:** https://github.com/simulot/immich-go.git
- **Repology URL:** https://repology.org/project/immich-go/versions
- **Short description:** Open-source CLI to import large photo collections (Google Photos takeouts, iCloud, local folders) into a self-hosted Immich server.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.04s
Result: 3c3c72a321f242f19a8ce0924ddc835c9cc91ec6aac56a03557652a27398c299
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.19s
Running brioche-run
{
  "name": "immich_go",
  "version": "0.31.0",
  "repository": "https://github.com/simulot/immich-go.git",
  "extra": {
    "moduleName": "github.com/simulot/immich-go"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.