### PR TITLE
feat(cloudflared): add package

### DIFF
--- a/packages/cloudflared/brioche.lock
+++ b/packages/cloudflared/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/cloudflare/cloudflared": {
+      "2026.7.2": "8679787525edc8575b2948a7c4a50b6292c6d426"
+    }
+  }
+}

--- a/packages/cloudflared/project.bri
+++ b/packages/cloudflared/project.bri
@@ -1,0 +1,49 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "cloudflared",
+  version: "2026.7.2",
+  repository: "https://github.com/cloudflare/cloudflared",
+};
+
+// Retrieve the source directly from the GitHub repository and not from the Go
+// proxy. Since, the one from Go proxy doesn't follow the same tagging scheme.
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function cloudflared(): std.Recipe<std.Directory> {
+  return goBuild({
+    source,
+    path: "./cmd/cloudflared",
+    buildParams: {
+      ldflags: ["-s", "-w", "-X", `main.Version=${project.version}`],
+    },
+    runnable: "bin/cloudflared",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    cloudflared --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cloudflared)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** cloudflared
- **Website / repository:** https://github.com/cloudflare/cloudflared
- **Repology URL:** https://repology.org/project/cloudflared/versions
- **Short description:** Cloudflare Tunnel client (formerly Argo Tunnel)

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.92s
Result: 2398e41514ce2e930c8609ff2eacc45d1c0ec01268b9fa11c5d1a4948c37b792
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.84s
Running brioche-run
{
  "name": "cloudflared",
  "version": "2026.7.2",
  "repository": "https://github.com/cloudflare/cloudflared"
}
```

</p>
</details>

## Implementation notes / special instructions

None.