### PR TITLE
feat(libbpf): add package

### DIFF
--- a/packages/libbpf/brioche.lock
+++ b/packages/libbpf/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/libbpf/libbpf": {
+      "v1.7.0": "f5dcbae736e5d7f83a35718e01be1a8e3010fa39"
+    }
+  }
+}

--- a/packages/libbpf/project.bri
+++ b/packages/libbpf/project.bri
@@ -1,0 +1,58 @@
+import * as std from "std";
+
+export const project = {
+  name: "libbpf",
+  version: "1.7.0",
+  repository: "https://github.com/libbpf/libbpf",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+});
+
+export default function libbpf(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -C src -j "$(nproc)"
+    make -C src install DESTDIR="$BRIOCHE_OUTPUT" PREFIX=/
+
+    # Create relative symlinks for lib64 contents to lib folder
+    ln --symbolic --relative "$BRIOCHE_OUTPUT"/lib64/* "$BRIOCHE_OUTPUT/lib/"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        lib: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libbpf | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libbpf)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libbpf
- **Website / repository:** https://github.com/libbpf/libbpf
- **Repology URL:** https://repology.org/project/libbpf/versions
- **Short description:** A C-based library for interacting with the Linux kernel's eBPF subsystem

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.74s
Result: 14caba863abdf7ca866203ef1b21bc8ea4c01f0848a8da2346272299f72e7bce
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.21s
Running brioche-run
{
  "name": "libbpf",
  "version": "1.7.0",
  "repository": "https://github.com/libbpf/libbpf"
}
```

</p>
</details>

## Implementation notes / special instructions

None.