### PR TITLE
feat(netcat_openbsd): add package

### DIFF
--- a/packages/netcat_openbsd/brioche.lock
+++ b/packages/netcat_openbsd/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://salsa.debian.org/debian/netcat-openbsd": {
+      "debian/1.238-1": "664275e483ed0e7f875a8d64c656d4c2625c3646"
+    }
+  }
+}

--- a/packages/netcat_openbsd/project.bri
+++ b/packages/netcat_openbsd/project.bri
@@ -1,0 +1,75 @@
+import * as std from "std";
+import libbsd from "libbsd";
+import libmd from "libmd";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "netcat_openbsd",
+  version: "1.238-1",
+  repository: "https://salsa.debian.org/debian/netcat-openbsd",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `debian/${project.version}`,
+}).pipe((source) =>
+  // Apply Debian's Linux portability patches.
+  std.runBash`
+    while read -r patch_file; do
+      patch -d "$BRIOCHE_OUTPUT" -p1 < "$BRIOCHE_OUTPUT/debian/patches/$patch_file"
+    done < "$BRIOCHE_OUTPUT/debian/patches/series"
+  `
+    .dependencies(std.toolchain)
+    .outputScaffold(source)
+    .toDirectory(),
+);
+
+export default function netcatOpenbsd(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make -j "$(nproc)"
+
+    # Manual installation
+    cp nc "$BRIOCHE_OUTPUT/bin/nc"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libbsd, libmd)
+    .outputScaffold(
+      std.directory({
+        bin: std.directory(),
+      }),
+    )
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/nc"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  // There is no way to print the package's version, so the help command
+  // is used to verify the correct installation
+  const script = std.runBash`
+    nc -h 2>&1 | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(netcatOpenbsd)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected output
+  std.assert(result !== "", `'${result}' should not be empty`);
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get 'https://salsa.debian.org/api/v4/projects/debian%2Fnetcat-openbsd/repository/tags?per_page=100'
+      | where name =~ '^debian/[0-9]+\\.[0-9]+-[0-9]+$'
+      | each { |tag| $tag.name | str replace 'debian/' '' }
+      | sort --natural --reverse
+      | first
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `netcat_openbsd`
- **Website / repository:** https://salsa.debian.org/debian/netcat-openbsd
- **Repology URL:** https://repology.org/project/netcat_openbsd/versions
- **Short description:** Netcat utility for reading and writing data across network connections.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.78s
Result: 76e10c1ec3911b824e2992806b9602321684a5118ba58f976cb861348d2821d7
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 455375 (std/runtime_utils.bri:49:6)
Process 455375 ran in 0.01s
Build finished, completed 1 job in 4.64s
Running brioche-run
{
  "name": "netcat_openbsd",
  "version": "1.238-1",
  "repository": "https://salsa.debian.org/debian/netcat-openbsd"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
