### PR TITLE
feat(ipset): add package

### DIFF
--- a/packages/ipset/brioche.lock
+++ b/packages/ipset/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://ipset.netfilter.org/ipset-7.24.tar.bz2": {
+      "type": "sha256",
+      "value": "fbe3424dff222c1cb5e5c34d38b64524b2217ce80226c14fdcbb13b29ea36112"
+    }
+  }
+}

--- a/packages/ipset/project.bri
+++ b/packages/ipset/project.bri
@@ -1,0 +1,72 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+
+export const project = {
+  name: "ipset",
+  version: "7.24",
+};
+
+const source = Brioche.download(
+  `https://ipset.netfilter.org/ipset-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function ipset(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin \\
+      --with-kmod=no
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl)
+    .toDirectory()
+    .pipe(std.pkgConfigMakePathsRelative)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        CPATH: { append: [{ path: "include" }] },
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+        PKG_CONFIG_PATH: { append: [{ path: "lib/pkgconfig" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ipset"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ipset --help | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ipset)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ipset v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/ipset
+      | lines
+      | where ($it | str contains "ipset-") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum")) and (not ($it | str contains "sha512sum"))
+      | parse --regex '<a href="ipset-(?<version>[\\d.]+)\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `ipset`
- **Website / repository:** `https://ipset.netfilter.org/`
- **Repology URL:** `https://repology.org/project/ipset/versions`
- **Short description:** IP set administration tool for the Linux kernel.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Launched process 743316 (std/core/recipes/process.bri:240:14)
[743316] ipset v7.24
[743316] 
[743316] Usage: ipset [options] COMMAND
[743316] 
[743316] Commands:
[743316] create SETNAME TYPENAME [type-specific-options]
[743316]         Create a new set
[743316] add SETNAME ENTRY
[743316]         Add entry to the named set
[743316] del SETNAME ENTRY
[743316]         Delete entry from the named set
[743316] test SETNAME ENTRY
[743316]         Test entry in the named set
[743316] destroy [SETNAME]
[743316]         Destroy a named set or all sets
[743316] list [SETNAME]
[743316]         List the entries of a named set or all sets
[743316] save [SETNAME]
[743316]         Save the named set or all sets to stdout
[743316] restore 
[743316]         Restore a saved state
[743316] flush [SETNAME]
[743316]         Flush a named set or all sets
[743316] rename FROM-SETNAME TO-SETNAME
[743316]         Rename two sets
[743316] swap FROM-SETNAME TO-SETNAME
[743316]         Swap the contect of two existing sets
[743316] help [TYPENAME]
[743316]         Print help, and settype specific help
[743316] version 
[743316]         Print version information
[743316] quit 
[743316]         Quit interactive mode
[743316] 
[743316] Options:
[743316] -o plain|save|xml|json
[743316]        Specify output mode for listing sets.
[743316]        Default value for "list" command is mode "plain"
[743316]        and for "save" command is mode "save".
[743316] -s 
[743316]         Print elements sorted (if supported by the set type).
[743316] -q 
[743316]         Suppress any notice or warning message.
[743316] -r 
[743316]         Try to resolve IP addresses in the output (slow!)
[743316] -! 
[743316]         Ignore errors when creating or adding sets or
[743316]         elements that do exist or when deleting elements
[743316]         that don't exist.
[743316] -n 
[743316]         When listing, just list setnames from the kernel.
[743316] 
[743316] -t 
[743316]         When listing, list setnames and set headers
[743316]         from kernel only.
[743316] -f 
[743316]         Read from the given file instead of standard
[743316]         input (restore) or write to given file instead
[743316]         of standard output (list/save).
[743316] 
[743316] Supported set types:
[743316]     list:set		3	skbinfo support
[743316]     list:set		2	comment support
[743316]     list:set		1	counters support
[743316]     list:set		0	Initial revision
[743316]     hash:mac		1	bucketsize, initval support
[743316]     hash:mac		0	Initial revision
[743316]     hash:ip,mac		1	bucketsize, initval support
[743316]     hash:ip,mac		0	Initial revision
[743316]     hash:net,iface	8	bucketsize, initval support
[743316]     hash:net,iface	7	skbinfo and wildcard support
[743316]     hash:net,iface	6	skbinfo support
[743316]     hash:net,iface	5	forceadd support
[743316]     hash:net,iface	4	comment support
[743316]     hash:net,iface	3	counters support
[743316]     hash:net,iface	2	/0 network support
[743316]     hash:net,iface	1	nomatch flag support
[743316]     hash:net,iface	0	Initial revision
[743316]     hash:net,port	8	bucketsize, initval support
[743316]     hash:net,port	7	skbinfo support
[743316]     hash:net,port	6	forceadd support
[743316]     hash:net,port	5	comment support
[743316]     hash:net,port	4	counters support
[743316]     hash:net,port	3	nomatch flag support
[743316]     hash:net,port	2	Add/del range support
[743316]     hash:net,port	1	SCTP and UDPLITE support
[743316]     hash:net,port,net	3	bucketsize, initval support
[743316]     hash:net,port,net	2	skbinfo support
[743316]     hash:net,port,net	1	forceadd support
[743316]     hash:net,port,net	0	initial revision
[743316]     hash:net,net	4	netmask and bitmask support
[743316]     hash:net,net	3	bucketsize, initval support
[743316]     hash:net,net	2	skbinfo support
[743316]     hash:net,net	1	forceadd support
[743316]     hash:net,net	0	initial revision
[743316]     hash:net		7	bucketsize, initval support
[743316]     hash:net		6	skbinfo support
[743316]     hash:net		5	forceadd support
[743316]     hash:net		4	comment support
[743316]     hash:net		3	counters support
[743316]     hash:net		2	nomatch flag support
[743316]     hash:net		1	Add/del range support
[743316]     hash:net		0	Initial revision
[743316]     hash:ip,port,net	8	bucketsize, initval support
[743316]     hash:ip,port,net	7	skbinfo support
[743316]     hash:ip,port,net	6	forceadd support
[743316]     hash:ip,port,net	5	comment support
[743316]     hash:ip,port,net	4	counters support
[743316]     hash:ip,port,net	3	nomatch flag support
[743316]     hash:ip,port,net	2	Add/del range support
[743316]     hash:ip,port,net	1	SCTP and UDPLITE support
[743316]     hash:ip,port,ip	6	bucketsize, initval support
[743316]     hash:ip,port,ip	5	skbinfo support
[743316]     hash:ip,port,ip	4	forceadd support
[743316]     hash:ip,port,ip	3	comment support
[743316]     hash:ip,port,ip	2	counters support
[743316]     hash:ip,port,ip	1	SCTP and UDPLITE support
[743316]     hash:ip,mark	3	bucketsize, initval support
[743316]     hash:ip,mark	2	skbinfo support
[743316]     hash:ip,mark	1	forceadd support
[743316]     hash:ip,mark	0	initial revision
[743316]     hash:ip,port	7	netmask and bitmask support
[743316]     hash:ip,port	6	bucketsize, initval support
[743316]     hash:ip,port	5	skbinfo support
[743316]     hash:ip,port	4	forceadd support
[743316]     hash:ip,port	3	comment support
[743316]     hash:ip,port	2	counters support
[743316]     hash:ip,port	1	SCTP and UDPLITE support
[743316]     hash:ip		6	bitmask support
[743316]     hash:ip		5	bucketsize, initval support
[743316]     hash:ip		4	skbinfo support
[743316]     hash:ip		3	forceadd support
[743316]     hash:ip		2	comment support
[743316]     hash:ip		1	counters support
[743316]     hash:ip		0	Initial revision
[743316]     bitmap:port		3	skbinfo support
[743316]     bitmap:port		2	comment support
[743316]     bitmap:port		1	counters support
[743316]     bitmap:port		0	Initial revision
[743316]     bitmap:ip,mac	3	skbinfo support
[743316]     bitmap:ip,mac	2	comment support
[743316]     bitmap:ip,mac	1	counters support
[743316]     bitmap:ip,mac	0	Initial revision
[743316]     bitmap:ip		3	skbinfo support
[743316]     bitmap:ip		2	comment support
[743316]     bitmap:ip		1	counters support
[743316]     bitmap:ip		0	Initial revision
Process 743316 ran in 0.01s
Build finished, completed 1 job in 1.47s
Result: 5849d12568546aeb2a6edfaef048a5efe1cdc647746265132a4c40dc2453b034
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 743328 (std/runtime_utils.bri:49:6)
Process 743328 ran in 0.03s
Build finished, completed 1 job in 3.48s
Running brioche-run
{
  "name": "ipset",
  "version": "7.24"
}
```

</p>
</details>

## Implementation notes / special instructions

None.
