### PR TITLE
feat(libmnl): add package

### DIFF
--- a/packages/libmnl/brioche.lock
+++ b/packages/libmnl/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libmnl/libmnl-1.0.5.tar.bz2": {
+      "type": "sha256",
+      "value": "274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525"
+    }
+  }
+}

--- a/packages/libmnl/project.bri
+++ b/packages/libmnl/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "libmnl",
+  version: "1.0.5",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libmnl/libmnl-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libmnl(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libmnl | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libmnl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libmnl
+      | lines
+      | where ($it | str contains "libmnl") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="libmnl-(?<version>.+)\\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libmnl
- **Website / repository:** https://github.com/justmirror/libmnl
- **Repology URL:** https://repology.org/project/libmnl/versions
- **Short description:** A minimalistic user-space library oriented to Netlink developers

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.90s
Result: a826ee49324f2bc5d6d467db7ddc18630e8ea541eb7c603c471ab475f696f50a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.95s
Running brioche-run
{
  "name": "libmnl",
  "version": "1.0.5"
}
```

</p>
</details>

## Implementation notes / special instructions

None.