### PR TITLE
feat(libnetfilter_conntrack): add package

### DIFF
--- a/packages/libnetfilter_conntrack/brioche.lock
+++ b/packages/libnetfilter_conntrack/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnetfilter_conntrack/libnetfilter_conntrack-1.1.1.tar.xz": {
+      "type": "sha256",
+      "value": "769d3eaf57fa4fbdb05dd12873b6cb9a5be7844d8937e222b647381d44284820"
+    }
+  }
+}

--- a/packages/libnetfilter_conntrack/project.bri
+++ b/packages/libnetfilter_conntrack/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnfnetlink from "libnfnetlink";
+
+export const project = {
+  name: "libnetfilter_conntrack",
+  version: "1.1.1",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnetfilter_conntrack/libnetfilter_conntrack-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function libnetfilterConntrack(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnfnetlink)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnetfilter_conntrack | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnetfilterConntrack)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnetfilter_conntrack
+      | lines
+      | where ($it | str contains "libnetfilter_conntrack") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="libnetfilter_conntrack-(?<version>[\\d.]+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libnetfilter_conntrack
- **Website / repository:** https://netfilter.org/pub/libnetfilter_conntrack/
- **Repology URL:** https://repology.org/project/libnetfilter_conntrack/versions
- **Short description:** Userspace library providing interface to the in-kernel connection tracking system

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 786223 (std/core/recipes/process.bri:240:14)
[786223] 1.1.1
Process 786223 ran in 0.01s
Build finished, completed 1 job in 1.33s
Result: 66c8394a113244e451081a1ac5641bd4f964b242066c0896768c585b9292fe70
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.29s
Running brioche-run
{
  "name": "libnetfilter_conntrack",
  "version": "1.1.1"
}
```

</p>
</details>

## Implementation notes / special instructions

None.