### PR TITLE
Update CI platform checking

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,6 +86,7 @@ jobs:
             fi
           done
         env:
+          PLATFORM: ${{ matrix.platform }}
           BRIOCHE_REGISTRY_PASSWORD: ${{ secrets.BRIOCHE_REGISTRY_PASSWORD }}
           BRIOCHE_CACHE_URL: ${{ vars.BRIOCHE_CACHE_READ_URL }}
           BRIOCHE_CACHE_WRITE_URL: ${{ vars.BRIOCHE_CACHE_WRITE_URL }}

--- a/packages/sse2neon/project.bri
+++ b/packages/sse2neon/project.bri
@@ -1,7 +1,7 @@
 import * as std from "std";
 
 // This recipe only supports aarch64 Linux
-// @brioche-packages skip-platform x86-64-linux
+// @brioche-packages skip-platform x86_64-linux
 export const project = {
   name: "sse2neon",
   version: "1.9.1",


### PR DESCRIPTION
@kylewlacy I opened this PR to fix the platform name resolution during executing the tests in the CI, I saw it in [these logs](https://github.com/brioche-dev/brioche-packages/actions/runs/27618135931/job/81659794308):

<img width="1352" height="692" alt="image" src="https://github.com/user-attachments/assets/05d68883-84a2-4634-a388-ea261521fdba" />

Prior this PR it was not correctly computed due to a missing environment variable.