### PR TITLE
feat(libnetfilter_acct): add package

### DIFF
--- a/packages/libnetfilter_acct/brioche.lock
+++ b/packages/libnetfilter_acct/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnetfilter_acct/libnetfilter_acct-1.0.3.tar.bz2": {
+      "type": "sha256",
+      "value": "4250ceef3efe2034f4ac05906c3ee427db31b9b0a2df41b2744f4bf79a959a1a"
+    }
+  }
+}

--- a/packages/libnetfilter_acct/project.bri
+++ b/packages/libnetfilter_acct/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnfnetlink from "libnfnetlink";
+
+export const project = {
+  name: "libnetfilter_acct",
+  version: "1.0.3",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnetfilter_acct/libnetfilter_acct-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libnetfilterAcct(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnfnetlink)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnetfilter_acct | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnetfilterAcct)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnetfilter_acct
+      | lines
+      | where ($it | str contains "libnetfilter_acct") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="libnetfilter_acct-(?<version>[\\d.]+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libnetfilter_acct
- **Website / repository:** https://netfilter.org/pub/libnetfilter_acct/
- **Repology URL:** https://repology.org/project/libnetfilter_acct/versions
- **Short description:** Netfilter accounting library

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 843798 (std/core/recipes/process.bri:240:14)
[843798] 1.0.3
Process 843798 ran in 0.01s
Build finished, completed 1 job in 2.32s
Result: ac7bcba313ae30f6eda14fc4f1c8293d650ab21b71fbcff3ac71195d44c083a2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.59s
Running brioche-run
{
  "name": "libnetfilter_acct",
  "version": "1.0.3"
}
```

</p>
</details>

## Implementation notes / special instructions

None.