### PR TITLE
feat(libnetfilter_log): add package

### DIFF
--- a/packages/libnetfilter_log/brioche.lock
+++ b/packages/libnetfilter_log/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnetfilter_log/libnetfilter_log-1.0.2.tar.bz2": {
+      "type": "sha256",
+      "value": "e3f408575614d849e4726b45e90c7ebb0e6744b04859555a9ce6ec40744ffeea"
+    }
+  }
+}

--- a/packages/libnetfilter_log/project.bri
+++ b/packages/libnetfilter_log/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnfnetlink from "libnfnetlink";
+
+export const project = {
+  name: "libnetfilter_log",
+  version: "1.0.2",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnetfilter_log/libnetfilter_log-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libnetfilterLog(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnfnetlink)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnetfilter_log | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnetfilterLog)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnetfilter_log
+      | lines
+      | where ($it | str contains "libnetfilter_log") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum")) and (not ($it | str contains "sha256sum"))
+      | parse --regex '<a href="libnetfilter_log-(?<version>[\\d.]+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libnetfilter_log
- **Website / repository:** https://netfilter.org/pub/libnetfilter_log/
- **Repology URL:** https://repology.org/project/libnetfilter_log/versions
- **Short description:** Netfilter logging library

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 843777 (std/core/recipes/process.bri:240:14)
[843777] 1.0.2
Process 843777 ran in 0.01s
Build finished, completed 1 job in 2.03s
Result: ced054e67be617fcbdbb0ca09ea39eb380f90b63aa98f9351b5897ca0f597e3e
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.39s
Running brioche-run
{
  "name": "libnetfilter_log",
  "version": "1.0.2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.