### PR TITLE
feat(dosfstools): add package

### DIFF
--- a/packages/dosfstools/brioche.lock
+++ b/packages/dosfstools/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://github.com/dosfstools/dosfstools/releases/download/v4.2/dosfstools-4.2.tar.gz": {
+      "type": "sha256",
+      "value": "64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527"
+    }
+  }
+}

--- a/packages/dosfstools/project.bri
+++ b/packages/dosfstools/project.bri
@@ -1,0 +1,51 @@
+import * as std from "std";
+
+export const project = {
+  name: "dosfstools",
+  version: "4.2",
+  repository: "https://github.com/dosfstools/dosfstools",
+};
+
+const source = Brioche.download(
+  `${project.repository}/releases/download/v${project.version}/dosfstools-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function dosfstools(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --bindir=/bin \\
+      --sbindir=/bin \\
+      --enable-compat-symlinks
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory();
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    mkfs.fat --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(dosfstools)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `mkfs.fat ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `dosfstools`
- **Website / repository:** `https://github.com/dosfstools/dosfstools`
- **Repology URL:** `https://repology.org/project/dosfstools/versions`
- **Short description:** Utilities for creating and checking FAT filesystems.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.87s
Result: 42a5988ec957afdd5f5e59accb18725b5891500c476f9e2976a23300281c650c
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.76s
Running brioche-run
{
  "name": "dosfstools",
  "version": "4.2",
  "repository": "https://github.com/dosfstools/dosfstools"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
