### PR TITLE
feat(websocat): add package

### DIFF
--- a/packages/websocat/brioche.lock
+++ b/packages/websocat/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://crates.io/api/v1/crates/websocat/1.14.1/download": {
+      "type": "sha256",
+      "value": "edd6d85a7412ed52d7ae8a2b85c91925e80b5bbb5ee615b5f36b36b751f1e486"
+    }
+  }
+}

--- a/packages/websocat/project.bri
+++ b/packages/websocat/project.bri
@@ -1,0 +1,47 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import openssl from "openssl";
+export const project = {
+  name: "websocat",
+  version: "1.14.1",
+  extra: {
+    crateName: "websocat",
+  },
+};
+
+const source = Brioche.download(
+  `https://crates.io/api/v1/crates/${project.extra.crateName}/${project.version}/download`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function websocat(): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source,
+    buildParams: {
+      features: ["ssl"],
+    },
+    dependencies: [openssl({ version: "3" })],
+    runnable: "bin/websocat",
+  });
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    websocat --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(websocat)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `websocat ${project.version}`;
+  std.assert(result === expected, `expected '${expected}', got '${result}'`);
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromRustCrates({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `websocat`
- **Website / repository:** `https://github.com/vi/websocat`
- **Repology URL:** `https://repology.org/project/websocat/versions`
- **Short description:** WebSocket command-line client with netcat-like functionality.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.25s
Result: b1c041ea93c7a37027b637f2a2e145c595db1b5b84db0f21f76d5dcaa29bab1b
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 3.17s
Running brioche-run
{
  "name": "websocat",
  "version": "1.14.1",
  "extra": {
    "crateName": "websocat"
  }
}
```

</p>
</details>

## Implementation notes / special instructions

None.
