### PR TITLE
Consolidated live updates: fizz, folly, mvfst

### DIFF
--- a/packages/fizz/brioche.lock
+++ b/packages/fizz/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.05.11.00.tar.gz": {
+    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.06.15.00.tar.gz": {
       "type": "sha256",
-      "value": "61268243fd017ddfc956627950783e2d2aa2aa21f253cd8d40c84340b0bb8e9e"
+      "value": "6f14e7c83ae846eb9f99f242cf1b6a89a9e065fac6982d06990523e7a2e10d6b"
     }
   }
 }

--- a/packages/fizz/project.bri
+++ b/packages/fizz/project.bri
@@ -15,7 +15,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "fizz",
-  version: "2026.05.11.00",
+  version: "2026.06.15.00",
   repository: "https://github.com/facebookincubator/fizz",
 };
 

--- a/packages/folly/brioche.lock
+++ b/packages/folly/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebook/folly/archive/refs/tags/v2026.05.11.00.tar.gz": {
+    "https://github.com/facebook/folly/archive/refs/tags/v2026.06.15.00.tar.gz": {
       "type": "sha256",
-      "value": "a0b21fc5fda9a4b0904d680a4970c34590ece65271cc1a91e0e49b4271f2fcad"
+      "value": "50c9140edea532bc3762c5615eaa5fb908796d4ff7dc99a4d8a1b0aae0ee90e2"
     }
   }
 }

--- a/packages/folly/project.bri
+++ b/packages/folly/project.bri
@@ -15,7 +15,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "folly",
-  version: "2026.05.11.00",
+  version: "2026.06.15.00",
   repository: "https://github.com/facebook/folly",
 };
 

--- a/packages/mvfst/brioche.lock
+++ b/packages/mvfst/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.05.11.00.tar.gz": {
+    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.06.15.00.tar.gz": {
       "type": "sha256",
-      "value": "eb466c8189032c48a558de56c447fd3aff8713e0e652e9374e8b0f8e37d942d9"
+      "value": "647934c11a5f6eb5276870ef31985f13088df234a51ea6561440e9c990ae53a1"
     }
   }
 }

--- a/packages/mvfst/project.bri
+++ b/packages/mvfst/project.bri
@@ -16,7 +16,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "mvfst",
-  version: "2026.05.11.00",
+  version: "2026.06.15.00",
   repository: "https://github.com/facebook/mvfst",
 };
 


### PR DESCRIPTION
This PR consolidates the following live update PRs into a single PR:

- #4887: [mvfst] (Live update)
- #4784: [folly] (Live update)  
- #4781: [fizz] (Live update)

All changes are from the same workflow run (Live updates #73) and involve version bumps for these packages.