### PR TITLE
feat(parted): add package

### DIFF
--- a/packages/parted/brioche.lock
+++ b/packages/parted/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ftpmirror.gnu.org/gnu/parted/parted-3.7.tar.xz": {
+      "type": "sha256",
+      "value": "008de57561a4f3c25a0648e66ed11e7b30be493889b64334a6d70f2c1951ef7b"
+    }
+  }
+}

--- a/packages/parted/project.bri
+++ b/packages/parted/project.bri
@@ -1,0 +1,74 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import lvm2 from "lvm2";
+
+export const project = {
+  name: "parted",
+  version: "3.7",
+  repository: "https://git.savannah.gnu.org/git/parted.git",
+};
+
+const source = Brioche.download(
+  `https://ftpmirror.gnu.org/gnu/parted/parted-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function parted(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --bindir=/bin \\
+      --sbindir=/bin \\
+      --with-readline
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, lvm2)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/parted"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    parted --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(parted)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `parted (GNU parted) ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://ftpmirror.gnu.org/gnu/parted
+      | lines
+      | where ($it | str contains "parted-") and (not ($it | str contains ".sig"))
+      | parse --regex '.*parted-(?<version>[\\d.]+)\\.tar\\.xz'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `parted`
- **Website / repository:** `https://git.savannah.gnu.org/git/parted.git`
- **Repology URL:** `https://repology.org/project/parted/versions`
- **Short description:** GNU Parted is a command-line disk partitioning utility.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.85s
Result: 66cac2d681233f6a9c172a2b8c867488d7d284bde7bef69f20ace1de15325974
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.74s
Running brioche-run
{
  "name": "parted",
  "version": "3.7",
  "repository": "https://git.savannah.gnu.org/git/parted.git"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
