### PR TITLE
feat(libressl): add package

### DIFF
--- a/packages/libressl/brioche.lock
+++ b/packages/libressl/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.3.2.tar.gz": {
+      "type": "sha256",
+      "value": "edf01aee24c65d69e6a9efcb9d44bcda682ff9d4f3bbbd95e794e1dfa90847b5"
+    }
+  }
+}

--- a/packages/libressl/project.bri
+++ b/packages/libressl/project.bri
@@ -1,0 +1,53 @@
+import * as std from "std";
+import { cmakeBuild } from "cmake";
+
+export const project = {
+  name: "libressl",
+  version: "4.3.2",
+  repository: "https://github.com/libressl/portable",
+};
+
+const source = Brioche.download(
+  `https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function libressl(): std.Recipe<std.Directory> {
+  return cmakeBuild({
+    source,
+    dependencies: [std.toolchain],
+    set: {
+      BUILD_SHARED_LIBS: "ON",
+      LIBRESSL_TESTS: "OFF",
+      ENABLE_NC: "ON",
+    },
+  }).pipe((recipe) =>
+    std.setEnv(recipe, {
+      CPATH: { append: [{ path: "include" }] },
+      LIBRARY_PATH: { append: [{ path: "lib" }] },
+      PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      CMAKE_PREFIX_PATH: { append: [{ path: "." }] },
+    }),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    pkg-config --modversion libtls | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(std.toolchain, libressl)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `libressl`
- **Website / repository:** `https://github.com/libressl/portable`
- **Repology URL:** `https://repology.org/project/libressl/versions`
- **Short description:** LibreSSL is a TLS and cryptography library forked from OpenSSL.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 261481 (std/core/recipes/process.bri:240:14)
[261481] 4.3.2
Process 261481 ran in 0.01s
Build finished, completed 1 job in 3.09s
Result: f048d55e15f72d3e4c8a6b7f2d4e479556da7fbdb08ce7c0798548f51f1fe3c1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.56s
Running brioche-run
{
  "name": "libressl",
  "version": "4.3.2",
  "repository": "https://github.com/libressl/portable"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
