### PR TITLE
feat(protobuf_c): add package

### DIFF
--- a/packages/protobuf_c/brioche.lock
+++ b/packages/protobuf_c/brioche.lock
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/protobuf-c/protobuf-c/commit/d39f001b4578966600de0aaf7fc665eec6e057e5.patch": {
+      "type": "sha256",
+      "value": "bf70df90f83d18fa2d4f2415378aa64e27ddaa8d1334deab2fde0407035dae90"
+    },
+    "https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.2/protobuf-c-1.5.2.tar.gz": {
+      "type": "sha256",
+      "value": "e2c86271873a79c92b58fef7ebf8de1aa0df4738347a8bd5d4e65a80a16d0d24"
+    }
+  }
+}

--- a/packages/protobuf_c/project.bri
+++ b/packages/protobuf_c/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import abseilCpp from "abseil_cpp";
+import protobuf from "protobuf";
+
+export const project = {
+  name: "protobuf_c",
+  version: "1.5.2",
+  repository: "https://github.com/protobuf-c/protobuf-c",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/protobuf-c-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel()
+  .pipe((source) =>
+    // Fix compilation against protobuf v34+.
+    // https://github.com/protobuf-c/protobuf-c/pull/797
+    std.applyPatch({
+      source,
+      patch: Brioche.download(
+        `${project.repository}/commit/d39f001b4578966600de0aaf7fc665eec6e057e5.patch`,
+      ),
+      strip: 1,
+    }),
+  );
+
+export default function protobufC(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, abseilCpp, protobuf)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/protoc-c"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libprotobuf-c | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, protobufC)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** protobuf_c
- **Website / repository:** https://github.com/protobuf-c/protobuf-c
- **Repology URL:** https://repology.org/project/protobuf_c/versions
- **Short description:** Protocol Buffers implementation in C

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.97s
Result: 92576f8ef62f29825147a587cdb7c70a10a101e220438d19e3c8301a44574a43
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.58s
Running brioche-run
{
  "name": "protobuf_c",
  "version": "1.5.2",
  "repository": "https://github.com/protobuf-c/protobuf-c"
}
```

</p>
</details>

## Implementation notes / special instructions

None.