### PR TITLE
feat(nfacct): add package

### DIFF
--- a/packages/nfacct/brioche.lock
+++ b/packages/nfacct/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/nfacct/nfacct-1.0.2.tar.bz2": {
+      "type": "sha256",
+      "value": "ecff2218754be318bce3c3a5d1775bab93bf4168b2c4aac465785de5655fbd69"
+    }
+  }
+}

--- a/packages/nfacct/project.bri
+++ b/packages/nfacct/project.bri
@@ -1,0 +1,65 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnetfilter_acct from "libnetfilter_acct";
+
+export const project = {
+  name: "nfacct",
+  version: "1.0.2",
+  repository: "https://git.netfilter.org/nfacct",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/nfacct/nfacct-${project.version}.tar.bz2`,
+)
+  .unarchive("tar", "bzip2")
+  .peel();
+
+export default function nfacct(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(std.toolchain, libmnl, libnetfilter_acct)
+    .toDirectory()
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/nfacct"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    nfacct version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nfacct)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `nfacct v${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/nfacct
+      | lines
+      | where ($it | str contains "nfacct-") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="nfacct-(?<version>[\\d.]+)\.tar\\.bz2">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `nfacct`
- **Website / repository:** `https://git.netfilter.org/nfacct`
- **Repology URL:** `https://repology.org/project/nfacct/versions`
- **Short description:** Netfilter accounting command-line utility.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 0.92s
Result: 85016e161a7a244708b7020dba25f9a17bbe8c78d788988a0f8d9c1e16a66724
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.99s
Running brioche-run
{
  "name": "nfacct",
  "version": "1.0.2",
  "repository": "https://git.netfilter.org/nfacct"
}
```

</p>
</details>

## Implementation notes / special instructions

None.