### PR TITLE
feat(e2fsprogs): add package

### DIFF
--- a/packages/e2fsprogs/brioche.lock
+++ b/packages/e2fsprogs/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.4/e2fsprogs-1.47.4.tar.xz": {
+      "type": "sha256",
+      "value": "fd5bf388cbdbe006a3d3b318d983b2948382440acc85a87f1e7d108653e8db0b"
+    }
+  }
+}

--- a/packages/e2fsprogs/project.bri
+++ b/packages/e2fsprogs/project.bri
@@ -1,0 +1,68 @@
+import * as std from "std";
+import libarchive from "libarchive";
+import libfuse from "libfuse";
+import liburing from "liburing";
+import openssl from "openssl";
+import numactl from "numactl";
+
+export const project = {
+  name: "e2fsprogs",
+  version: "1.47.4",
+  repository: "https://github.com/tytso/e2fsprogs",
+};
+
+const source = Brioche.download(
+  `https://kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${project.version}/e2fsprogs-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function e2fsprogs(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin \\
+      --enable-elf-shlibs
+    make -j "$(nproc)"
+    make install install-libs DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      libarchive,
+      libfuse,
+      liburing,
+      openssl,
+      numactl,
+    )
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/mke2fs"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion ext2fs | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, e2fsprogs)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}

--- a/packages/libfuse/project.bri
+++ b/packages/libfuse/project.bri
@@ -29,7 +29,7 @@ export default function libfuse(): std.Recipe<std.Directory> {
     },
   }).pipe((recipe) =>
     std.setEnv(recipe, {
-      CPATH: { append: [{ path: "include" }] },
+      CPATH: { append: [{ path: "include" }, { path: "include/fuse3" }] },
       LIBRARY_PATH: { append: [{ path: "lib" }] },
       PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
     }),


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `e2fsprogs`
- **Website / repository:** `https://github.com/tytso/e2fsprogs`
- **Repology URL:** `https://repology.org/project/e2fsprogs/versions`
- **Short description:** Utilities and libraries for creating and maintaining ext2, ext3, and ext4 filesystems.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 254175 (std/core/recipes/process.bri:240:14)
[254175] 1.47.4
Process 254175 ran in 0.01s
Build finished, completed 1 job in 3.58s
Result: 005519546d5d79082cf82fa4e0a38d982f8781746bba53f32d87f7d492327ce4
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.18s
Running brioche-run
{
  "name": "e2fsprogs",
  "version": "1.47.4",
  "repository": "https://github.com/tytso/e2fsprogs"
}
```

</p>
</details>

## Implementation notes / special instructions

None.