### PR TITLE
feat(ulogd): add package

### DIFF
--- a/packages/ulogd/brioche.lock
+++ b/packages/ulogd/brioche.lock
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://netfilter.org/pub/ulogd/ulogd-2.0.9.tar.xz": {
+      "type": "sha256",
+      "value": "523a651fe0a9f25b0cd87d5d35fc37d9382e7eecfcf61e48d5505ff3cf80eda5"
+    }
+  }
+}

--- a/packages/ulogd/project.bri
+++ b/packages/ulogd/project.bri
@@ -1,0 +1,94 @@
+import * as std from "std";
+import { nushellRunnable, type NushellRunnable } from "nushell";
+import libmnl from "libmnl";
+import libnetfilter_acct from "libnetfilter_acct";
+import libnetfilter_conntrack from "libnetfilter_conntrack";
+import libnetfilter_log from "libnetfilter_log";
+import libnfnetlink from "libnfnetlink";
+import jansson from "jansson";
+import libpcap from "libpcap";
+import sqlite from "sqlite";
+
+export const project = {
+  name: "ulogd",
+  version: "2.0.9",
+  repository: "https://git.netfilter.org/ulogd",
+};
+
+const source = Brioche.download(
+  `https://netfilter.org/pub/ulogd/ulogd-${project.version}.tar.xz`,
+)
+  .unarchive("tar", "xz")
+  .peel();
+
+export default function ulogd(): std.Recipe<std.Directory> {
+  return std.runBash`
+    ./configure \\
+      --prefix=/ \\
+      --sbindir=/bin \\
+      --sysconfdir=/etc \\
+      --enable-pcap \\
+      --enable-sqlite3 \\
+      --enable-json \\
+      --disable-pgsql \\
+      --disable-mysql \\
+      --disable-dbi
+    make -j "$(nproc)"
+    make install DESTDIR="$BRIOCHE_OUTPUT"
+  `
+    .workDir(source)
+    .dependencies(
+      std.toolchain,
+      libmnl,
+      libnetfilter_acct,
+      libnetfilter_conntrack,
+      libnetfilter_log,
+      libnfnetlink,
+      jansson,
+      libpcap,
+      sqlite,
+    )
+    .toDirectory()
+    .pipe(std.libtoolSanitizeDependencies)
+    .pipe((recipe) =>
+      std.setEnv(recipe, {
+        LIBRARY_PATH: { append: [{ path: "lib" }] },
+      }),
+    )
+    .pipe((recipe) => std.withRunnableLink(recipe, "bin/ulogd"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    ulogd --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(ulogd)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `ulogd Version ${project.version}`;
+  std.assert(
+    result.startsWith(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): NushellRunnable {
+  return nushellRunnable`
+    let version = http get https://netfilter.org/pub/ulogd
+      | lines
+      | where ($it | str contains "ulogd-") and (not ($it | str contains "sig")) and (not ($it | str contains "md5sum")) and (not ($it | str contains "sha1sum"))
+      | parse --regex '<a href="ulogd-(?<version>[\\d.]+)\.tar\\.xz">'
+      | sort-by --natural --reverse version
+      | get 0.version
+
+    $env.project
+      | from json
+      | update version $version
+      | to json
+  `.env({ project: JSON.stringify(project) });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `ulogd`
- **Website / repository:** `https://git.netfilter.org/ulogd`
- **Repology URL:** `https://repology.org/project/ulogd/versions`
- **Short description:** Netfilter userspace logging daemon for packet logs, connection tracking events, and accounting data.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 1.01s
Result: 8512c608ddee1eee90a119fcefae06f61311db0d9d51655bbd377723684c43b1
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Build finished, completed (no new jobs) in 2.88s
Running brioche-run
{
  "name": "ulogd",
  "version": "2.0.9",
  "repository": "https://git.netfilter.org/ulogd"
}
```

</p>
</details>

## Implementation notes / special instructions

None.