### PR TITLE
feat(uv_build): add package

### DIFF
--- a/packages/uv_build/brioche.lock
+++ b/packages/uv_build/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/uv-build/0.11.28/download": {
+      "type": "sha256",
+      "value": "e0968a90eda576bcb00ff55d5ae37f678d08fb6e6a8eb5611d10b0f30f0c290e"
+    }
+  }
+}

--- a/packages/uv_build/project.bri
+++ b/packages/uv_build/project.bri
@@ -1,0 +1,44 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "uv_build",
+  version: "0.11.28",
+  extra: {
+    crateName: "uv-build",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function uvBuild(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/uv-build",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    uv-build --help 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(uvBuild)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** 
- **Website / repository:** https://github.com/astral-sh/uv
- **Repology URL:** https://repology.org/project/uv-build/versions
- **Short description:** A slimmed-down version of uv containing only the build backend

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.95s
Result: 6a0dc963ee0d0ca81275b2ba83b5c2228c21c2c378093cc3992b28d3d15de689
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.32s
Running brioche-run
{
  "name": "uv_build",
  "version": "0.11.28",
  "extra": {
    "crateName": "uv-build"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.