### PR TITLE
feat(lvm2): add package

### DIFF
--- a/packages/lvm2/brioche.lock
+++ b/packages/lvm2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.42.tgz": {
+      "type": "sha256",
+      "value": "352703ef5b72ebb22d4f250284a29b89fe64d4049c6bf64c693f9af486c8081e"
+    }
+  }
+}

--- a/packages/lvm2/project.bri
+++ b/packages/lvm2/project.bri
@@ -1,0 +1,67 @@
+import * as std from "std";
+import libaio from "libaio";
+
+export const project = {
+  name: "lvm2",
+  version: "2.03.42",
+  repository: "https://gitlab.com/lvmteam/lvm2",
+};
+
+const source = Brioche.download(
+  `https://sourceware.org/pub/lvm2/releases/LVM2.${project.version}.tgz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function lvm2(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin \\
+      --with-usrsbindir=/bin \\
+      --sysconfdir=/etc/lvm \\
+      --localstatedir=/var \\
+      --without-systemd \\
+      --without-udev \\
+      --enable-pkgconfig
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libaio)
+    .toDirectory()
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/lvm"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    lvm version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(lvm2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = project.version;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGitlabTags({
+    project,
+    matchTag: /^v(?<version>2_[0-9]+_[0-9]+)$/,
+  });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `lvm2`
- **Website / repository:** `https://gitlab.com/lvmteam/lvm2`
- **Repology URL:** `https://repology.org/project/lvm2/versions`
- **Short description:** Linux Logical Volume Manager userspace tools and libraries.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 423316 (std/core/recipes/process.bri:240:14)
[423316] /dev/mapper/control: open failed: Permission denied
[423316] Failure to communicate with kernel device-mapper driver.
[423316] Failed to get driver version.
[423316]   LVM version:     2.03.42(2) (2026-08-06)
[423316]   Library version: 1.02.216 (2026-08-06)
[423316]   Configuration:   ./configure --prefix=/ --sbindir=/bin --with-usrsbindir=/bin --sysconfdir=/etc/lvm --localstatedir=/var --without-systemd --without-udev --enable-pkgconfig
Process 423316 ran in 0.01s
Build finished, completed 1 job in 3.07s
Result: 9ca9085264b1a921572fedcc13532da13ef6fa0ae7bc7adf7e3e3aa886d31e05
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.81s
Running brioche-run
{
  "name": "lvm2",
  "version": "2_03_42",
  "repository": "https://gitlab.com/lvmteam/lvm2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
