### PR TITLE
feat(libicns): add package

### DIFF
--- a/packages/libicns/brioche.lock
+++ b/packages/libicns/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz": {
+      "type": "sha256",
+      "value": "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
+    }
+  }
+}

--- a/packages/libicns/project.bri
+++ b/packages/libicns/project.bri
@@ -1,0 +1,68 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import jasper from "jasper";
+import libpng from "libpng";
+
+export const project = {
+  name: "libicns",
+  version: "0.8.1",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/icns/libicns-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libicns(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, jasper, libpng)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libicns | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libicns)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/icns/files/
+      | lines
+      | where ($it | str contains '<a href="/projects/icns/files/libicns-')
+      | where ($it | str contains '.tar.gz')
+      | parse --regex '<a href="/projects/icns/files/libicns-(?<version>[0-9.]+)\\.tar\\.gz/'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libicns`
- **Website / repository:** `https://icns.sourceforge.io/`
- **Repology URL:** `https://repology.org/project/libicns/versions`
- **Short description:** `Library for manipulation of the Mac OS icns resource format (Apple .icns icon files), with tools to convert to/from PNG.`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 659713 (std/core/recipes/process.bri:240:14)
[659713] 0.8.1
Process 659713 ran in 0.01s
Build finished, completed 1 job in 1.55s
Result: 836fe79d2fe7ec5e436f6098450435a10ebf49094cf6b6d8b1ccb984f400146c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.21s
Running brioche-run
{
  "name": "libicns",
  "version": "0.8.1"
}
```

</p>
</details>

## Implementation notes / special instructions

None.