### PR TITLE
feat(crane): add package

### DIFF
--- a/packages/crane/brioche.lock
+++ b/packages/crane/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/google/go-containerregistry/@v/v0.21.7.zip": {
+      "type": "sha256",
+      "value": "70c92eaefc68579adcd49cd95cdfab663b6fd82bf83ea40eb0e2c8ce09c0b8e6"
+    }
+  }
+}

--- a/packages/crane/project.bri
+++ b/packages/crane/project.bri
@@ -1,0 +1,52 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "crane",
+  version: "0.21.7",
+  extra: {
+    moduleName: "github.com/google/go-containerregistry",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(3);
+
+export default function crane(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/crane",
+    buildParams: {
+      ldflags: [
+        "-s",
+        "-w",
+        "-X",
+        `${project.extra.moduleName}/cmd/crane/cmd.Version=${project.version}`,
+      ],
+    },
+    runnable: "bin/crane",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    crane version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(crane)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** crane
- **Website / repository:** https://github.com/google/go-containerregistry
- **Repology URL:** https://repology.org/project/crane/versions
- **Short description:** Tool for interacting with remote images and registries

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.91s
Result: 0721f19aa61de79fa9e12324458b651262aabf4282f2eedb6b7ae5e49918e477
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 674683 (std/runtime_utils.bri:49:6)
Process 674683 ran in 0.01s
Build finished, completed 1 job in 4.92s
Running brioche-run
{
  "name": "crane",
  "version": "0.21.7",
  "extra": {
    "moduleName": "github.com/google/go-containerregistry"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.