### PR TITLE
feat(boringssl): add package

### DIFF
--- a/packages/boringssl/brioche.lock
+++ b/packages/boringssl/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/google/boringssl/releases/download/0.20260616.0/boringssl-0.20260616.0.tar.gz": {
+      "type": "sha256",
+      "value": "d1c599485fd1919d75ea2925af5fff81c1d5b21ab2f0d41fee1f788b1d917159"
+    }
+  }
+}

--- a/packages/boringssl/project.bri
+++ b/packages/boringssl/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "boringssl",
+  version: "0.20260616.0",
+  repository: "https://github.com/google/boringssl",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/boringssl-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function boringssl(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_TESTING: "OFF",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const src = std.directory({
+    "main.c": std.file(std.indoc`
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <openssl/crypto.h>
+
+      int main(void)
+      {
+          printf("%s", OpenSSL_version(OPENSSL_VERSION));
+
+          return EXIT_SUCCESS;
+      }
+    `),
+  });
+
+  const script = std.runBash`
+    gcc main.c -o main -lssl -lcrypto
+    ./main | tee "$BRIOCHE_OUTPUT"
+  `
+    .workDir(src)
+    .dependencies(std.toolchain, boringssl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = "BoringSSL";
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `boringssl`
- **Website / repository:** https://github.com/google/boringssl
- **Repology URL:** https://repology.org/project/boringssl/versions
- **Short description:** BoringSSL is a fork of OpenSSL designed to meet Google'"'"'s needs, used as the SSL library in Chrome/Chromium and Android.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 3500554 (std/core/recipes/process.bri:240:14)
[3500554] BoringSSL
Process 3500554 ran in 0.23s
Build finished, completed 1 job in 2.71s
Result: 7904e51a7c759cb1e8282f9cbe1fe52d93ef2ac757fa6a3c13f1905d06d9566a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 3500576 (std/runtime_utils.bri:49:6)
Process 3500576 ran in 0.02s
Build finished, completed 1 job in 3.89s
Running brioche-run
{
  "name": "boringssl",
  "version": "0.20260616.0",
  "repository": "https://github.com/google/boringssl"
}
```

</p>
</details>

## Implementation notes / special instructions

None.