### PR TITLE
feat(netcat_gnu): add package

### DIFF
--- a/packages/netcat_gnu/brioche.lock
+++ b/packages/netcat_gnu/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2": {
+      "type": "sha256",
+      "value": "b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb"
+    }
+  }
+}

--- a/packages/netcat_gnu/project.bri
+++ b/packages/netcat_gnu/project.bri
@@ -1,0 +1,70 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "netcat_gnu",
+  version: "0.7.1",
+};
+
+const source = Brioche.download(
+  `https://downloads.sourceforge.net/project/netcat/netcat/${project.version}/netcat-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel()
+  .pipe((source) =>
+    // Bundled config.guess does not recognize aarch64
+    std.runBash`
+      cp "$(automake --print-libdir)/config.guess" "$BRIOCHE_OUTPUT/config.guess"
+      cp "$(automake --print-libdir)/config.sub" "$BRIOCHE_OUTPUT/config.sub"
+    `
+      .dependencies(std.toolchain)
+      .outputScaffold(source)
+      .toDirectory(),
+  );
+
+export default function netcatGnu(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure --prefix=/
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/netcat"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    netcat -V | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(netcatGnu)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `netcat (The GNU Netcat) ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got: ${result}`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://sourceforge.net/projects/netcat/files/netcat
+      | lines
+      | where ($it | str contains 'href="/projects/netcat/files/netcat/')
+      | parse --regex '<a href="/projects/netcat/files/netcat/(?<version>[\\d.]+)/"'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `netcat_gnu`
- **Website / repository:** `https://netcat.sourceforge.net/`
- **Repology URL:** `https://repology.org/project/netcat_gnu/versions`
- **Short description:** GNU Netcat, a networking utility for TCP and UDP connections.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.89s
Result: e3ce9e459cff12fc273b6eb1a990720ea809e97788bb534aac3ca320a4ac673f
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.76s
Running brioche-run
{
  "name": "netcat_gnu",
  "version": "0.7.1"
}
```

</p>
</details>

## Implementation notes / special instructions

None.