### PR TITLE
feat(busybox): add package

### DIFF
--- a/packages/busybox/brioche.lock
+++ b/packages/busybox/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://busybox.net/downloads/busybox-1.38.0.tar.bz2": {
+      "type": "sha256",
+      "value": "34f9ea6ff8636f2c9241153b9114eefa9e65674a45318ae1ef95bb5f31c53bb2"
+    }
+  }
+}

--- a/packages/busybox/project.bri
+++ b/packages/busybox/project.bri
@@ -1,0 +1,63 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "busybox",
+  version: "1.38.0",
+};
+
+const source = Brioche.download(
+  `https://busybox.net/downloads/busybox-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function busybox(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make defconfig
+    make -j "$(nproc)"
+    make CONFIG_PREFIX="$BRIOCHE_OUTPUT" install
+
+    # Manual installation
+    cp busybox "$BRIOCHE_OUTPUT/bin/busybox"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/busybox"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    busybox | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(busybox)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `BusyBox v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://busybox.net/downloads/
+      | lines
+      | where ($it | str contains "busybox-") and ($it | str contains ".tar.bz2") and (not ($it | str contains ".sha256")) and (not ($it | str contains ".sig"))
+      | parse --regex 'href="busybox-(?<version>[\\d.]+)\.tar\.bz2">'
+      | sort-by version --natural --reverse
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** busybox
- **Website / repository:** https://github.com/mirror/busybox
- **Repology URL:** https://repology.org/project/busybox/versions
- **Short description:** BusyBox combines tiny versions of many common UNIX utilities into a single small executable, optimized for size and limited resources

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.75s
Result: 972b4b6867a450b388487a2cc1f6a024fe9169cb6cd06cf64e0b5f85f4567819
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.55s
Running brioche-run
{
  "name": "busybox",
  "version": "1.38.0"
}
```

</p>
</details>

## Implementation notes / special instructions

None.