### PR TITLE
feat(dagu): add package

### DIFF
--- a/packages/dagu/brioche.lock
+++ b/packages/dagu/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/dagucloud/dagu": {
+      "v2.8.2": "9b6a7ff13010b1253cb9b161bf901eb6f24ece71"
+    }
+  }
+}

--- a/packages/dagu/project.bri
+++ b/packages/dagu/project.bri
@@ -1,0 +1,55 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "dagu",
+  version: "2.8.2",
+  repository: "https://github.com/dagucloud/dagu",
+};
+
+// Retrieve the source directly from the GitHub repository and not from the Go
+// proxy. The Go module path lacks the required `/v2` suffix for v2.x
+// releases, so the Go proxy rejects the versioned zip archives.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function dagu(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    env: {
+      CGO_ENABLED: "0",
+    },
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.version=${project.version}`],
+    },
+    path: "./cmd",
+  })
+    .pipe(
+      // Rename binary file
+      (recipe) =>
+        recipe.insert("bin/dagu", recipe.get("bin/cmd")).remove("bin/cmd"),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/dagu"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    dagu version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dagu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `dagu`
- **Website / repository:** `https://github.com/dagucloud/dagu`
- **Repology URL:** `https://repology.org/project/dagu/versions`
- **Short description:** Compact, portable, and language-agnostic workflow engine for orchestrating command execution.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 3530586 (std/core/recipes/process.bri:240:14)
[3530586] 2.8.2
Process 3530586 ran in 0.07s
Build finished, completed 1 job in 2.92s
Result: 7e6df5ea215da8626f53a30d0fea00db63a4f5f3de50d68a0037cb667775d051
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 3531051 (std/runtime_utils.bri:49:6)
Process 3531051 ran in 0.01s
Build finished, completed 1 job in 4.03s
Running brioche-run
{
  "name": "dagu",
  "version": "2.8.2",
  "repository": "https://github.com/dagucloud/dagu"
}
```

</p>
</details>

## Implementation notes / special instructions

None.