### PR TITLE
feat(libnetfilter_cthelper): add package

### DIFF
--- a/packages/libnetfilter_cthelper/brioche.lock
+++ b/packages/libnetfilter_cthelper/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/libnetfilter_cthelper/libnetfilter_cthelper-1.0.1.tar.bz2": {
+      "type": "sha256",
+      "value": "14073d5487233897355d3ff04ddc1c8d03cc5ba8d2356236aa88161a9f2dc912"
+    }
+  }
+}

--- a/packages/libnetfilter_cthelper/project.bri
+++ b/packages/libnetfilter_cthelper/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnfnetlink from "libnfnetlink";
+
+export const project = {
+  name: "libnetfilter_cthelper",
+  version: "1.0.1",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/libnetfilter_cthelper/libnetfilter_cthelper-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function libnetfilterCthelper(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnfnetlink)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libnetfilter_cthelper | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libnetfilterCthelper)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/libnetfilter_cthelper
+      | lines
+      | where ($it | str contains "libnetfilter_cthelper") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum")) and (not ($it | str contains "sha256sum"))
+      | parse --regex '<a href="libnetfilter_cthelper-(?<version>[\\d.]+)\.tar\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libnetfilter_cthelper
- **Website / repository:** https://netfilter.org/pub/libnetfilter_cthelper/
- **Repology URL:** https://repology.org/project/libnetfilter_cthelper/versions
- **Short description:** Netfilter connection tracking helper library

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 844062 (std/core/recipes/process.bri:240:14)
[844062] 1.0.1
Process 844062 ran in 0.02s
Build finished, completed 1 job in 2.11s
Result: 1fcc694c3303cc3e10b613728223c767dba7da7625201d0af70a8a9113d1a899
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 844092 (std/runtime_utils.bri:49:6)
Process 844092 ran in 0.01s
Build finished, completed 1 job in 3.97s
Running brioche-run
{
  "name": "libnetfilter_cthelper",
  "version": "1.0.1"
}
```

</p>
</details>

## Implementation notes / special instructions

None.