### PR TITLE
feat(libtomcrypt): add package

### DIFF
--- a/packages/libtomcrypt/brioche.lock
+++ b/packages/libtomcrypt/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libtom/libtomcrypt": {
+      "v1.18.2": "7e7eb695d581782f04b24dc444cbfde86af59853"
+    }
+  }
+}

--- a/packages/libtomcrypt/project.bri
+++ b/packages/libtomcrypt/project.bri
@@ -1,0 +1,77 @@
+import * as std from "std";
+import libtommath from "libtommath";
+
+export const project = {
+  name: "libtomcrypt",
+  version: "1.18.2",
+  repository: "https://github.com/libtom/libtomcrypt",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libtomcrypt(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make \\
+      CFLAGS="-DUSE_LTM -DLTM_DESC" \\
+      EXTRALIBS="-ltommath" \\
+      -j "$(nproc)"
+
+    # Manual installation
+    cp libtomcrypt.a "$BRIOCHE_OUTPUT/lib/libtomcrypt.a"
+    cp src/headers/tomcrypt*.h "$BRIOCHE_OUTPUT/include/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libtommath)
+    .outputScaffold(
+      std.directory({
+        lib: std.directory(),
+        include: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <tomcrypt.h>
+
+      int main(void)
+      {
+          printf("%s", SCRYPT);
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -ltomcrypt -ltommath -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, libtomcrypt, libtommath)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtomcrypt`
- **Website / repository:** `https://github.com/libtom/libtomcrypt`
- **Repology URL:** `https://repology.org/project/libtomcrypt/versions`
- **Short description:** A modular, portable cryptographic toolkit providing block ciphers, hash functions, chaining modes, PRNGs, and public key cryptography routines.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 669251 (std/core/recipes/process.bri:240:14)
[669251] 1.18.2
Process 669251 ran in 0.11s
Build finished, completed 1 job in 1.47s
Result: 6a70c63af1d77739c09788ba1ea15805daa1f7e4a3cca19e4ea1abc9fc43c87b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.29s
Running brioche-run
{
  "name": "libtomcrypt",
  "version": "1.18.2",
  "repository": "https://github.com/libtom/libtomcrypt"
}
```

</p>
</details>

## Implementation notes / special instructions

None.