### PR TITLE
feat(lodepng): add package

### DIFF
--- a/packages/lodepng/brioche.lock
+++ b/packages/lodepng/brioche.lock
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/packages/lodepng/project.bri
+++ b/packages/lodepng/project.bri
@@ -1,0 +1,95 @@
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import * as std from "std";
+
+export const project = {
+  name: "lodepng",
+  version: "20260119",
+  repository: "https://github.com/lvandeve/lodepng",
+  extra: {
+    gitRef: "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+  },
+};
+
+// No tags or releases published yet, pin to the latest commit.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.extra.gitRef,
+});
+
+export default function lodepng(): std.Recipe<std.Directory> {
+  return std.runBash`
+    c++ -I. -ansi -pedantic -O2 -fPIC -c lodepng.cpp -o lodepng.o
+    ar rcs liblodepng.a lodepng.o
+    c++ -shared -Wl,-soname,liblodepng.so -o liblodepng.so lodepng.o
+
+    # Manual installation
+    cp lodepng.h "$BRIOCHE_OUTPUT/include/"
+    cp liblodepng.a liblodepng.so "$BRIOCHE_OUTPUT/lib/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        include: std.directory(),
+        lib: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <lodepng.h>
+
+      int main(void)
+      {
+          printf("%s", LODEPNG_VERSION_STRING);
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    c++ main.c -llodepng -o main
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, lodepng)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let response = http get https://api.github.com/repos/lvandeve/lodepng/commits/master
+    let gitRef = $response.sha
+    let url = $"https://raw.githubusercontent.com/lvandeve/lodepng/($gitRef)/lodepng.h"
+    let version = http get $url
+      | lines
+      | where ($it | str contains "LodePNG version")
+      | parse --regex 'LodePNG version (?<version>\\d+)'
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | update extra.gitRef $gitRef
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lodepng`
- **Website / repository:** `https://github.com/lvandeve/lodepng`
- **Repology URL:** `https://repology.org/project/lodepng/versions`
- **Short description:** PNG encoder and decoder in C and C++, without external dependencies.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 736759 (std/core/recipes/process.bri:240:14)
[736759] 20260119
Process 736759 ran in 0.54s
Build finished, completed 1 job in 3.10s
Result: 3632ec359cc6733135995a161bdb36f0ca99db01d66adf69a3b82f9dc940545a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.97s
Running brioche-run
{
  "name": "lodepng",
  "version": "20260119",
  "repository": "https://github.com/lvandeve/lodepng",
  "extra": {
    "gitRef": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

The upstream LodePNG project does not publish git tags or GitHub releases. The recipe pins the source to the latest commit.