### PR TITLE
feat(libslirp): add package

### DIFF
--- a/packages/libslirp/brioche.lock
+++ b/packages/libslirp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.9.3/libslirp-v4.9.3.tar.bz2": {
+      "type": "sha256",
+      "value": "c82e22c73bdc3f2c038e538d4f0c9c2166defb2402212d61bb7cb1b530ba952f"
+    }
+  }
+}

--- a/packages/libslirp/project.bri
+++ b/packages/libslirp/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import glib from "glib";
+import { mesonBuild } from "meson";
+import ninja from "ninja";
+import pcre2 from "pcre2";
+
+export const project = {
+  name: "libslirp",
+  version: "4.9.3",
+  repository: "https://gitlab.freedesktop.org/slirp/libslirp",
+};
+
+const source = Brioche.download(
+  `${project.repository}/-/archive/v${project.version}/libslirp-v${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libslirp(): std.Recipe<std.Directory> {
+  return mesonBuild({
+    source,
+    dependencies: [std.toolchain, glib, ninja, pcre2],
+    set: {
+      default_library: "both",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion slirp | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libslirp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabReleases({
+    gitlabUrl: "https://gitlab.freedesktop.org",
+    project,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libslirp`
- **Website / repository:** https://gitlab.freedesktop.org/slirp/libslirp
- **Repology URL:** https://repology.org/project/libslirp/versions
- **Short description:** User-space networking library used by virtual machines, containers, and various tools

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.10s
Result: d8c9fabb20bedf4ef12757949a017c7136489749277c4bcaef3bae84e2b9f4da
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.42s
Running brioche-run
{
  "name": "libslirp",
  "version": "4.9.3",
  "repository": "https://gitlab.freedesktop.org/slirp/libslirp"
}
```

</p>
</details>

## Implementation notes / special instructions

None.