### PR TITLE
feat(loudmouth): add package

### DIFF
--- a/packages/loudmouth/brioche.lock
+++ b/packages/loudmouth/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://mcabber.com/files/loudmouth/loudmouth-1.5.4.tar.bz2": {
+      "type": "sha256",
+      "value": "31cbc91c1fddcc5346b3373b8fb45594e9ea9cc7fe36d0595e8912c47ad94d0d"
+    }
+  }
+}

--- a/packages/loudmouth/project.bri
+++ b/packages/loudmouth/project.bri
@@ -1,0 +1,82 @@
+import * as std from "std";
+import glib from "glib";
+import gnutls from "gnutls";
+import libffi from "libffi";
+import libiconv from "libiconv";
+import libidn from "libidn";
+import libidn2 from "libidn2";
+import libtasn1 from "libtasn1";
+import libunistring from "libunistring";
+import nettle from "nettle";
+import p11Kit from "p11_kit";
+import pcre2 from "pcre2";
+
+export const project = {
+  name: "loudmouth",
+  version: "1.5.4",
+  repository: "https://github.com/mcabber/loudmouth",
+};
+
+const source = Brioche.download(
+  `https://mcabber.com/files/loudmouth/loudmouth-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function loudmouth(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --with-ssl=gnutls
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      glib,
+      gnutls,
+      libffi,
+      libiconv,
+      libidn,
+      libidn2,
+      libtasn1,
+      libunistring,
+      nettle,
+      p11Kit,
+      pcre2,
+    )
+    .env({
+      CFLAGS: "-Wno-error=deprecated-declarations",
+    })
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion loudmouth-1.0 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, loudmouth)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `loudmouth`
- **Website / repository:** `https://github.com/mcabber/loudmouth`
- **Repology URL:** `https://repology.org/project/loudmouth/versions`
- **Short description:** Lightweight C library for the Jabber/XMPP protocol

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 1045032 (std/core/recipes/process.bri:240:14)
[1045032] 1.5.4
Process 1045032 ran in 0.03s
Build finished, completed 1 job in 2.86s
Result: f15abcc4d150214c697ed89fc601febe272cdbcd1ac20abf87c818249aebe994
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.84s
Running brioche-run
{
  "name": "loudmouth",
  "version": "1.5.4",
  "repository": "https://github.com/mcabber/loudmouth"
}
```

</p>
</details>

## Implementation notes / special instructions

None.