### PR TITLE
feat(libimobiledevice): add package

### DIFF
--- a/packages/libimobiledevice/brioche.lock
+++ b/packages/libimobiledevice/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libimobiledevice/libimobiledevice/releases/download/1.4.0/libimobiledevice-1.4.0.tar.bz2": {
+      "type": "sha256",
+      "value": "23cc0077e221c7d991bd0eb02150a0d49199bcca1ddf059edccee9ffd914939d"
+    }
+  }
+}

--- a/packages/libimobiledevice/project.bri
+++ b/packages/libimobiledevice/project.bri
@@ -1,0 +1,71 @@
+import * as std from "std";
+import curl from "curl";
+import libimobiledeviceGlue from "libimobiledevice_glue";
+import libplist from "libplist";
+import libtatsu from "libtatsu";
+import libusbmuxd from "libusbmuxd";
+import openssl from "openssl";
+
+export const project = {
+  name: "libimobiledevice",
+  version: "1.4.0",
+  repository: "https://github.com/libimobiledevice/libimobiledevice",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/libimobiledevice-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libimobiledevice(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --without-cython \\
+      --enable-static \\
+      --enable-shared
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      libimobiledeviceGlue,
+      libplist,
+      libtatsu,
+      libusbmuxd,
+      openssl,
+      curl({ minimal: true }),
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libimobiledevice-1.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libimobiledevice)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libimobiledevice`
- **Website / repository:** https://github.com/libimobiledevice/libimobiledevice
- **Repology URL:** https://repology.org/project/libimobiledevice/versions
- **Short description:** A cross-platform protocol library to communicate with iOS devices.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 570956 (std/core/recipes/process.bri:240:14)
[570956] 1.4.0
Process 570956 ran in 0.01s
Build finished, completed 1 job in 1.94s
Result: f527d21102adf366d6c52e79f9eb83a9939feb039d5b62f023f359959fb7b0d6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 570972 (std/runtime_utils.bri:49:6)
Process 570972 ran in 0.00s
Build finished, completed 1 job in 2.68s
Running brioche-run
{
  "name": "libimobiledevice",
  "version": "1.4.0",
  "repository": "https://github.com/libimobiledevice/libimobiledevice"
}
```

</p>
</details>

## Implementation notes / special instructions

None.