### PR TITLE
feat(libtcod): add package

### DIFF
--- a/packages/libtcod/brioche.lock
+++ b/packages/libtcod/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libtcod/libtcod": {
+      "2.2.2": "27c2dbc9d97bacb18b9fd43a5c7f070dc34339ed"
+    }
+  }
+}

--- a/packages/libtcod/project.bri
+++ b/packages/libtcod/project.bri
@@ -1,0 +1,76 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+import sdl3 from "sdl3";
+import utf8proc from "utf8proc";
+
+export const project = {
+  name: "libtcod",
+  version: "2.2.2",
+  repository: "https://github.com/libtcod/libtcod",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libtcod(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, sdl3, utf8proc],
+    set: {
+      LIBTCOD_SAMPLES: "OFF",
+      LIBTCOD_TESTS: "OFF",
+      LIBTCOD_LODEPNG: "vendored",
+      LIBTCOD_STB: "vendored",
+      BUILD_SHARED_LIBS: "ON",
+      // Redirect FetchContent declarations to find_package() so declared
+      // dependencies are resolved from the build environment instead of
+      // being downloaded at configure time.
+      FETCHCONTENT_FULLY_DISCONNECTED: "ON",
+      FETCHCONTENT_TRY_FIND_PACKAGE_MODE: "ALWAYS",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "share/libtcod" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <libtcod/version.h>
+
+      int main(void)
+      {
+          printf("%s", TCOD_STRVERSION);
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    cc main.c -ltcod -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, libtcod)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}

--- a/packages/onnxruntime/project.bri
+++ b/packages/onnxruntime/project.bri
@@ -65,6 +65,9 @@ export default function onnxruntime(): std.Recipe<std.Directory> {
       onnxruntime_RUN_ONNX_TESTS: "OFF",
       onnxruntime_USE_FULL_PROTOBUF: "OFF",
       onnxruntime_USE_COREML: "OFF",
+      // Redirect FetchContent declarations to find_package() so declared
+      // dependencies are resolved from the build environment instead of
+      // being downloaded at configure time.
       FETCHCONTENT_FULLY_DISCONNECTED: "ON",
       FETCHCONTENT_TRY_FIND_PACKAGE_MODE: "ALWAYS",
       FETCHCONTENT_SOURCE_DIR_MP11: std.tpl`${boost}`,


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libtcod`
- **Website / repository:** https://github.com/libtcod/libtcod
- **Repology URL:** https://repology.org/project/libtcod/versions
- **Short description:** A free, fast, portable and uncomplicated API for roguelike developers providing a true color console, pathfinding, field-of-view, and other utilities.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 21.39s
Result: 17647cc952cc22d27bfb20cc134b7d9c34b812ae227a6d526699e8bfee1b6050
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.81s
Running brioche-run
{
  "name": "libtcod",
  "version": "2.2.2",
  "repository": "https://github.com/libtcod/libtcod"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
