### PR TITLE
feat(aws_sso_cli): add package

### DIFF
--- a/packages/aws_sso_cli/brioche.lock
+++ b/packages/aws_sso_cli/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/synfinatic/aws-sso-cli.git": {
+      "v2.3.1": "36a09df6a76bf0a02aa02a39a36fb2b655154626"
+    }
+  }
+}

--- a/packages/aws_sso_cli/project.bri
+++ b/packages/aws_sso_cli/project.bri
@@ -1,0 +1,57 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "aws_sso_cli",
+  version: "2.3.1",
+  repository: "https://github.com/synfinatic/aws-sso-cli.git",
+};
+
+// Retrieve the source directly from the GitHub repository and not from the Go
+// proxy. Since, the one from Go proxy does not include the latest releases.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function awsSsoCli(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      trimpath: true,
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `main.Version=${project.version}`,
+        "-X",
+        `main.Tag=v${project.version}`,
+      ],
+    },
+    path: "./cmd/aws-sso",
+    runnable: "bin/aws-sso",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    aws-sso version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(awsSsoCli)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `AWS SSO CLI Version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `aws_sso_cli`
- **Website / repository:** `https://github.com/synfinatic/aws-sso-cli`
- **Repology URL:** `https://repology.org/project/aws-sso-cli/versions`
- **Short description:** A powerful tool for using AWS Identity Center for the CLI and web console.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.11s
Result: eb1aed5e475b610fbb29e2e1796e3dc3fce7265c9313200854dc3cae830b02e7
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.03s
Running brioche-run
{
  "name": "aws_sso_cli",
  "version": "2.3.1",
  "repository": "https://github.com/synfinatic/aws-sso-cli.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.