### PR TITLE
[aws_*] (Live update)

### DIFF
--- a/packages/aws_c_auth/brioche.lock
+++ b/packages/aws_c_auth/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-c-auth": {
-      "v0.10.3": "4cb7127fc2fe402310f9b2ccd7719baa348b2a19"
+      "v0.10.4": "4b5d524bf1a511b05e0fffe5bdc51800770b9427"
     }
   }
 }

--- a/packages/aws_c_auth/project.bri
+++ b/packages/aws_c_auth/project.bri
@@ -11,7 +11,7 @@ import s2n from "s2n";
 
 export const project = {
   name: "aws_c_auth",
-  version: "0.10.3",
+  version: "0.10.4",
   repository: "https://github.com/awslabs/aws-c-auth",
 };
 

--- a/packages/aws_c_common/brioche.lock
+++ b/packages/aws_c_common/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-c-common": {
-      "v0.14.0": "48dd6cdff7bac0005a9c6b49c15a0765622c0e70"
+      "v0.14.2": "a9d57d2d372582fa18bf1d81741e107c59a23226"
     }
   }
 }

--- a/packages/aws_c_common/project.bri
+++ b/packages/aws_c_common/project.bri
@@ -3,7 +3,7 @@ import cmake, { cmakeBuild } from "cmake";
 
 export const project = {
   name: "aws_c_common",
-  version: "0.14.0",
+  version: "0.14.2",
   repository: "https://github.com/awslabs/aws-c-common",
 };
 

--- a/packages/aws_c_io/brioche.lock
+++ b/packages/aws_c_io/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-c-io": {
-      "v0.27.2": "9156a8f7970d615cbb689900f7adef70f2366c88"
+      "v0.27.4": "54350963b64dfc6c4b0ea623b08aa252aae3d7d7"
     }
   }
 }

--- a/packages/aws_c_io/project.bri
+++ b/packages/aws_c_io/project.bri
@@ -7,7 +7,7 @@ import s2n from "s2n";
 
 export const project = {
   name: "aws_c_io",
-  version: "0.27.2",
+  version: "0.27.4",
   repository: "https://github.com/awslabs/aws-c-io",
 };
 

--- a/packages/aws_c_s3/brioche.lock
+++ b/packages/aws_c_s3/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-c-s3": {
-      "v0.12.6": "e8bf59aaa77442d7f066a2df05604f40889f044a"
+      "v0.12.8": "448ec5e49eb181687f9af39b0d3b83a563b15039"
     }
   }
 }

--- a/packages/aws_c_s3/project.bri
+++ b/packages/aws_c_s3/project.bri
@@ -13,7 +13,7 @@ import s2n from "s2n";
 
 export const project = {
   name: "aws_c_s3",
-  version: "0.12.6",
+  version: "0.12.8",
   repository: "https://github.com/awslabs/aws-c-s3",
 };
 

--- a/packages/aws_c_sdkutils/brioche.lock
+++ b/packages/aws_c_sdkutils/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-c-sdkutils": {
-      "v0.2.5": "c70418c17d8f970ff1d80d88d08beeccd425a887"
+      "v0.2.7": "cb14fea362c82c995eebd34e2e96590ab4e0ed58"
     }
   }
 }

--- a/packages/aws_c_sdkutils/project.bri
+++ b/packages/aws_c_sdkutils/project.bri
@@ -4,7 +4,7 @@ import awsCCommon from "aws_c_common";
 
 export const project = {
   name: "aws_c_sdkutils",
-  version: "0.2.5",
+  version: "0.2.7",
   repository: "https://github.com/awslabs/aws-c-sdkutils",
 };
 

--- a/packages/aws_cdk/project.bri
+++ b/packages/aws_cdk/project.bri
@@ -3,7 +3,7 @@ import { npmInstallGlobal } from "nodejs";
 
 export const project = {
   name: "aws_cdk",
-  version: "2.1127.0",
+  version: "2.1131.0",
   extra: {
     packageName: "aws-cdk",
   },

--- a/packages/aws_cli/brioche.lock
+++ b/packages/aws_cli/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/aws/aws-cli": {
-      "2.35.5": "2494b4b07964b7e6ee69f08a35d1338a913a9259"
+      "2.35.23": "d519fa23fa7ee13b31ab2f69beaf37c3178c9fd6"
     }
   }
 }

--- a/packages/aws_cli/project.bri
+++ b/packages/aws_cli/project.bri
@@ -3,7 +3,7 @@ import python, { fixScriptShebangs, wrapVenvScripts } from "python";
 
 export const project = {
   name: "aws_cli",
-  version: "2.35.5",
+  version: "2.35.23",
   repository: "https://github.com/aws/aws-cli",
 };
 

--- a/packages/aws_crt_cpp/brioche.lock
+++ b/packages/aws_crt_cpp/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/awslabs/aws-crt-cpp": {
-      "v0.40.1": "64429d60265ee8c30ae1c8f2ff8e1b9474eea455"
+      "v0.41.0": "d8ee6b6912c196e574be10f207868721117dd397"
     }
   }
 }

--- a/packages/aws_crt_cpp/project.bri
+++ b/packages/aws_crt_cpp/project.bri
@@ -16,7 +16,7 @@ import s2n from "s2n";
 
 export const project = {
   name: "aws_crt_cpp",
-  version: "0.40.1",
+  version: "0.41.0",
   repository: "https://github.com/awslabs/aws-crt-cpp",
 };
 

--- a/packages/aws_sdk_cpp/brioche.lock
+++ b/packages/aws_sdk_cpp/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/aws/aws-sdk-cpp": {
-      "1.11.828": "531fc621e620ee190dc0296806ff7aa0909748da"
+      "1.11.847": "1777328572ce4ec9e5326cfc2c51690813389620"
     }
   }
 }

--- a/packages/aws_sdk_cpp/project.bri
+++ b/packages/aws_sdk_cpp/project.bri
@@ -18,7 +18,7 @@ import s2n from "s2n";
 
 export const project = {
   name: "aws_sdk_cpp",
-  version: "1.11.828",
+  version: "1.11.847",
   repository: "https://github.com/aws/aws-sdk-cpp",
 };
 


### PR DESCRIPTION
This Pull Request consolidates the aws_* live updates into one PR.

Included live updates:
- aws_c_auth
- aws_c_common
- aws_c_io
- aws_c_s3
- aws_c_sdkutils
- aws_cdk
- aws_cli
- aws_crt_cpp
- aws_sdk_cpp

This PR supersedes #5073, #5074, #5075, #5076, #5077, #5078, #5079, #5080, and #5081. The individual PRs will be closed after this replacement PR is created.

The nine source commits were cherry-picked onto the consolidation branch. The resulting diff is limited to the expected aws_* package metadata and lockfiles, and git diff --check passes.