### PR TITLE
feat(boring): add package

### DIFF
--- a/packages/boring/brioche.lock
+++ b/packages/boring/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/alebeck/boring/@v/v0.16.0.info": {
+      "type": "sha256",
+      "value": "393900853176df2c3021d11d7c19dd8213f7e0ae95c16a3b085e7293e18f78af"
+    },
+    "https://proxy.golang.org/github.com/alebeck/boring/@v/v0.16.0.zip": {
+      "type": "sha256",
+      "value": "4b8d3c8c6dd9e20cdf7dfada944ba86b00998525691780f05b9d0ac62ac3fdfd"
+    }
+  }
+}

--- a/packages/boring/project.bri
+++ b/packages/boring/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import { goBuild, goModuleManifest } from "go";
+
+export const project = {
+  name: "boring",
+  version: "0.16.0",
+  extra: {
+    moduleName: "github.com/alebeck/boring",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+const manifest = await goModuleManifest(
+  Brioche.download(
+    `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.info`,
+  ),
+);
+
+export default function boring(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/internal/buildinfo.Version=${project.version}`,
+        "-X",
+        `${project.extra.moduleName}/internal/buildinfo.Commit=${manifest.origin.hash}`,
+      ],
+    },
+    path: "./cmd/boring",
+    runnable: "bin/boring",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    boring version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(boring)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `boring ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `boring`
- **Website / repository:** `https://github.com/alebeck/boring`
- **Repology URL:** `https://repology.org/project/boring/versions`
- **Short description:** `Simple command-line SSH tunnel manager that just works`

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 3489156 (std/core/recipes/process.bri:240:14)
[3489156] boring 0.16.0
Process 3489156 ran in 0.03s
Build finished, completed 1 job in 1.55s
Result: 9e59e54ee1b8d83e5a6ec69406afea397a4045861b3b7495d9791c04d1fa95d1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 3498608 (std/runtime_utils.bri:49:6)
Process 3498608 ran in 0.04s
Build finished, completed 1 job in 9.02s
Running brioche-run
{
  "name": "boring",
  "version": "0.16.0",
  "extra": {
    "moduleName": "github.com/alebeck/boring"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.