### PR TITLE
feat(ebtables): add package

### DIFF
--- a/packages/ebtables/brioche.lock
+++ b/packages/ebtables/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/ebtables/ebtables-2.0.11.tar.gz": {
+      "type": "sha256",
+      "value": "b71f654784a726329f88b412ef7b96b4e5d786ed2bd28193ed7b4c0d677dfd2a"
+    }
+  }
+}

--- a/packages/ebtables/project.bri
+++ b/packages/ebtables/project.bri
@@ -1,0 +1,81 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+
+export const project = {
+  name: "ebtables",
+  version: "2.0.11",
+  repository: "https://git.netfilter.org/ebtables",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/ebtables/ebtables-${project.version}.tar.gz`,
+)
+  .unarchive("tar", "gzip")
+  .peel();
+
+export default function ebtables(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain)
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) =>
+      recipe
+        .insert("bin/ebtables", std.symlink({ target: "ebtables-legacy" }))
+        .insert(
+          "bin/ebtables-restore",
+          std.symlink({ target: "ebtables-legacy-restore" }),
+        )
+        .insert(
+          "bin/ebtables-save",
+          std.symlink({ target: "ebtables-legacy-save" }),
+        ),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ebtables"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ebtables --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ebtables)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ebtables v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/ebtables
+      | lines
+      | where ($it | str contains "ebtables-") and (not ($it | str contains "sig")) and (not ($it | str contains "sha"))
+      | parse --regex '<a href="ebtables-(?:v)?(?<version>[\\d.-]+)\\.tar\\.gz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `ebtables`
- **Website / repository:** `https://git.netfilter.org/ebtables`
- **Repology URL:** `https://repology.org/project/ebtables/versions`
- **Short description:** Linux Netfilter userspace tool for filtering and manipulating Ethernet frames on bridges.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 699749 (std/core/recipes/process.bri:240:14)
[699749] ebtables v2.0.11 (legacy) (December 2011)
Process 699749 ran in 0.03s
Build finished, completed 1 job in 2.45s
Result: cc6deab01691287959da72a350a1f75359a9af7024f23e1d55e575e6fa08ebf9
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.69s
Running brioche-run
{
  "name": "ebtables",
  "version": "2.0.11",
  "repository": "https://git.netfilter.org/ebtables"
}
```

</p>
</details>

## Implementation notes / special instructions

None.