### PR TITLE
feat(conntrack_tools): add package

### DIFF
--- a/packages/conntrack_tools/brioche.lock
+++ b/packages/conntrack_tools/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/conntrack-tools/conntrack-tools-1.4.9.tar.xz": {
+      "type": "sha256",
+      "value": "c15afe488a8d408c9d6d61e97dbd19f3c591942f62c13df6453a961ca4231cae"
+    }
+  }
+}

--- a/packages/conntrack_tools/project.bri
+++ b/packages/conntrack_tools/project.bri
@@ -1,0 +1,84 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnetfilter_conntrack from "libnetfilter_conntrack";
+import libnetfilter_cthelper from "libnetfilter_cthelper";
+import libnetfilter_cttimeout from "libnetfilter_cttimeout";
+import libnetfilter_queue from "libnetfilter_queue";
+import libnfnetlink from "libnfnetlink";
+import libtirpc from "libtirpc";
+
+export const project = {
+  name: "conntrack_tools",
+  version: "1.4.9",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/conntrack-tools/conntrack-tools-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function conntrackTools(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      libmnl,
+      libnetfilter_conntrack,
+      libnetfilter_cthelper,
+      libnetfilter_cttimeout,
+      libnetfilter_queue,
+      libnfnetlink,
+      libtirpc,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/conntrack"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    conntrack --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(conntrackTools)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `Version ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/conntrack-tools
+      | lines
+      | where ($it | str contains "conntrack-tools-") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="conntrack-tools-(?<version>[\\d.]+)\.tar\\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `conntrack_tools`
- **Website / repository:** `https://netfilter.org/projects/conntrack-tools/`
- **Repology URL:** `https://repology.org/project/conntrack-tools/versions`
- **Short description:** Linux Netfilter connection tracking tools, including the conntrack CLI and conntrackd daemon.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.75s
Result: 89ab13db271da8f5aec04c6cb44d7b5a748a5ea6a6335bf0af5d88accfdae8f6
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 667980 (std/runtime_utils.bri:49:6)
Process 667980 ran in 0.02s
Build finished, completed 1 job in 4.22s
Running brioche-run
{
  "name": "conntrack_tools",
  "version": "1.4.9"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
