### PR TITLE
feat(libtermkey): add package

### DIFF
--- a/packages/libtermkey/brioche.lock
+++ b/packages/libtermkey/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/neovim/libtermkey/archive/refs/tags/v0.22.tar.gz": {
+      "type": "sha256",
+      "value": "81cac2b685c9ada4ead4ea788fb69ff74fc1947ad188ed0264c646fe12b496ba"
+    }
+  }
+}

--- a/packages/libtermkey/project.bri
+++ b/packages/libtermkey/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import unibilium from "unibilium";
+
+export const project = {
+  name: "libtermkey",
+  version: "0.22",
+  repository: "https://github.com/neovim/libtermkey",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libtermkey(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, unibilium)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion termkey | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libtermkey)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtermkey`
- **Website / repository:** https://github.com/neovim/libtermkey
- **Repology URL:** https://repology.org/project/libtermkey/versions
- **Short description:** Abstract terminal key input library for processing keyboard entry from terminal-based programs.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.80s
Result: f77698a4e5b66497d6d3dc0f8097f52e2841f432acaff9ce262b195762e9083d
```

The cached test recipe prints `0.22` to stdout (pkg-config --modversion termkey), which matches `project.version`.

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.65s
Running brioche-run
{
  "name": "libtermkey",
  "version": "0.22",
  "repository": "https://github.com/neovim/libtermkey"
}
```

</p>
</details>

## Implementation notes / special instructions

None.