### PR TITLE
live-update: vulkan_headers, vulkan_utility_libraries, vulkan_tools, vulkan_profiles (v1.4.352 -> v1.4.354)

### DIFF
--- a/packages/vulkan_headers/brioche.lock
+++ b/packages/vulkan_headers/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/KhronosGroup/Vulkan-Headers": {
-      "v1.4.352": "015e25c3c91b70eb1a754d36fb14c4ba6ad9b0b9"
+      "v1.4.354": "01393c3df0e5285b54ee6527466513f9e614be94"
     }
   }
 }

--- a/packages/vulkan_headers/project.bri
+++ b/packages/vulkan_headers/project.bri
@@ -3,7 +3,7 @@ import cmake, { cmakeBuild } from "cmake";
 
 export const project = {
   name: "vulkan_headers",
-  version: "1.4.352",
+  version: "1.4.354",
   repository: "https://github.com/KhronosGroup/Vulkan-Headers",
 };
 

--- a/packages/vulkan_profiles/brioche.lock
+++ b/packages/vulkan_profiles/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/KhronosGroup/Vulkan-Profiles": {
-      "v1.4.352": "ed2e474339a80f261f0c233dfbe82fce1ff37180"
+      "v1.4.354": "63704aa52f7cb75bac1276cd923bd3d4a3645f33"
     }
   }
 }

--- a/packages/vulkan_profiles/project.bri
+++ b/packages/vulkan_profiles/project.bri
@@ -8,7 +8,7 @@ import vulkanUtilityLibraries from "vulkan_utility_libraries";
 
 export const project = {
   name: "vulkan_profiles",
-  version: "1.4.352",
+  version: "1.4.354",
   repository: "https://github.com/KhronosGroup/Vulkan-Profiles",
 };
 

--- a/packages/vulkan_tools/brioche.lock
+++ b/packages/vulkan_tools/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/KhronosGroup/Vulkan-Tools": {
-      "v1.4.352": "822a2d8efb2ec261295bf40bd17b60252823b459"
+      "v1.4.354": "ec6931a360d89d08f1c7578fa43958fb3829b10a"
     }
   }
 }

--- a/packages/vulkan_tools/project.bri
+++ b/packages/vulkan_tools/project.bri
@@ -14,7 +14,7 @@ import xorgproto from "xorgproto";
 
 export const project = {
   name: "vulkan_tools",
-  version: "1.4.352",
+  version: "1.4.354",
   repository: "https://github.com/KhronosGroup/Vulkan-Tools",
 };
 

--- a/packages/vulkan_utility_libraries/brioche.lock
+++ b/packages/vulkan_utility_libraries/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/KhronosGroup/Vulkan-Utility-Libraries": {
-      "v1.4.352": "28d3b5930a6da0e4f15040679d8b51dda0b29c86"
+      "v1.4.354": "8183a0b86632bf1107553eab1e69d7b85d455477"
     }
   }
 }

--- a/packages/vulkan_utility_libraries/project.bri
+++ b/packages/vulkan_utility_libraries/project.bri
@@ -4,7 +4,7 @@ import vulkanHeaders from "vulkan_headers";
 
 export const project = {
   name: "vulkan_utility_libraries",
-  version: "1.4.352",
+  version: "1.4.354",
   repository: "https://github.com/KhronosGroup/Vulkan-Utility-Libraries",
 };
 


### PR DESCRIPTION
Consolidated live updates for the Vulkan package family to v1.4.354. This bundles the four separate live-update PRs since the related packages should be kept in sync.

- vulkan_headers
- vulkan_utility_libraries
- vulkan_tools
- vulkan_profiles

Cherry-picked from:
- #5017
- #5020
- #5019
- #5018

cc @package-update-bot