### PR TITLE
chore: update Facebook package releases

### DIFF
--- a/packages/fizz/brioche.lock
+++ b/packages/fizz/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.06.15.00.tar.gz": {
+    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.07.13.00.tar.gz": {
       "type": "sha256",
-      "value": "6f14e7c83ae846eb9f99f242cf1b6a89a9e065fac6982d06990523e7a2e10d6b"
+      "value": "19ac460edd73f0fab68a637fcf55672c1e270c5596684dd726d72e9fadae7e12"
     }
   }
 }

--- a/packages/fizz/brioche.lock
+++ b/packages/fizz/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.07.13.00.tar.gz": {
+    "https://github.com/facebookincubator/fizz/archive/refs/tags/v2026.08.03.00.tar.gz": {
       "type": "sha256",
-      "value": "19ac460edd73f0fab68a637fcf55672c1e270c5596684dd726d72e9fadae7e12"
+      "value": "78050eaa317c2ff66c000a91a4ddce9bc969fecf5188dc196c01cc9a2515ab06"
     }
   }
 }

--- a/packages/fizz/project.bri
+++ b/packages/fizz/project.bri
@@ -15,7 +15,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "fizz",
-  version: "2026.06.15.00",
+  version: "2026.07.13.00",
   repository: "https://github.com/facebookincubator/fizz",
 };
 

--- a/packages/fizz/project.bri
+++ b/packages/fizz/project.bri
@@ -15,7 +15,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "fizz",
-  version: "2026.07.13.00",
+  version: "2026.08.03.00",
   repository: "https://github.com/facebookincubator/fizz",
 };
 

--- a/packages/fmt/brioche.lock
+++ b/packages/fmt/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/fmtlib/fmt.git": {
-      "12.1.0": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f"
+      "12.2.0": "1be298e1bd68957e4cd352e1f676f00e07dcfb57"
     }
   }
 }

--- a/packages/fmt/project.bri
+++ b/packages/fmt/project.bri
@@ -3,7 +3,7 @@ import { cmakeBuild } from "cmake";
 
 export const project = {
   name: "fmt",
-  version: "12.1.0",
+  version: "12.2.0",
   repository: "https://github.com/fmtlib/fmt.git",
 };
 

--- a/packages/folly/brioche.lock
+++ b/packages/folly/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebook/folly/archive/refs/tags/v2026.07.13.00.tar.gz": {
+    "https://github.com/facebook/folly/archive/refs/tags/v2026.08.03.00.tar.gz": {
       "type": "sha256",
-      "value": "4400e68827b28abfce920882706fa358903ab253fcc547426c39eb425a28e447"
+      "value": "4e2f840f4d69f32b881dd60c2ab21fa78ac223f802dcb8ac541025069b76a9e6"
     }
   }
 }

--- a/packages/folly/project.bri
+++ b/packages/folly/project.bri
@@ -15,7 +15,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "folly",
-  version: "2026.07.13.00",
+  version: "2026.08.03.00",
   repository: "https://github.com/facebook/folly",
 };
 

--- a/packages/mvfst/brioche.lock
+++ b/packages/mvfst/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.06.15.00.tar.gz": {
+    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.07.13.00.tar.gz": {
       "type": "sha256",
-      "value": "647934c11a5f6eb5276870ef31985f13088df234a51ea6561440e9c990ae53a1"
+      "value": "ee7273a219317f992551ef9f4b0f05ec826288720aa2fe08154f192e2ce32ed9"
     }
   }
 }

--- a/packages/mvfst/brioche.lock
+++ b/packages/mvfst/brioche.lock
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "downloads": {
-    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.07.13.00.tar.gz": {
+    "https://github.com/facebook/mvfst/archive/refs/tags/v2026.08.03.00.tar.gz": {
       "type": "sha256",
-      "value": "ee7273a219317f992551ef9f4b0f05ec826288720aa2fe08154f192e2ce32ed9"
+      "value": "fe54b237315036982cf808384dadc9c25ad707eb0707319d8ed0b043d27c2eca"
     }
   }
 }

--- a/packages/mvfst/project.bri
+++ b/packages/mvfst/project.bri
@@ -16,7 +16,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "mvfst",
-  version: "2026.06.15.00",
+  version: "2026.07.13.00",
   repository: "https://github.com/facebook/mvfst",
 };
 

--- a/packages/mvfst/project.bri
+++ b/packages/mvfst/project.bri
@@ -16,7 +16,7 @@ import snappy from "snappy";
 
 export const project = {
   name: "mvfst",
-  version: "2026.07.13.00",
+  version: "2026.08.03.00",
   repository: "https://github.com/facebook/mvfst",
 };
 

--- a/packages/pyrefly/brioche.lock
+++ b/packages/pyrefly/brioche.lock
@@ -2,7 +2,7 @@
   "dependencies": {},
   "git_refs": {
     "https://github.com/facebook/pyrefly.git": {
-      "1.1.1": "b87de05834c401898c79fd9686b806c051dd3667"
+      "1.2.0": "1933169ad8ee9e4d4114112eb56ef0811fb0a094"
     }
   }
 }

--- a/packages/pyrefly/project.bri
+++ b/packages/pyrefly/project.bri
@@ -3,7 +3,7 @@ import { cargoBuild } from "rust";
 
 export const project = {
   name: "pyrefly",
-  version: "1.1.1",
+  version: "1.2.0",
   repository: "https://github.com/facebook/pyrefly.git",
 };
 


### PR DESCRIPTION
## Summary

This PR combines the package updates from #5160, #5163, and #5282 into one tested branch and refreshes the Facebook package recipes to current upstream tags.

Updated packages:

- fizz 2026.08.03.00
- fmt 12.2.0
- mvfst 2026.08.03.00
- folly 2026.08.03.00
- pyrefly 1.2.0

Already current:

- jemalloc 5.3.0
- zstd 1.5.7

The Folly refresh includes the upstream cstring include that fixes the merge queue failure triggered by fmt 12.2.0.

## Validation

- brioche fmt passed for fizz, fmt, folly, mvfst, and pyrefly.
- brioche check passed for fizz, fmt, folly, mvfst, and pyrefly.
- Full builds passed for fizz, fmt, and mvfst.
- Test and live-update scenarios passed for fizz, fmt, and mvfst.

This PR supersedes #5160, #5163, and #5282.