### PR TITLE
feat(litellm): add package

### DIFF
--- a/packages/litellm/brioche.lock
+++ b/packages/litellm/brioche.lock
@@ -1,0 +1,34 @@
+{
+  "dependencies": {},
+  "downloads": {
+    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248"
+    },
+    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"
+    },
+    "https://files.pythonhosted.org/packages/13/7c/b11b870fc4fd84de2099906314ce45488ae17be32ff5493519a6cddc518a/maturin-1.9.4.tar.gz": {
+      "type": "sha256",
+      "value": "235163a0c99bc6f380fb8786c04fd14dcf6cd622ff295ea3de525015e6ac40cf"
+    },
+    "https://files.pythonhosted.org/packages/f9/7b/d05b1778f2d4e354d103e3421c6267d923032fefcc5ca5b7df0cb21cefd0/setuptools_rust-1.12.0-py3-none-any.whl": {
+      "type": "sha256",
+      "value": "7e7db90547f224a835b45f5ad90c983340828a345554a9a660bdb2de8605dcdd"
+    },
+    "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl": {
+      "type": "sha256",
+      "value": "de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"
+    },
+    "https://files.pythonhosted.org/packages/ca/f9/2be83a4b40e9353536dfd15e17550102947b3e10b729a018df3e66bf9b73/uv_build-0.11.8.tar.gz": {
+      "type": "sha256",
+      "value": "77c7f1eb47f4fa76b0848e1d8838255f75f5777bdbfbf06d4aa66bac19aad82e"
+    }
+  },
+  "git_refs": {
+    "https://github.com/BerriAI/litellm": {
+      "v1.95.0": "72a4a55f43ea7266de589f005d0d33624fe5d555"
+    }
+  }
+}

--- a/packages/litellm/fastapi-compat.patch
+++ b/packages/litellm/fastapi-compat.patch
@@ -1,0 +1,30 @@
+diff --git a/litellm/proxy/management_endpoints/management_v1/common.py b/litellm/proxy/management_endpoints/management_v1/common.py
+--- a/litellm/proxy/management_endpoints/management_v1/common.py
++++ b/litellm/proxy/management_endpoints/management_v1/common.py
+@@ -5,3 +5,2 @@
+ from fastapi import Request
+-from fastapi.dependencies.utils import get_flat_dependant
+ from fastapi.responses import JSONResponse
+@@ -20,1 +20,17 @@
+ PROBLEM_TYPE_BASE = "urn:litellm:error:"
++
++def _query_params_from_dependant(
++    dependant: object, visited: set[int] | None = None
++) -> frozenset[str]:
++    if visited is None:
++        visited = set()
++    marker = id(dependant)
++    if marker in visited:
++        return frozenset()
++    visited.add(marker)
++
++    fields = {field.alias for field in getattr(dependant, "query_params", ())}
++    for dependency in getattr(dependant, "dependencies", ()):
++        fields.update(_query_params_from_dependant(dependency, visited))
++    return frozenset(fields)
++
+@@ -41,3 +56,3 @@
+     if dependant is None:
+         return frozenset()
+-    return frozenset(field.alias for field in get_flat_dependant(dependant, skip_repeats=True).query_params)
++    return _query_params_from_dependant(dependant)

