### PR TITLE
feat(libtar): add package

### DIFF
--- a/packages/libtar/brioche.lock
+++ b/packages/libtar/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/tklauser/libtar.git": {
+      "v1.2.20": "0907a9034eaf2a57e8e4a9439f793f3f05d446cd"
+    }
+  }
+}

--- a/packages/libtar/project.bri
+++ b/packages/libtar/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+
+export const project = {
+  name: "libtar",
+  version: "1.2.20",
+  repository: "https://github.com/tklauser/libtar.git",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libtar(): std.Recipe<std.Directory> {
+  return std.runBash`
+    autoreconf --install --force
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/libtar"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    (libtar -V || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(libtar)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `libtar ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtar`
- **Website / repository:** `https://github.com/tklauser/libtar.git`
- **Repology URL:** `https://repology.org/project/libtar/versions`
- **Short description:** C library for manipulating tar files (POSIX and GNU tar format support)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
libtar 1.2.20 by Mark D. Roth <roth@uiuc.edu>
Usage: libtar [-C rootdir] [-g] [-z] -x|-t filename.tar
       libtar [-C rootdir] [-g] [-z] -c filename.tar ...
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "libtar",
  "version": "1.2.20",
  "repository": "https://github.com/tklauser/libtar.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.