### PR TITLE
Consolidate live updates: cmake, openssl, python

### DIFF
--- a/packages/cmake/brioche.lock
+++ b/packages/cmake/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2.tar.gz": {
+    "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3.tar.gz": {
       "type": "sha256",
-      "value": "b0231eb39b3c3cabdc568c619df78208a7bd95ea10c9b2236d61218bac1b367d"
+      "value": "cba4bb7a44edf2877bb6f059932896383babe435b3a8c3b5df48b4aa41c9bb85"
     }
   },
   "git_refs": {

--- a/packages/cmake/project.bri
+++ b/packages/cmake/project.bri
@@ -4,7 +4,7 @@ import curl from "curl";
 
 export const project = {
   name: "cmake",
-  version: "4.3.2",
+  version: "4.3.3",
   repository: "https://github.com/Kitware/CMake",
 };
 

--- a/packages/openssl/brioche.lock
+++ b/packages/openssl/brioche.lock
@@ -1,13 +1,13 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz": {
+    "https://github.com/openssl/openssl/releases/download/openssl-3.6.3/openssl-3.6.3.tar.gz": {
       "type": "sha256",
-      "value": "aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f"
+      "value": "243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1"
     },
-    "https://github.com/openssl/openssl/releases/download/openssl-4.0.0/openssl-4.0.0.tar.gz": {
+    "https://github.com/openssl/openssl/releases/download/openssl-4.0.1/openssl-4.0.1.tar.gz": {
       "type": "sha256",
-      "value": "c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac"
+      "value": "2db3f3a0d6ea4b59e1f094ace2c8cd536dffb87cdc39084c5afa1e6f7f37dd09"
     }
   }
 }

--- a/packages/openssl/project.bri
+++ b/packages/openssl/project.bri
@@ -3,12 +3,12 @@ import { cmakeSanitizePaths } from "cmake";
 
 export const project = {
   name: "openssl",
-  version: "4.0.0",
+  version: "4.0.1",
   repository: "https://github.com/openssl/openssl",
   extra: {
     otherVersions: {
-      "4": "4.0.0",
-      "3": "3.6.2",
+      "4": "4.0.1",
+      "3": "3.6.3",
     },
   },
 } as const;

--- a/packages/python/brioche.lock
+++ b/packages/python/brioche.lock
@@ -5,13 +5,13 @@
       "type": "sha256",
       "value": "c08bc65a81971c1dd5783182826503369466c7e67374d1646519adf05207b684"
     },
-    "https://www.python.org/ftp/python/3.13.13/Python-3.13.13.tar.xz": {
+    "https://www.python.org/ftp/python/3.13.14/Python-3.13.14.tar.xz": {
       "type": "sha256",
-      "value": "2ab91ff401783ccca64f75d10c882e957bdfd60e2bf5a72f8421793729b78a71"
+      "value": "639e43243c620a308f968213df9e00f2f8f62332f7adbaa7a7eeb9783057c690"
     },
-    "https://www.python.org/ftp/python/3.14.5/Python-3.14.5.tar.xz": {
+    "https://www.python.org/ftp/python/3.14.6/Python-3.14.6.tar.xz": {
       "type": "sha256",
-      "value": "7e32597b99e5d9a39abed35de4693fa169df3e5850d4c334337ffd6a19a36db6"
+      "value": "143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63"
     }
   }
 }

--- a/packages/python/project.bri
+++ b/packages/python/project.bri
@@ -6,12 +6,12 @@ import sqlite from "sqlite";
 
 export const project = {
   name: "python",
-  version: "3.14.5",
+  version: "3.14.6",
   repository: "https://github.com/python/cpython",
   extra: {
     otherVersions: {
-      "3.14": "3.14.5",
-      "3.13": "3.13.13",
+      "3.14": "3.14.6",
+      "3.13": "3.13.14",
       "3.12": "3.12.13",
     },
   },


### PR DESCRIPTION
Consolidated live update PRs:
- #4740 (cmake)
- #4911 (openssl)  
- #4939 (python)

These were cherry-picked into a single consolidated PR.