### PR TITLE
feat(cargo_psp): add package

### DIFF
--- a/packages/cargo_psp/brioche.lock
+++ b/packages/cargo_psp/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/cargo-psp/0.2.9/download": {
+      "type": "sha256",
+      "value": "acf9360909360d639034fc22f1c1957b3e2a507d8a04804c20508c8024d4a1ae"
+    }
+  }
+}

--- a/packages/cargo_psp/project.bri
+++ b/packages/cargo_psp/project.bri
@@ -1,0 +1,45 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+
+export const project = {
+  name: "cargo_psp",
+  version: "0.2.9",
+  extra: {
+    crateName: "cargo-psp",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function cargoPsp(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    runnable: "bin/cargo-psp",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // Do not directly use 'cargo-psp' to obtain package version
+  // since it requires a Rust nightly toolchain
+  const script = std.runBash`
+    pack-pbp --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(cargoPsp)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `pack-pbp 0.1`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** cargo_psp
- **Website / repository:** https://github.com/overdrivenpotato/rust-psp
- **Repology URL:** https://repology.org/project/cargo-psp/versions
- **Short description:**  wrapper for creating Sony PSP executables

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x]  method added.
- [x]  method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>



</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>



</p>
</details>

## Implementation notes / special instructions

The  binary requires a Rust nightly toolchain when run directly, so the test function uses the  binary instead to verify the package builds correctly.
