### PR TITLE
feat(arptables): add package

### DIFF
--- a/packages/arptables/brioche.lock
+++ b/packages/arptables/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.netfilter.org/pub/arptables/arptables-0.0.5.tar.gz": {
+      "type": "sha256",
+      "value": "4f9a0656ce5c90868f551cd4deeb2d04f33899667e1fb2818b64e432fe8f629c"
+    }
+  }
+}

--- a/packages/arptables/project.bri
+++ b/packages/arptables/project.bri
@@ -1,0 +1,69 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "arptables",
+  version: "0.0.5",
+  repository: "https://git.netfilter.org/arptables",
+};
+
+const source = Brioche.download(
+  `https://www.netfilter.org/pub/arptables/arptables-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function arptables(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+    make install PREFIX=/ DESTDIR="$BRIOCHE_OUTPUT"
+
+    # Manual installation
+    cp "$BRIOCHE_OUTPUT/sbin/arptables-legacy" "$BRIOCHE_OUTPUT/bin/arptables-legacy"
+    cp "$BRIOCHE_OUTPUT/sbin/arptables-save" "$BRIOCHE_OUTPUT/bin/arptables-save"
+    cp "$BRIOCHE_OUTPUT/sbin/arptables-restore" "$BRIOCHE_OUTPUT/bin/arptables-restore"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/arptables-legacy"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    (arptables-legacy 2>&1 || true) | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(arptables)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `arptables v${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/arptables
+      | lines
+      | parse --regex '<a href="arptables-(?<version>[0-9.]+)[.]tar[.]gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `arptables`
- **Website / repository:** `https://git.netfilter.org/arptables`
- **Repology URL:** `https://repology.org/project/arptables/versions`
- **Short description:** Legacy Linux userspace utility for filtering ARP packets with Netfilter.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.63s
Result: e6fa90c59902a28a6f4aa580d9f01cf34a5bc63e063ace5848659b96fa78aac5
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.91s
Running brioche-run
{
  "name": "arptables",
  "version": "0.0.5",
  "repository": "https://git.netfilter.org/arptables"
}
```

</p>
</details>

## Implementation notes / special instructions

None.