### PR TITLE
feat(nftables): add package

### DIFF
--- a/packages/nftables/brioche.lock
+++ b/packages/nftables/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.netfilter.org/pub/nftables/nftables-1.1.6.tar.xz": {
+      "type": "sha256",
+      "value": "372931bda8556b310636a2f9020adc710f9bab66f47efe0ce90bff800ac2530c"
+    }
+  }
+}

--- a/packages/nftables/project.bri
+++ b/packages/nftables/project.bri
@@ -1,0 +1,79 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import jansson from "jansson";
+import libedit from "libedit";
+import libmnl from "libmnl";
+import libnftnl from "libnftnl";
+
+export const project = {
+  name: "nftables",
+  version: "1.1.6",
+};
+
+const source = Brioche.download(
+  `https://www.netfilter.org/pub/nftables/nftables-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function nftables(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, jansson, libedit, libmnl, libnftnl)
+    .env({
+      // Fix a syntax error 'Bad for loop variable' in configure script
+      CONFIG_SHELL: "bash",
+    })
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/nft"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    nft --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nftables)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `nftables v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/nftables
+      | lines
+      | where ($it | str contains "nftables") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="nftables-(?<version>.+)\.tar\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** nftables
- **Website / repository:** https://www.netfilter.org/projects/nftables/
- **Repology URL:** https://repology.org/project/nftables/versions
- **Short description:** Netfilter nftables packet filtering framework

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.74s
Result: 29fb163e372479fc390ee63fb0ffd60a750b08563c28cbe0debe2d9816afe284
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 818274 (std/runtime_utils.bri:49:6)
Process 818274 ran in 0.01s
Build finished, completed 1 job in 4.75s
Running brioche-run
{
  "name": "nftables",
  "version": "1.1.6"
}
```

</p>
</details>

## Implementation notes / special instructions

None.