### PR TITLE
feat(rootlesskit): add package

### DIFF
--- a/packages/rootlesskit/brioche.lock
+++ b/packages/rootlesskit/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://proxy.golang.org/github.com/rootless-containers/rootlesskit/v3/@v/v3.0.2.zip": {
+      "type": "sha256",
+      "value": "ec40c88a178b51e4c72e2ac709f1a6c4093aabfb9fdd70ada369532f59ceddcf"
+    }
+  }
+}

--- a/packages/rootlesskit/project.bri
+++ b/packages/rootlesskit/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+import { goBuild } from "go";
+
+export const project = {
+  name: "rootlesskit",
+  version: "3.0.2",
+  extra: {
+    moduleName: "github.com/rootless-containers/rootlesskit/v3",
+  },
+};
+
+const source = Brioche.download(
+  `https://proxy.golang.org/${project.extra.moduleName}/@v/v${project.version}.zip`,
+)
+  .unarchive("zip")
+  .peel(4);
+
+export default function rootlesskit(): std.Recipe<std.Directory> {
+  // List of binaries to build
+  const binaries = ["rootlesskit", "rootlessctl", "rootlesskit-docker-proxy"];
+
+  // Build all
+  const builds = binaries.map((binary) =>
+    goBuild({
+      source,
+      path: `./cmd/${binary}`,
+      buildParams: {
+        ldflags: ["-s", "-w"],
+      },
+    }),
+  );
+
+  return std
+    .merge(...builds)
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/rootlesskit"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    rootlesskit --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(rootlesskit)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `rootlesskit version ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGoModules({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** rootlesskit
- **Website / repository:** https://github.com/rootless-containers/rootlesskit
- **Repology URL:** https://repology.org/project/rootlesskit/versions
- **Short description:** Linux-native implementation of 'fake root' using user_namespaces for running Docker and Kubernetes as an unprivileged user

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.74s
Result: f672bc06cd75b6474e32e98c5f59e8d11ddbf5e82e4a43546a88f42e955fccde
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 758438 (std/runtime_utils.bri:49:6)
Process 758438 ran in 0.01s
Build finished, completed 1 job in 4.86s
Running brioche-run
{
  "name": "rootlesskit",
  "version": "3.0.2",
  "extra": {
    "moduleName": "github.com/rootless-containers/rootlesskit/v3"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.
