### PR TITLE
ci: so not save or show failed processes when Brioche fails to install

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Brioche
+        id: install_brioche
         uses: brioche-dev/setup-brioche@v1
         with:
           version: "nightly"
@@ -100,7 +101,7 @@ jobs:
           AWS_RESPONSE_CHECKSUM_CALCULATION: WHEN_REQUIRED
 
       - name: Save failed processes
-        if: failure()
+        if: failure() && steps.install_brioche.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: process-events-${{ github.run_id }}-${{ matrix.platform }}
@@ -108,7 +109,7 @@ jobs:
           compression-level: 0
 
       - name: Show failed processes
-        if: failure()
+        if: failure() && steps.install_brioche.outcome == 'success'
         run: |
           process_events=(~/.local/share/brioche/process-temp/*/events.bin.zst)
 


### PR DESCRIPTION
This PR prevents "Show failed processes" from running when "Install Brioche" fails, avoiding a secondary `brioche: command not found` error. It addresses the issue shown in [this job](https://github.com/brioche-dev/brioche-packages/actions/runs/30076732593/job/89429473516).

@kylewlacy 