### PR TITLE
feat(libpqxx): add package

### DIFF
--- a/packages/libpqxx/brioche.lock
+++ b/packages/libpqxx/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/jtv/libpqxx": {
+      "8.0.2": "92e7d64a3ee91abcecbd5182096a8d8d36de12c0"
+    }
+  }
+}

--- a/packages/libpqxx/project.bri
+++ b/packages/libpqxx/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import postgresql from "postgresql";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libpqxx",
+  version: "8.0.2",
+  repository: "https://github.com/jtv/libpqxx",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+});
+
+export default function libpqxx(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain, postgresql],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      SKIP_BUILD_TEST: "ON",
+      SKIP_BUILD_EXAMPLES: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libpqxx | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libpqxx)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** libpqxx
- **Website / repository:** https://github.com/jtv/libpqxx
- **Repology URL:** https://repology.org/project/libpqxx/versions
- **Short description:** C++ client API for PostgreSQL

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
[17201] 8.0.2
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
{
  "name": "libpqxx",
  "version": "8.0.2",
  "repository": "https://github.com/jtv/libpqxx"
}
```

</p>
</details>

## Implementation notes / special instructions

None.