### PR TITLE
feat(crun): add package

### DIFF
--- a/packages/crun/brioche.lock
+++ b/packages/crun/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/containers/crun/releases/download/1.28/crun-1.28.tar.gz": {
+      "type": "sha256",
+      "value": "eb8fe73ffe44d868b14bb94fa6c295bd57e8bf023de43b61579da826c07cc406"
+    }
+  }
+}

--- a/packages/crun/project.bri
+++ b/packages/crun/project.bri
@@ -1,0 +1,61 @@
+import * as std from "std";
+import blake3 from "blake3";
+import jsonC from "json_c";
+import libcap from "libcap";
+import libseccomp from "libseccomp";
+import python from "python";
+
+export const project = {
+  name: "crun",
+  version: "1.28",
+  repository: "https://github.com/containers/crun",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/${project.version}/crun-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function crun(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --disable-systemd
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, blake3, jsonC, libcap, libseccomp, python)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/crun"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    crun --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(crun)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `crun version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `crun`
- **Website / repository:** https://github.com/containers/crun
- **Repology URL:** https://repology.org/project/crun/versions
- **Short description:** A fast and lightweight fully featured OCI Container Runtime written in C

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 719170 (std/core/recipes/process.bri:240:14)
[719170] crun version 1.28
[719170] commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc
[719170] spec: 1.0.0
[719170] +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +JSON_C
Process 719170 ran in 0.02s
Build finished, completed 1 job in 1.47s
Result: d336a4af5a26ceed324cbb19828c45d847602a3c05699af97d25e98336ccf5ac
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.63s
Running brioche-run
{
  "name": "crun",
  "version": "1.28",
  "repository": "https://github.com/containers/crun"
}
```

</p>
</details>

## Implementation notes / special instructions

- Built with `--disable-systemd` as the `systemd` package is not available in brioche-packages
- CRIU support is not enabled (criu package not available)
