### PR TITLE
feat(libnfnetlink): add package

### DIFF
--- a/packages/libnfnetlink/brioche.lock
+++ b/packages/libnfnetlink/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnfnetlink/libnfnetlink-1.0.2.tar.bz2": {
+      "type": "sha256",
+      "value": "b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376"
+    }
+  }
+}

--- a/packages/libnfnetlink/project.bri
+++ b/packages/libnfnetlink/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "libnfnetlink",
+  version: "1.0.2",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnfnetlink/libnfnetlink-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libnfnetlink(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnfnetlink | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnfnetlink)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnfnetlink
+      | lines
+      | where ($it | str contains "libnfnetlink") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="libnfnetlink-(?<version>.+)\\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libnfnetlink`
- **Website / repository:** `https://netfilter.org/pub/libnfnetlink/`
- **Repology URL:** `https://repology.org/project/libnfnetlink/versions`
- **Short description:** Low-level userspace library for netfilter-related kernel/userspace communication

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.93s
Result: ced054e67be617fcbdbb0ca09ea39eb380f90b63aa98f9351b5897ca0f597e3e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.93s
Running brioche-run
{
  "name": "libnfnetlink",
  "version": "1.0.2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.