### PR TITLE
feat(toybox): add package

### DIFF
--- a/packages/toybox/brioche.lock
+++ b/packages/toybox/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "git_refs": {
+    "https://github.com/landley/toybox": {
+      "0.8.14": "b7ec52ac35e075caffca5d330995d44e8dbfc8c3"
+    }
+  }
+}

--- a/packages/toybox/project.bri
+++ b/packages/toybox/project.bri
@@ -1,0 +1,56 @@
+import * as std from "std";
+
+export const project = {
+  name: "toybox",
+  version: "0.8.14",
+  repository: "https://github.com/landley/toybox",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: project.version,
+}).pipe((source) =>
+  // Normalize bundled shell scripts.
+  std.runBash`
+    chmod +x "$BRIOCHE_OUTPUT"/scripts/*.sh
+    sed -i '1s|#!/bin/bash|#!/usr/bin/env bash|' "$BRIOCHE_OUTPUT"/scripts/*.sh
+  `
+    .dependencies(std.toolchain)
+    .outputScaffold(source)
+    .toDirectory(),
+);
+
+export default function toybox(): std.Recipe<std.Directory> {
+  return std.runBash`
+    make defconfig
+    make -j "$(nproc)"
+    PREFIX="$BRIOCHE_OUTPUT" make install
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/toybox"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    toybox --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(toybox)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `toybox ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `toybox`
- **Website / repository:** `https://github.com/landley/toybox`
- **Repology URL:** `https://repology.org/project/toybox/versions`
- **Short description:** All-in-one Linux command line utility suite.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.08s
Result: 34c3509b01c5a973367bf26541fca83da69457fe347cbede06d638f74488ede6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.63s
Running brioche-run
{
  "name": "toybox",
  "version": "0.8.14",
  "repository": "https://github.com/landley/toybox"
}
```

</p>
</details>

## Implementation notes / special instructions

None.