### PR TITLE
feat(iproute2): add package

### DIFF
--- a/packages/iproute2/brioche.lock
+++ b/packages/iproute2/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-7.1.0.tar.xz": {
+      "type": "sha256",
+      "value": "fd9fa1b95809417157ca83dd72957e3261bdbce896353cb936f80af0b33a4b5c"
+    }
+  }
+}

--- a/packages/iproute2/project.bri
+++ b/packages/iproute2/project.bri
@@ -1,0 +1,59 @@
+import * as std from "std";
+import elfutils from "elfutils";
+import libbpf from "libbpf";
+import libcap from "libcap";
+import libmnl from "libmnl";
+import libtirpc from "libtirpc";
+
+export const project = {
+  name: "iproute2",
+  version: "7.1.0",
+  repository: "https://github.com/iproute2/iproute2",
+};
+
+const source = Brioche.download(
+  `https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function iproute2(): std.Recipe<std.Directory> {
+  return std.pipe(
+    std.runBash`
+      ./configure \\
+        --prefix=/ \\
+        --libdir=/lib
+      make -j "$(nproc)"
+      make install \\
+        SBINDIR=/bin \\
+        DESTDIR="$BRIOCHE_OUTPUT"
+    `
+      .workDir(source)
+      .dependencies(std.toolchain, elfutils, libbpf, libcap, libmnl, libtirpc)
+      .toDirectory(),
+    (recipe) => std.withRunnableLink(recipe, "bin/ip"),
+  );
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ip -Version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(iproute2)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ip utility, iproute2-${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubTags({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `iproute2`
- **Website / repository:** `https://github.com/iproute2/iproute2`
- **Repology URL:** `https://repology.org/project/iproute2/versions`
- **Short description:** The core userspace networking suite for inspecting and configuring interfaces, routes, sockets, bridges, and traffic control.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 4.20s
Result: 68623bb4d4530f3b3b7afb5a1d70894061539670df2efccad5afc0f694b75db9
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 6.11s
Running brioche-run
{
  "name": "iproute2",
  "version": "7.1.0",
  "repository": "https://github.com/iproute2/iproute2"
}
```

</p>
</details>

## Implementation notes / special instructions

None.