### PR TITLE
feat(tomsfastmath): add package

### DIFF
--- a/packages/tomsfastmath/brioche.lock
+++ b/packages/tomsfastmath/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/libtom/tomsfastmath/releases/download/v0.13.1/tfm-0.13.1.tar.xz": {
+      "type": "sha256",
+      "value": "47c97a1ada3ccc9fcbd2a8a922d5859a84b4ba53778c84c1d509c1a955ac1738"
+    }
+  }
+}

--- a/packages/tomsfastmath/project.bri
+++ b/packages/tomsfastmath/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+
+export const project = {
+  name: "tomsfastmath",
+  version: "0.13.1",
+  repository: "https://github.com/libtom/tomsfastmath",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/tfm-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function tomsfastmath(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)" LIBNAME=libtfm.a
+
+    # Manual installation
+    cp libtfm.a "$BRIOCHE_OUTPUT/lib/libtfm.a"
+    cp src/headers/tfm.h "$BRIOCHE_OUTPUT/include/tfm.h"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        lib: std.directory(),
+        include: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <tfm.h>
+
+      int main(void)
+      {
+          printf("%s", TFM_VERSION_S);
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -ltfm -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, tomsfastmath)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `v${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `tomsfastmath`
- **Website / repository:** `https://github.com/libtom/tomsfastmath`
- **Repology URL:** `https://repology.org/project/tomsfastmath/versions`
- **Short description:** TomsFastMath is a fast public domain, open source, large integer arithmetic library written in portable ISO C.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.60s
Result: d7f66d371eb1efadea217e8e0753fb75813aeac5a64701bc8e003a50bfc1e065
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.15s
Running brioche-run
{
  "name": "tomsfastmath",
  "version": "0.13.1",
  "repository": "https://github.com/libtom/tomsfastmath"
}
```

</p>
</details>

## Implementation notes / special instructions

None.