### PR TITLE
feat(libiodbc): add package

### DIFF
--- a/packages/libiodbc/brioche.lock
+++ b/packages/libiodbc/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/openlink/iODBC/releases/download/v3.52.16/libiodbc-3.52.16.tar.gz": {
+      "type": "sha256",
+      "value": "3898b32d07961360f6f2cf36db36036b719a230e476469258a80f32243e845fa"
+    }
+  }
+}

--- a/packages/libiodbc/project.bri
+++ b/packages/libiodbc/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+
+export const project = {
+  name: "libiodbc",
+  version: "3.52.16",
+  repository: "https://github.com/openlink/iODBC",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/libiodbc-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libiodbc(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-gui \\
+      --enable-odbc3 \\
+      --enable-libodbc
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/iodbc-config"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libiodbc | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libiodbc)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libiodbc`
- **Website / repository:** `https://github.com/openlink/iODBC`
- **Repology URL:** `https://repology.org/project/libiodbc/versions`
- **Short description:** Open-source ODBC driver manager and SDK for Unix-like systems (including Linux, macOS, and BSDs).

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 583353 (std/core/recipes/process.bri:240:14)
[583353] 3.52.16
Process 583353 ran in 0.01s
Build finished, completed 1 job in 1.22s
Result: 8762b92367b92b6de7e71aff1ca0d75134c29cf76caf42f5435b8ad9f9cdd249
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.19s
Running brioche-run
{
  "name": "libiodbc",
  "version": "3.52.16",
  "repository": "https://github.com/openlink/iODBC"
}
```

</p>
</details>

## Implementation notes / special instructions

None.