### PR TITLE
feat(libnetfilter_queue): add package

### DIFF
--- a/packages/libnetfilter_queue/brioche.lock
+++ b/packages/libnetfilter_queue/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnetfilter_queue/libnetfilter_queue-1.0.5.tar.bz2": {
+      "type": "sha256",
+      "value": "f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5"
+    }
+  }
+}

--- a/packages/libnetfilter_queue/project.bri
+++ b/packages/libnetfilter_queue/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnfnetlink from "libnfnetlink";
+
+export const project = {
+  name: "libnetfilter_queue",
+  version: "1.0.5",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnetfilter_queue/libnetfilter_queue-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libnetfilterQueue(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnfnetlink)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnetfilter_queue | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnetfilterQueue)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnetfilter_queue
+      | lines
+      | where ($it | str contains "libnetfilter_queue") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum")) and (not ($it | str contains "sha256sum"))
+      | parse --regex '<a href="libnetfilter_queue-(?<version>[\\d.]+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libnetfilter_queue
- **Website / repository:** https://netfilter.org/pub/libnetfilter_queue/
- **Repology URL:** https://repology.org/project/libnetfilter_queue/versions
- **Short description:** Netfilter queueing library

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 844072 (std/core/recipes/process.bri:240:14)
[844072] 1.0.5
Process 844072 ran in 0.01s
Build finished, completed 1 job in 2.39s
Result: a826ee49324f2bc5d6d467db7ddc18630e8ea541eb7c603c471ab475f696f50a
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 844106 (std/runtime_utils.bri:49:6)
Process 844106 ran in 0.01s
Build finished, completed 1 job in 4.19s
Running brioche-run
{
  "name": "libnetfilter_queue",
  "version": "1.0.5"
}
```

</p>
</details>

## Implementation notes / special instructions

None.