--- a/packages/litellm/project.bri
+++ b/packages/litellm/project.bri
@@ -1,0 +1,154 @@
+import * as std from "std";
+import python, { getLatestVersion as getPythonVersion } from "python";
+import rust from "rust";
+import uv from "uv";
+
+export const project = {
+  name: "litellm",
+  version: "1.95.0",
+  repository: "https://github.com/BerriAI/litellm",
+};
+
+const source = Brioche.gitCheckout({
+  repository: project.repository,
+  ref: `v${project.version}`,
+}).pipe((source) =>
+  // Keep LiteLLM compatible with FastAPI's dependency API.
+  std.applyPatch({
+    source,
+    patch: Brioche.includeFile("fastapi-compat.patch"),
+    strip: 1,
+  }),
+);
+
+const pipDependencies = std.directory({
+  "setuptools-80.9.0-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl",
+  ),
+  "wheel-0.45.1-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
+  ),
+  "setuptools_rust-1.12.0-py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/f9/7b/d05b1778f2d4e354d103e3421c6267d923032fefcc5ca5b7df0cb21cefd0/setuptools_rust-1.12.0-py3-none-any.whl",
+  ),
+  "semantic_version-2.10.0-py2.py3-none-any.whl": Brioche.download(
+    "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl",
+  ),
+  "uv_build-0.11.8.tar.gz": Brioche.download(
+    "https://files.pythonhosted.org/packages/ca/f9/2be83a4b40e9353536dfd15e17550102947b3e10b729a018df3e66bf9b73/uv_build-0.11.8.tar.gz",
+  ),
+  "maturin-1.9.4.tar.gz": Brioche.download(
+    "https://files.pythonhosted.org/packages/13/7c/b11b870fc4fd84de2099906314ce45488ae17be32ff5493519a6cddc518a/maturin-1.9.4.tar.gz",
+  ),
+});
+
+export default function litellm(): std.Recipe<std.Directory> {
+  const managedPython = python();
+
+  // Create a venv
+  let venv = std.recipe(managedPython);
+
+  // Install build dependencies
+  venv = std.runBash`
+    pip install setuptools wheel setuptools-rust semantic-version
+  `
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .toDirectory();
+
+  // Build maturin and uv-build
+  venv = std.runBash`
+    pip install --no-build-isolation maturin
+    pip install --no-build-isolation uv-build
+  `
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      PIP_FIND_LINKS: pipDependencies,
+      PIP_NO_INDEX: "1",
+    })
+    .outputScaffold(venv)
+    .dependencies(rust, std.toolchain)
+    .unsafe({ networking: true })
+    .toDirectory();
+
+  // Install litellm with proxy dependencies
+  venv = std.runBash`
+    uv tool install --no-build-isolation '.[proxy,extra_proxy,proxy-runtime]'
+  `
+    .workDir(source)
+    .dependencies(uv, rust, std.toolchain)
+    .env({
+      PATH: std.tpl`${std.outputPath}/bin`,
+      UV_NO_MANAGED_PYTHON: "1",
+      UV_LINK_MODE: "copy",
+      UV_LOCKED: "1",
+      UV_TOOL_DIR: std.outputPath,
+      UV_TOOL_BIN_DIR: std.tpl`${std.outputPath}/bin`,
+      PYTHONPATH: std.tpl`${
+        std.outputPath
+      }/lib/python${getPythonVersion()}/site-packages`,
+    })
+    .outputScaffold(venv)
+    .unsafe({ networking: true })
+    .toDirectory();
+
+  // Create the final recipe with the venv under `venv`
+  let recipe = std.directory({
+    venv,
+  });
+
+  // Add toolchain for runtime libraries
+  recipe = recipe.insert("brioche-run.d/toolchain", std.toolchain);
+
+  // Create runnable wrappers
+  const binaries = ["litellm", "lite", "litellm-proxy"];
+  for (const binary of binaries) {
+    recipe = std.addRunnable(recipe, `bin/${binary}`, {
+      command: { relativePath: "venv/bin/python" },
+      args: [{ relativePath: `venv/litellm/bin/${binary}` }],
+      env: {
+        PYTHONPATH: {
+          prepend: {
+            relativePath: `venv/litellm/lib/python${getPythonVersion()}/site-packages`,
+          },
+          separator: ":",
+        },
+        LD_LIBRARY_PATH: {
+          prepend: {
+            relativePath: "brioche-run.d/toolchain/lib",
+          },
+          separator: ":",
+        },
+      },
+    });
+  }
+
+  return recipe.pipe((recipe) => std.withRunnableLink(recipe, "bin/litellm"));
+}
+
+export async function test(): Promise<std.Recipe<std.File>> {
+  const script = std.runBash`
+    litellm --version | tee "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(litellm)
+    .toFile();
+
+  const result = (await script.read()).trim();
+
+  // Check that the result contains the expected version
+  const expected = `LiteLLM: Current Version = ${project.version}`;
+  std.assert(
+    result.includes(expected),
+    `expected '${expected}', got '${result}'`,
+  );
+
+  return script;
+}
+
+export function liveUpdate(): std.Recipe<std.Directory> {
+  return std.liveUpdateFromGithubReleases({ project });
+}


### PR DESCRIPTION
# Add a new Brioche recipe

## Summary

This Pull Request adds a new recipe to the registry.

- **Recipe name:** `litellm`
- **Website / repository:** `https://github.com/BerriAI/litellm`
- **Repology URL:** `https://repology.org/project/litellm/versions`
- **Short description:** Open-source AI gateway and Python SDK providing a unified interface to many LLM providers.

## Related issue(s) or discussion(s)

None.

## Checklist (required)

- [x] `liveUpdate()` method added.
- [x] `test()` method added.

## How I tested this locally (required)

1. Run the **test** scenario:

<details><summary>Test output (click to expand)</summary>
<p>

```
Preparing process (std/core/recipes/process.bri:240:14)
Prepared process 810845 in 18.83s
Launched process 810845 (std/core/recipes/process.bri:240:14)
[810845] 18:15:12 - LiteLLM:WARNING: get_model_cost_map.py:290 - LiteLLM: Failed to fetch remote model cost map from https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json: [Errno -3] Temporary failure in name resolution. Falling back to local backup.
[810845] 
[810845] LiteLLM: Current Version = 1.95.0
Process 810845 ran in 6.02s
Build finished, completed 1 job in 28.01s
Result: 61bacb72f102b28669188296c31e17df6ac8a1667cd68dee61e1c1820a55717d
```

</p>
</details>

2. Run the **live-update** scenario:

<details><summary>Live-update output (click to expand)</summary>
<p>

```
Preparing process (std/runtime_utils.bri:49:6)
Launched process 810829 (std/runtime_utils.bri:49:6)
Process 810829 ran in 0.02s
Build finished, completed 1 job in 3.32s
Running brioche-run
{
  "name": "litellm",
  "version": "1.95.0",
  "repository": "https://github.com/BerriAI/litellm"
}
```

</p>
</details>

## Implementation notes / special instructions

None.