### PR TITLE
feat(slirp4netns): add package

### DIFF
--- a/packages/slirp4netns/brioche.lock
+++ b/packages/slirp4netns/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/rootless-containers/slirp4netns/archive/refs/tags/v1.3.4.tar.gz": {
+      "type": "sha256",
+      "value": "c8e445deded09c5e777af3c599f808b3d0cbfeab482d9e76746df0926234200d"
+    }
+  }
+}

--- a/packages/slirp4netns/project.bri
+++ b/packages/slirp4netns/project.bri
@@ -1,0 +1,54 @@
+import * as std from "std";
+import glib from "glib";
+import libcap from "libcap";
+import libslirp from "libslirp";
+import libseccomp from "libseccomp";
+import pcre2 from "pcre2";
+
+export const project = {
+  name: "slirp4netns",
+  version: "1.3.4",
+  repository: "https://github.com/rootless-containers/slirp4netns",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/v${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function slirp4netns(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./autogen.sh
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, glib, libcap, libseccomp, libslirp, pcre2)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/slirp4netns"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    slirp4netns --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(slirp4netns)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** slirp4netns
- **Website / repository:** https://github.com/rootless-containers/slirp4netns
- **Repology URL:** https://repology.org/project/slirp4netns/versions
- **Short description:** User-mode networking for unprivileged network namespaces

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.16s
Result: 0afa75be1153c326860297a35e06e8e71b3f1366502815c976b49bbfd01d917a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.03s
Running brioche-run
{
  "name": "slirp4netns",
  "version": "1.3.4",
  "repository": "https://github.com/rootless-containers/slirp4netns"
}
```

</p>
</details>

## Implementation notes / special instructions

None.