### PR TITLE
feat(pspg): add package

### DIFF
--- a/packages/pspg/brioche.lock
+++ b/packages/pspg/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/okbob/pspg/archive/refs/tags/5.8.16.tar.gz": {
+      "type": "sha256",
+      "value": "3dcfb810cc6675cac6e3ea53775a6f819e0e12e0d2bde8122e3136b740f38ae5"
+    }
+  }
+}

--- a/packages/pspg/project.bri
+++ b/packages/pspg/project.bri
@@ -1,0 +1,46 @@
+import * as std from "std";
+import postgresql from "postgresql";
+
+export const project = {
+  name: "pspg",
+  version: "5.8.16",
+  repository: "https://github.com/okbob/pspg",
+};
+
+const source = Brioche.download(
+  `${project.repository}/archive/refs/tags/${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function pspg(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, postgresql)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/pspg"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pspg --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(pspg)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `pspg-${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** pspg
- **Website / repository:** https://github.com/okbob/pspg
- **Repology URL:** https://repology.org/project/pspg/versions
- **Short description:** Unix pager designed for table browsing, especially for PostgreSQL results

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 23168 (std/core/recipes/process.bri:240:14)
[23168] pspg-5.8.16
Process 23168 ran in 0.01s
Build finished, completed 1 job in 1.98s
Result: 45b16eda818340269228c8ffadfba3d356898cf18c9ed5e43b06c40ed48c05ef
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.12s
Running brioche-run
{
  "name": "pspg",
  "version": "5.8.16",
  "repository": "https://github.com/okbob/pspg"
}
```

</p>
</details>

## Implementation notes / special instructions

None.